### PR TITLE
修复获取CPU名称为空问题

### DIFF
--- a/FCLauncher/src/main/java/com/tungsten/fclauncher/FCLauncher.java
+++ b/FCLauncher/src/main/java/com/tungsten/fclauncher/FCLauncher.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.os.Build;
 import android.system.Os;
 import android.util.ArrayMap;
+import android.util.Log;
 
 import com.jaredrummler.android.device.DeviceName;
 import com.oracle.dalvik.VMLauncher;
@@ -519,7 +520,7 @@ public class FCLauncher {
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String name = reader.readLine();
             reader.close();
-            return name;
+            return name.isBlank() ? Build.HARDWARE : name;
         } catch (Exception e) {
             return Build.HARDWARE;
         }


### PR DESCRIPTION
直接通过Runtime.getRuntime().exec()执行命令有一个BUG，当主命令有效而它后面跟的参数无效只会返回空而不是抛出异常（若主命令无效则直接异常）。

修改：在返回值前判断是否为空，若为空依旧执行Build.HARDWARE