### PR TITLE
修复主界面两侧分割线未设置动画的问题

### DIFF
--- a/FCL/src/main/java/com/tungsten/fcl/ui/account/AccountUI.java
+++ b/FCL/src/main/java/com/tungsten/fcl/ui/account/AccountUI.java
@@ -52,22 +52,24 @@ public class AccountUI extends FCLCommonUI implements View.OnClickListener {
 
     @Override
     public Task<?> refresh(Object... param) {
-        if (accountListAdapter == null) {
-            ObservableList<AccountListItem> list = new ObservableListBase<AccountListItem>() {
-                @Override
-                public AccountListItem get(int i) {
-                    return new AccountListItem(getContext(), Accounts.getAccounts().get(i));
-                }
+        if (listView != null) {
+            if (accountListAdapter == null) {
+                ObservableList<AccountListItem> list = new ObservableListBase<AccountListItem>() {
+                    @Override
+                    public AccountListItem get(int i) {
+                        return new AccountListItem(getContext(), Accounts.getAccounts().get(i));
+                    }
 
-                @Override
-                public int size() {
-                    return Accounts.getAccounts().size();
-                }
-            };
-            accountListAdapter = new AccountListAdapter(getContext(), list);
-            listView.setAdapter(accountListAdapter);
-        } else {
-            accountListAdapter.notifyDataSetChanged();
+                    @Override
+                    public int size() {
+                        return Accounts.getAccounts().size();
+                    }
+                };
+                accountListAdapter = new AccountListAdapter(getContext(), list);
+                listView.setAdapter(accountListAdapter);
+            } else {
+                accountListAdapter.notifyDataSetChanged();
+            }
         }
         return Task.runAsync(() -> {
 

--- a/FCL/src/main/res/layout/activity_main.xml
+++ b/FCL/src/main/res/layout/activity_main.xml
@@ -8,90 +8,91 @@
         android:id="@+id/background"
         tools:context=".activity.MainActivity">
 
-        <ScrollView
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/left_menu"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             app:layout_constraintStart_toStartOf="parent">
 
-            <androidx.appcompat.widget.LinearLayoutCompat
-                android:id="@+id/menu"
-                android:paddingStart="5dp"
-                android:paddingEnd="5dp"
-                android:paddingTop="10dp"
-                android:paddingBottom="10dp"
-                android:orientation="vertical"
+            <ScrollView
+                android:id="@+id/left_scroll_menu"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:clipChildren="false"
-                android:clipToPadding="false">
+                android:layout_height="match_parent"
+                app:layout_constraintStart_toStartOf="parent">
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
+                <androidx.appcompat.widget.LinearLayoutCompat
+                    android:id="@+id/menu"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp"
+                    android:paddingTop="10dp"
+                    android:paddingBottom="10dp"
+                    android:orientation="vertical"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_home_24"
-                    android:id="@+id/home"/>
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
-                    android:layout_marginTop="10dp"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_build_24"
-                    android:id="@+id/manage"/>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_home_24"
+                        android:id="@+id/home"/>
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
-                    android:layout_marginTop="10dp"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_cloud_download_24"
-                    android:id="@+id/download"/>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:layout_marginTop="10dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_build_24"
+                        android:id="@+id/manage"/>
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
-                    android:layout_marginTop="10dp"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_videogame_asset_24"
-                    android:id="@+id/controller"/>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:layout_marginTop="10dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_cloud_download_24"
+                        android:id="@+id/download"/>
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
-                    android:visibility="gone"
-                    android:layout_marginTop="10dp"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_wifi_24"
-                    android:id="@+id/multiplayer"/>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:layout_marginTop="10dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_videogame_asset_24"
+                        android:id="@+id/controller"/>
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
-                    android:layout_marginTop="10dp"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_settings_24"
-                    android:id="@+id/setting"/>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:visibility="gone"
+                        android:layout_marginTop="10dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_wifi_24"
+                        android:id="@+id/multiplayer"/>
 
-                <com.tungsten.fcllibrary.component.view.FCLMenuView
-                    android:layout_marginTop="10dp"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_baseline_arrow_back_24"
-                    android:id="@+id/back"/>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:layout_marginTop="10dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_settings_24"
+                        android:id="@+id/setting"/>
 
-            </androidx.appcompat.widget.LinearLayoutCompat>
+                    <com.tungsten.fcllibrary.component.view.FCLMenuView
+                        android:layout_marginTop="10dp"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_baseline_arrow_back_24"
+                        android:id="@+id/back"/>
 
-        </ScrollView>
+                </androidx.appcompat.widget.LinearLayoutCompat>
 
-        <View
-            android:background="@android:color/darker_gray"
-            android:id="@+id/split_left"
-            android:layout_width="1dp"
-            android:layout_height="match_parent"
-            app:layout_constraintStart_toEndOf="@id/left_menu"/>
+            </ScrollView>
 
-        <View
-            android:background="@android:color/darker_gray"
-            android:id="@+id/split_right"
-            android:layout_width="1dp"
-            android:layout_height="match_parent"
-            app:layout_constraintEnd_toStartOf="@id/right_menu"/>
+            <View
+                android:background="@android:color/darker_gray"
+                android:id="@+id/split_left"
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                app:layout_constraintStart_toEndOf="@id/left_scroll_menu"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:background="@color/ui_bg_color"
@@ -104,6 +105,13 @@
             app:layout_constraintHorizontal_bias="1"
             app:layout_constraintWidth_percent="0.25">
 
+            <View
+                android:background="@android:color/darker_gray"
+                android:id="@+id/split_right"
+                android:layout_width="1dp"
+                android:layout_height="match_parent"
+                app:layout_constraintStart_toStartOf="parent"/>
+
             <com.tungsten.fcllibrary.component.view.FCLTextView
                 android:id="@+id/account_textview"
                 android:singleLine="true"
@@ -115,7 +123,7 @@
                 android:text="@string/account"
                 android:textSize="11sp"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
             <View
                 android:id="@+id/view"
@@ -125,7 +133,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:background="@android:color/darker_gray"
-                app:layout_constraintTop_toBottomOf="@id/account_textview"/>
+                app:layout_constraintTop_toBottomOf="@id/account_textview"
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:layout_marginTop="10dp"
@@ -138,6 +147,7 @@
                 android:orientation="horizontal"
                 android:padding="10dp"
                 app:layout_constraintTop_toBottomOf="@+id/view"
+                app:layout_constraintStart_toEndOf="@id/split_right"
                 android:clipChildren="false"
                 android:clipToPadding="false"
                 android:stateListAnimator="@xml/anim_scale">
@@ -195,7 +205,7 @@
                 android:text="@string/version"
                 android:textSize="11sp"
                 app:layout_constraintTop_toBottomOf="@id/account"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
             <View
                 android:id="@+id/view2"
@@ -206,7 +216,7 @@
                 android:layout_height="1dp"
                 android:background="@android:color/darker_gray"
                 app:layout_constraintTop_toBottomOf="@id/version_textview"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:layout_marginTop="10dp"
@@ -219,7 +229,7 @@
                 android:orientation="horizontal"
                 android:padding="10dp"
                 app:layout_constraintTop_toBottomOf="@id/view2"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toEndOf="@id/split_right"
                 android:stateListAnimator="@xml/anim_scale">
 
                 <com.tungsten.fcllibrary.component.view.FCLImageView
@@ -269,7 +279,7 @@
                 android:orientation="horizontal"
                 android:padding="10dp"
                 app:layout_constraintTop_toBottomOf="@id/view2"
-                app:layout_constraintStart_toStartOf="parent"/>
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
             <com.tungsten.fcllibrary.component.view.FCLButton
                 android:id="@+id/execute_jar"
@@ -279,7 +289,8 @@
                 android:layout_marginBottom="10dp"
                 android:layout_marginHorizontal="8dp"
                 app:ripple="true"
-                app:layout_constraintBottom_toTopOf="@id/launch"/>
+                app:layout_constraintBottom_toTopOf="@id/launch"
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
             <com.tungsten.fcllibrary.component.view.FCLButton
                 android:id="@+id/launch"
@@ -288,7 +299,8 @@
                 android:text="@string/launch"
                 android:layout_marginHorizontal="8dp"
                 app:ripple="true"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/split_right"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -296,8 +308,8 @@
             android:id="@+id/ui_layout"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            app:layout_constraintStart_toEndOf="@+id/split_left"
-            app:layout_constraintEnd_toStartOf="@id/split_right"/>
+            app:layout_constraintStart_toEndOf="@+id/left_menu"
+            app:layout_constraintEnd_toStartOf="@id/right_menu"/>
 
         <com.tungsten.fcllibrary.component.view.FCLDynamicIsland
             android:stateListAnimator="@null"


### PR DESCRIPTION
**问题一 账户登录时触发的问题**
问题发生的条件：
- 在启动游戏前，未进入过“账户管理”界面
- 当前未登陆过账号
- 在弹出的“创建账户”弹窗内登录账号

视频演示：  

https://github.com/user-attachments/assets/8e3b1ffb-436d-4769-a484-f6865502b71c

由于用户未进入过“账户管理”界面，该界面的视图未完成初始化，而启动游戏时会检测是否登录了账号，如果没有账号，则会弹出“创建账号”弹窗，在此弹窗内完成登录后，弹窗会获取“账户管理”对象，并且希望刷新“账户管理”，但是“listView”对象未完成初始化，直接调用了“setAdapter”方法，导致了空指针异常。

此次提交将在“账户管理”刷新之前，检查“listView”是否未空，若为空则不执行刷新过程。当用户自行点击“账户管理”并进入界面时，“listView”会完成初始化，并且自动刷新。

**问题二 主界面两侧分割线未设置动画的问题**
简单调整了xml布局文件，即可修复此问题

修复前视频演示：  

https://github.com/user-attachments/assets/7c361839-87cf-4101-8fc5-ade8ba83d9f0

修复后视频演示：  

https://github.com/user-attachments/assets/a7ba5ef0-b5bd-478d-993e-4b4285b7fe1f