### PR TITLE
导入 PrismLauncher 格式整合包时 $.jvmArgs 参数未正确移除两侧引号 | 安装 MultiMC 整合包后应当设置图标 | 修复 HMCL 3.5.8.248 无法安装启动带 forge 的 1.11.2 版本的问题 | 更新 mod 数据 | 修复 Minecraft 1.20.2+Forge 默认图标错误的问题

### DIFF
--- a/FCL/src/main/assets/mod_data.txt
+++ b/FCL/src/main/assets/mod_data.txt
@@ -1,9 +1,9 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2024  huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # mcmod.cn
-# Copyright (C) 2024. All Rights Reserved.
+# Copyright (C) 2025. All Rights Reserved.
 #
 industrial-craft;2;IC2,ic2;工业时代2;Industrial Craft 2;IC2
 ;3;RedPowerCore,RedPowerBase;红石力量2;RedPower2;RP2
@@ -42,7 +42,7 @@ not-enough-items-1-8;41;NotEnoughItems,nei;NEI物品管理器;Not Enough Items;N
 ;42;TooManyItems;TMI内置修改器;TooManyItems;TMI
 ;43;;中文输入修复补丁;Minecraft Language InputFix;
 ;44;MoLanguage;更多语言;MoLanguage;
-custom-npcs;45;customnpcs,AdvNPCs;自定义NPC;Custom Npcs;
+custom-npcs;45;customnpcs,AdvNPCs;自定义NPC;Custom NPCs;
 millenaire;46;millenaire;千年村庄;Millénaire;
 clay-soldiers-mod;47;claysoldiers;粘土士兵;Clay Soldiers Mod;
 mo-creatures;48;mocreatures;更多生物;Mo' Creatures;MOC
@@ -50,7 +50,7 @@ mo-creatures;48;mocreatures;更多生物;Mo' Creatures;MOC
 extrabiomesxl;50;ExtrabiomesXL,extrabiomesxl;更多生态群系;ExtraBiomesXL;EBXL
 ;51;gregtech;格雷科技4;GregTech 4;GT4
 tale-of-kingdoms;55;taleofkingdoms;王国;Tale Of Kingdoms;
-;56;FamiliarsAPI;守护精灵;familiars;
+;56;FamiliarsAPI;守护精灵;Familiars;
 ;58;;正版皮肤显示修正;AntiSteve;
 tfcraft;59;terrafirmacraft;群峦传说;TerraFirmaCraft;TFC
 ;60;SoulShards;灵魂碎片;Soul Shards;SS
@@ -59,7 +59,7 @@ binnies-mods;62;ExtraBees,extrabees;更多蜜蜂;Extra Bees;EB
 portal-gun;63;PortalGun,portalgun;传送枪;Portal Gun;
 simpleores;64;simpleores;简单矿石;SimpleOres;
 smart-moving;65;SmartMoving;灵活动作;Smart Moving;
-easycrafting;66;;轻松合成;Easy Crafting;
+easycrafting;66;EasyCrafting;轻松合成;Easy Crafting;
 thermal-expansion;67;ThermalExpansion;热力膨胀3;Thermal Expansion 3;TE3
 ;68;FerullosGunsMod;费如罗的枪械;Ferullo's Guns;
 ;69;compactkineticgenerators;压缩风电阵列;Compact Windmills;
@@ -67,7 +67,7 @@ thermal-expansion;67;ThermalExpansion;热力膨胀3;Thermal Expansion 3;TE3
 computercraft;71;ComputerCraft;电脑;Computer Craft;CC
 ;72;SpecialArmor;特殊防具;Special Armor;
 inventory-tweaks;73;inventorytweaks;R键整理;Inventory Tweaks;
-;74;;更多弓;More Bows;
+;74;More Bows;更多弓;More Bows;
 minecraft-minions;75;minions;召唤奴仆;Minecraft Minions;
 ender-storage;76;enderstorage;末影存储;Ender Storage;
 ;77;DQMV;勇者斗恶龙;Dragon Quest Monster;DQM
@@ -77,25 +77,25 @@ extra-utilities;81;ExtraUtilities;更多实用设备;Extra Utilities;ExU
 ;84;ssHookShot,HookShot;立体机动装置;Hookshot;
 rotarycraft;85;RotaryCraft;旋转工艺;RotaryCraft;RoC
 ;86;;万用工具;OmniTools;
-applied-energistics-1;87;AppliedEnergistics;应用能源;Applied Energistics;AE
+applied-energistics-1;87;AppliedEnergistics;应用能源;Applied Energistics 1;AE
 ;88;;奥法卷轴;Arcane Scroll;
 ;89;HarkenScythe_Core;死神之镰;Harken Scythes;
 ;90;AsgardShield;盾与巨剑;Asgard Shield;
 ;91;;锁链;CHAINZ: THE -MISSING- IRON LINK;
 Universal-Electricity;92;UniversalElectricity;通用电力;Universal Electricity;UE
 ;93;btw;比狼好;Better Than Wolves;BTW
-the-aether;94;aether,aether_legacy;天境;The Aether;AE
-;95;;电脑外设;MiscPeripherals;
+aether;94;aether,aether_legacy;天境;The Aether;AE
+;95;miscperipherals;电脑外设;MiscPeripherals;
 ;96;AdvancedReactors;高级核电;Advanced Reactors;AR
 assassincraft-assassins-creed-mod;97;AssassinCraft;刺客信条;AssassinCraft;
 ;98;RWG;更真实的地图生成;Realistic World Gen;RWG
-custom-recipes;99;;自定义合成表;Custom Recipes;
+custom-recipes;99;customrecipes;自定义合成表;Custom Recipes;
 minecraft-comes-alive-mca;100;mca;虚拟人生/凡家物语;Minecraft Comes Alive;MCA
 tinkers-construct;101;TConstruct;匠魂;Tinkers' Construct;TiC
 ;102;BukkitForge;BukkitForge;;
-forge-essentials-74735;103;ForgeEssentials;ForgeEssentials;;
+forge-essentials-74735;103;ForgeEssentials;ForgeEssentials;;FE
 ;104;palaria;帕拉瑞亚;Palaria;
-translocators;105;Translocator,translocators;转运器;Translocators;
+translocators-1-8;105;Translocator,translocators;转运器;Translocators;
 craftguide;106;craftguide;G键合成表;CraftGuide;
 ;107;mobdictionary;生物图鉴;Mob Dictionary;
 biomes-o-plenty;108;biomesoplenty;超多生物群系;Biomes O' Plenty;BOP
@@ -140,7 +140,7 @@ minesweeper-mod;154;MinesweeperMod;扫雷;Minesweeper;
 minechess;155;MineChess;国际象棋;MineChess;
 ;156;MineCharacter;职业;MineCharacter;
 ;157;tennox_bacteria;细菌;Bacteria;
-;158;;贝爷;BearGrylls;BG
+;158;Beargrylls;贝爷;BearGrylls;BG
 ;159;factorization;工厂化/因式分解;Factorization;FZ
 ;160;;我的幻想;MineFantasy;MF
 ;161;UgoCraft;机关;UgoCraft;
@@ -160,15 +160,15 @@ extracells2;174;extracells;更多存储单元2;Extra Cells 2;EC2
 ;175;itemrender;渲染图片导出;Item Render;IR
 ;176;Zeppelin;齐柏林;Zeppelin;
 billund-223258;177;Billund;乐高;Billund;
-alchemyplusplus;178;AlchemyPlusPlus;炼金++;Alchemy++;
-better-bows;179;QuiverMod;更好弓箭系统;Better Archery Mod;
+alchemyplusplus;178;AlchemyPlusPlus;炼金++;AlchemyPlusPlus;
+better-bows;179;QuiverMod;更好弓箭系统;Better Archery;
 mumblelink;180;mumblelink;Mumble语音链接;Mumblelink;
 ender-io;181;enderioconduitsappliedenergistics,enderiointegrationforestry,enderioconduitsopencomputers,enderioconduitsrefinedstorage,enderioendergy,enderiobase,enderioconduits,enderiointegrationticlate,enderiomachines,enderiopowertools,enderiointegrationtic,enderio,EnderIO;末影接口;Ender IO;EIO
 ;184;LevelStorage;等级存储;LevelStorage;
 electrodynamics;185;electrodynamics;电动力学;Electrodynamics;
-mc-1-6-4-solar-apocalypse;186;genuine-ea;Elite Armageddon;;
+elite-armageddon;186;genuine-ea,SolarApoc;Elite Armageddon / Solar Apocalypse;;
 mekanism;187;Mekanism,mekanism;通用机械;Mekanism;Mek
-;188;;吹熄火焰！;Blow Me!;
+;188;blowme;吹熄火焰！;Blow Me!;
 ;189;Somnia;梦短人生长/真实睡眠;Somnia;
 magic-crusade-rpg-mod;190;;魔法远征:魔法十字军;Magic Crusade;
 invasions;191;Invasion,mod_Invasion;入侵;Invasion;
@@ -187,13 +187,13 @@ thaumcraft;204;Thaumcraft;神秘时代4;Thaumcraft 4;TC4
 highlands;205;Highlands;高地;Highlands;
 doggy-talents;206;doggytalents;小狗天才;Doggy Talents;DT
 plasmacraft;207;plasmacraft;电浆工艺;PlasmaCraft;PC
-;208;;更多生命;More Health ENHANCED;
+;208;morehealth;更多生命;More Health ENHANCED;
 fossils;209;HungerOverhaul;考古与化石;Fossils and Archeology Revival;F/A
 glenns-gases;210;gasesFrameworkCore,gasesFramework,gases;格林的气体;Glenn's Gases;
 the-lord-of-the-rings-mod-legacy;211;lotr;魔戒：传承;The Lord of the Rings Mod: Legacy;LotR
 thaumic-tinkerer;212;ThaumicTinkerer,ThaumicTinkerer-preloader,thaumictinkerer;神秘工匠;Thaumic Tinkerer;TT
 ;213;Paleocraft;古生代;Paleocraft;
-metallurgy;214;;冶金3;MetallurgyIII;
+metallurgy;214;Metallurgy3Core,Metallurgy3Machines,Metallurgy3Base,Metallurgy3Vanilla;冶金3;MetallurgyIII;
 xycraft;216;xycraft;XyCraft;;
 chococraft;217;chococraft;陆行鸟;ChocoCraft;
 pams-harvestcraft;218;harvestcraft;潘马斯农场;Pam's HarvestCraft;PHC
@@ -202,7 +202,7 @@ opis;220;Opis;Opis;;
 ;221;;世界树/巨树;Yggdrasill;
 openblocks;222;OpenBlocks,openblocks;开放式方块;OpenBlocks;OB
 ;223;TinyCarts;微型矿车;TinyCarts;
-;225;;冒险;AdventureCraft;AC
+;225;adventurecraft;冒险;AdventureCraft;AC
 ;226;MITE;MC实在是太简单了;Minecraft Is Too Easy;MITE
 randomcraft-v0-1-0;227;RandomCraft;随机工艺;RandomCraft;
 ;228;DragonMounts;龙坐骑/龙骑士;Dragon Mounts;DM
@@ -216,10 +216,10 @@ thaumic-infusion;236;thaumicinfusion;神秘注魔;Thaumic Infusion;TI
 thaumic-exploration;237;ThaumicExploration;神秘探险;Thaumic Exploration;TX
 deconstruction-table;238;deconstruction;解构工作台;Deconstruction Table;
 ;240;magmamod;岩浆工具;The Magma Items;
-b0bgarys-growable-ores;241;B0bGrowsOre;可生长矿石;B0bGary's Growable Ores;BGO
-;242;;基础ID修复工具;Idfix;
+kcs-growable-ores;241;B0bGrowsOre;可生长矿石;Kc's Growable Ores;BGO
+;242;Idfix;基础ID修复工具;Idfix;
 ;243;;高级ID修复工具;IdfixMinus;
-;244;;远陆时代2;Far Land Era2;FLE2
+;244;fle;远陆时代2;Far Land Era2;FLE2
 ;245;CompactEngine;高效率引擎;Compact Engine;
 waila;246;Waila,waila;高亮信息拓展;What am I looking at;Waila
 chaoscraft-2;247;Chaos_Technology;混沌工艺;ChaosCraft;CC
@@ -231,7 +231,7 @@ bctools;252;BCTools;BC扩展：更多工具;Buildcraft Tools;
 additional-buildcraft-objects;253;Additional-Buildcraft-Objects;更多管道;Additional Buildcraft Objects;ABO
 foundry;254;foundry;金属工坊;Foundry;
 gravitation-suite;255;GraviSuite,gravisuite;重力装甲;Gravitation Suite;
-redstone-arsenal;256;redstonearsenal,RedstoneArsenal;红石兵工厂;Redstone Arsenal;RSA
+redstone-arsenal;256;redstonearsenal,RedstoneArsenal,redstone_arsenal;红石兵工厂;Redstone Arsenal;RSA
 big-reactors;257;BigReactors;大型反应堆;Big Reactors;BR
 ;258;;谐振感应;Resonant Induction;RI
 endertanks;259;endertanks;末影水槽;Ender Tanks;
@@ -253,10 +253,10 @@ pchan3-steamship-steamboat-pirates;274;pchan3;飞艇与汽船;SteamShip - SteamB
 ;275;powersuits;模块化动力套装扩展;Modular Powersuits Addons;MPSA
 betterfarming;276;BetterFarming;农业增强;Better Farming;
 ;277;AdvancedTools;IC扩展：高级工具;Advanced Tools;
-lots-of-food;278;LotsOfFood;更多食物;Lots Of Food;
+lots-of-food;278;LotsOfFood;更多食物;Lots of Food;
 ;279;FoodPlus;食物Plus;Food Plus;
 aquaculture;281;aquaculture;水产业2/水产品2;Aquaculture 2;
-project-bench;282;;高级工作台;Project Bench;
+project-bench;282;bau5_ProjectBench,projectbench;高级工作台;Project Bench;
 ;283;extendedWorkbench;扩展工作台;Extended Workbench;
 apples-plus;284;apples;更多苹果;Apples+;
 ;285;;啤酒;Beer Mod;
@@ -265,9 +265,9 @@ qcraft;286;qCraft;量子物理;QCraft;QC
 mad-science;288;madscience;疯狂科学;Mad Science;
 ;289;QuarryPlus;采石场增强;Quarry Plus;
 enviromine;290;enviromine;更多生存要素;EnviroMine;
-;291;;群峦扩展;ExtraFirma;EF
+;291;ExtraFirma;群峦扩展;ExtraFirma;EF
 the-erebus;292;erebus;混沌之地;The Erebus;
-emerald-mod;293;emeraldmod;绿宝石Mod;Emerald Mod;
+emerald-mod;293;emeraldmod;绿宝石 Mod;Emerald Mod;
 lucky-block-official;294;lucky;幸运方块;Lucky Block;LB
 dynamic-lights;295;DynamicLights,DynamicLights_onFire,DynamicLights_creepers,DynamicLights_dropItems,DynamicLights_entityClasses,DynamicLights_mobEquipment,DynamicLights_thePlayer,DynamicLights_otherPlayers,DynamicLights_flameArrows,dynamiclights;动态光源;Dynamic Lights;DL
 yarr-cute-mob-models-remake;296;yarr_cutemobmodels;怪物娘化;Yarr Cute Mob Models - Remake;
@@ -277,10 +277,10 @@ remote-io;299;RIO;远程接口;Remote IO;RIO
 electrical-age;300;Eln;电力时代;Electrical Age;ELN
 ;301;;可升级机器;Upgradable Machines;
 ;302;PowerUtils;电力转换;Power Utilites;
-minor-alchemy;303;;小型炼金术;Minor Alchemy;
+minor-alchemy;303;MA,MinorAlchemy;小型炼金术;Minor Alchemy;MA
 ;304;TooMuchTNT;更多TNT;TooMuchTNT;
 ;305;;更多爆炸物;More Explosives Mod;
-;306;;生物病毒;MineInfection;
+;306;infection;生物病毒;MineInfection;
 ;307;advancedfluxtools;高级能量工具;Advanced Flux Tools;
 ;308;;自然工艺;Natural Craft;NC
 mcicraft;309;mcicraft,mcicraft_machines,mcicraft_redstone,mcicraft_farming;MCI工艺;MCI Craft;
@@ -289,7 +289,7 @@ mcicraft;309;mcicraft,mcicraft_machines,mcicraft_redstone,mcicraft_farming;MCI�
 engineers-toolbox;312;eng_toolbox;工程师工具箱;Engineer's Toolbox;
 e-tools-redstone-powered-tools;313;;电子工具：红石供电工具;E-Tools: Redstone Powered Tools;
 ;314;AppliedThermodynamics;应用热力学;Applied Thermodynamics;
-modular-systems;315;modularsystems;模块化熔炉2;Modular Furnaces 2/Modular Systems;
+modular-systems;315;modularsystems;模块化系统;Modular Systems;
 ;316;;原子科技;Atomicraft;
 traincraft;317;tc;火车工业;Traincraft;TC
 hydraulicraft;318;HydCraft;液压工艺;Hydraulicraft;HC
@@ -315,7 +315,7 @@ zelda-sword-skills;340;zeldaswordskills;塞尔达剑技;ZELDA SWORD SKILLS;ZSS
 minemenu;342;minemenu;我的菜单;MineMenu;
 symcalc;343;symcalc;对称度运算仪;Symcalc;
 ;344;mod_ecru_MapleTree;枫树;MapleTree;MT
-;345;;匠魂强化;TiC Tweaks;
+;345;IguanaTweaksTConstruct;匠魂强化;TiC Tweaks;
 jabba;346;JABBA;更好的储物桶;Just Another Better Barrel Attempt;JABBA
 mcheli-minecraft-helicopter-mod;347;mcheli;MC直升机;MC Helicopter Mod;MCheli
 ex-aliquo;348;exaliquo;Ex Aliquo;;
@@ -334,7 +334,7 @@ applemilktea2;363;DCsAppleMilk;苹果奶茶2;AppleMilkTea2;AMT2
 flaxbeards-steam-power;365;Steamcraft;FSP蒸汽动力;Flaxbeard's Steam Power;FSP
 slashblade;366;flammpfeil.slashblade;拔刀剑;SlashBlade;
 steves-factory-manager;367;StevesFactoryManager;史蒂夫工厂管理;Steve's Factory Manager;SFM
-;369;;神秘管道;Thaumic Pipes;
+;369;thaumicpipes;神秘管道;Thaumic Pipes;
 thaumcraftgates;370;thaumiumPipe;奥法管道;ThaumcraftGates;
 ;371;;神秘合成;Thaumcraft Recipes;
 player-heads-forge;372;PlayerHeads;玩家死亡掉头;Player Heads;
@@ -378,7 +378,7 @@ lanteacraft;415;LanteaCraft;星际之门;LanteaCraft;
 matteroverdrive-17-edition;416;matteroverdrive,mo;超能物质;Matter Overdrive;MO
 tainted-magic;417;TaintedMagic;污秽魔法;Tainted Magic;TM
 minetweaker3;418;MineTweaker3;MineTweaker 3;;MT
-treecapitator;419;Treecapitator;砍树;Tree Capitator;
+treecapitator;419;Treecapitator;砍树;Treecapitator;
 insta-house;420;instahouse;即时建造;Insta House;
 multi-page-chest;421;MultiPageChest,multipagechest;多页箱子;Multi-Page Chest;MPC
 draconic-evolution;423;draconicevolution;龙之进化/龙之研究;Draconic Evolution;DE
@@ -396,7 +396,7 @@ hardcore-ender-expansion;434;HardcoreEnderExpansion;极限末地生存;Hardcore 
 more-fun-quicksand-mod;435;MFQM;更多流沙;More Fun Quicksand Mod;MFQM
 fastcraft;436;FastCraft;快速工艺;FastCraft;
 forgeautoshutdown-1-12-2;437;forgeautoshutdown;Forge Auto Shutdown;;
-;438;;行动助手;Movement Assistant;
+;438;MovementAssistant;行动助手;Movement Assistant;
 sao-ui;439;saoui;刀剑神域UI;Sword Art Online UI / SAO UI;SAOUI
 extratic;440;ExtraTiC;匠魂扩展;Extra TiC;
 dimensional-pockets;441;dimensionalPockets;四次元口袋;DimensionalPockets;DP
@@ -414,16 +414,16 @@ project-zulu;451;ProjectZulu|Core;祖鲁;Project Zulu;PZ
 chinacraft;453;chinacraft;华夏文明;ChinaCraft;CC
 thaumcraft;454;Thaumcraft;神秘时代5;Thaumcraft 5;TC5
 ;455;gregtech;格雷科技6;GregTech 6;GT6
-betterbeginnings-mod;456;;更好的开局;Better Beginnings;BB
+betterbeginnings-mod;456;betterbeginnings;更好的开局;Better Beginnings;BB
 utility-mobs;457;UtilityMobs;工具怪物;Utility Mobs;
 hunger-overhaul;458;hungeroverhaul;饥饿改革;Hunger Overhaul;HO
 jei;459;jei,JEI;JEI物品管理器;Just Enough Items;JEI
-jeiaddons;460;;JEI Addons;;
+jeiaddons;460;JEIAddons;JEI Addons;;
 magneticraft;461;Magneticraft,magneticraft;磁场工艺;MagnetiCraft;MAGC
 chromaticraft;462;ChromatiCraft;缤纷纪元;ChromatiCraft;ChC
 immersive-engineering;463;ImmersiveEngineering,immersiveengineering;沉浸工程;Immersive Engineering;IE
 armourers-workshop;464;armourersWorkshop,armourers_workshop,plushieWrapper;时装工坊;Armourer's Workshop;
-;465;plo;植物矿石;Plants To Ores;
+plants-to-ores;465;plo;植物矿石;Plants To Ores;
 slash;466;Slash;命令强化;Slash;
 et-futurum;467;etfuturum;把未来带回现实;Et Futurum;
 cooking-for-blockheads;468;cookingforblockheads,cookingbook;傻瓜烹饪/懒人厨房;Cooking for Blockheads;
@@ -432,7 +432,7 @@ psi;470;psi,Psi;Psi;;
 good-nights-sleep;471;good_nights_sleep,goodnightsleep;夜眠梦境/晚安的梦境;Good Night's Sleep;GNS
 binnies-mods;472;BinnieCore,ExtraBees,ExtraTrees,Botany,Genetics;Binnie's Mods;;
 baubles;473;Baubles,baubles;饰品栏;Baubles;
-more-swords-mod;474;;更多剑;MoreSwords;
+more-swords-mod;474;MSM3;更多剑;MoreSwords;
 thaumic-bases;475;thaumicbases;神秘基础学;Thaumic Bases;TB
 essentialcraft-3;476;essentialcraft;源质魔法3;EssentialCraft 3;EC3
 ;477;Wa;和风;和風;Wa
@@ -459,7 +459,7 @@ botania-unofficial;498;;植物魔法非官方版;Botania Unoffical;
 angry-pixel-the-betweenlands-mod;499;thebetweenlands;交错次元;The Betweenlands;TBL
 real-first-person-render;500;rfp2,realrender;真实的第一人称;Real First Person 2;
 ;501;;丹药笔记;PillNote;PN
-;502;;TW-信息;TW-Info;TW-Info
+;502;TW-Info;TW-信息;TW-Info;TW-Info
 custom-stuff-3;503;CustomStuff3;自定义物品3;Custom Stuff 3;CS3
 lockdown;504;lockdown;地图生成锁定;Lockdown;
 avaritia;505;Avaritia,avaritia;无尽贪婪;Avaritia;
@@ -482,7 +482,7 @@ inventory-pets;521;inventorypets;背包宠物;Inventory Pets;
 levels;522;levels;装备等级;Levels;
 keeping-inventory;523;keepinginventory;Keeping Inventory;;
 orespawn;524;orespawn;矿石菌种;OreSpawn;OS
-reliquary-v1-3;525;xreliquary;圣遗物;Reliquary Reincarnations (Reliquary) / Xeno's Reliquary;
+reliquary-reincarnations;525;xreliquary;圣遗物;Reliquary Reincarnations (Reliquary) / Xeno's Reliquary;
 mo-bends;526;mobends;更多弯曲;Mo' Bends;
 quark;527;quark,Quark;夸克;Quark;
 blood-magic;528;bloodmagic,BloodMagic;血魔法2;Blood Magic 2;BM2
@@ -500,7 +500,7 @@ openmodularturrets;539;openmodularturrets;开放式炮台;OpenModularTurrets;OMT
 technomancy;540;technom;量子魔法;Technomancy;
 quantumflux;541;quantumflux;量子通量;QuantumFlux;QF
 blocksniffer;542;sniffer;方块探测;Block Sniffer;
-dragonapi;543;;Dragon API;;
+dragonapi;543;DragonAPI;Dragon API;;
 electricraft;544;ElectriCraft;电力工艺;ElectriCraft;EC
 candycraft;545;candycraftmod;糖果世界;CandyCraft;
 ;546;ihl;IHL Tools & Machines;;IHL
@@ -513,7 +513,7 @@ latiao-craft;552;latiaocraft;辣条工艺;Latiao Craft;LTC
 ;553;TofuFactory;豆腐工厂重置版;Tofu Factory Reloaded;TFR
 meteorcraft;554;MeteorCraft;陨石工艺;MeteorCraft;
 iguanas-tinker-tweaks;555;IguanaTweaksTConstruct;匠魂增强;Iguanas Tinker Tweaks;
-arrow-cam;556;;箭矢视角;Arrow Cam Mod;ACM
+arrow-cam;556;arrowcammod;箭矢视角;Arrow Cam Mod;ACM
 tea-the-story;557;teastory;茶风·纪事;Tea the Story;TS
 techreborn;558;techreborn,techreborn_compat;科技复兴;Tech Reborn;TR
 infusinbrewing;559;InfusionBrewing;注魔酿造;Infusion Brewing;IB
@@ -526,7 +526,7 @@ aobd-singularities;565;aobdsingularities;AOBD的奇点;AOBD Singularities;
 universal-singularities;566;universalsingularities;通用奇点;Universal Singularities;US
 academy-monster;567;academy-monster;超能力怪物;Academy Monster;AM
 sonar-core;568;sonarcore;声呐核心;Sonar Core;
-armorstatushud-updated;569;armorstatushud;耐久信息显示;ArmorStatusHUD;
+armorstatushud;569;armorstatushud;耐久信息显示;ArmorStatusHUD;
 wanionlib;570;wanionlib;Wanion Lib;;
 llibrary;571;llibrary;LLibrary;;
 ;575;gtextras;GTExtras;;
@@ -543,7 +543,7 @@ mine-mine-no-mi;593;mineminenomi;恶魔果实;Mine Mine no Mi;
 advanced-rocketry;594;advancedRocketry,advancedrocketrycore,advancedrocketry,AdvancedRocketryCore;高级火箭;Advanced Rocketry;AR
 vics-modern-warfare-mod;595;mw;维克的现代战争;Vic's Modern Warfare Mod;VMW
 chance-cubes;596;chancecubes;机会方块;Chance Cubes;
-gun-customization;597;;Gun Customization;;
+gun-customization;597;guncus;Gun Customization;;GunCus
 endercore;598;endercore;末影核心;EnderCore;
 brandons-core;599;brandonscore;Brandon's Core;;
 cofh-core;600;CoFHCore,cofh_core,cofhcore;CoFH核心;CoFH Core;
@@ -570,16 +570,16 @@ mob-properties;620;MobProperties,mob_properties;怪物属性;Mob Properties;MP
 ganys-surface;621;ganyssurface;Gany的世界;Gany's Surface;
 ;622;;遗忘的火光;Amnesia Lights;AL
 ezstorage;623;ezstorage;EZ存储;EZStorage;EZ
-ichunutil;624;ichunutil;iChunUtil;;
+ichunutil;624;ichunutil,iChunUtil;iChunUtil;;
 intangible;625;intangible;Intangible;;
-;626;;灵魂森林;Soul Forest;
+;626;soulforest;灵魂森林;Soul Forest;
 forge-multipart-cbe;627;ForgeMultipart,forgemultipartcbe,microblockcbe,minecraftmultipartcbe;CB Multipart / Forge Multipart CBE / ForgeMultipart;;
 the-titans-mod;628;TitansAnimationAPI,thetitans;泰坦生物;The Titans;
 enchiridion;629;Enchiridion,Enchiridion2;Enchiridion;;
 stimmedcow-nomorerecipeconflict;630;recipehandler;合成冲突消除;NoMoreRecipeConflict;
 tinker-i-o;631;tinker_io;工匠接口;Tinker I/O;
 woot;632;woot,Woot;生物工厂;Woot;
-;633;;滑稽纪元;Huaji Age;
+;633;huaji;滑稽纪元;Huaji Age;
 thermal-expansion;634;thermalexpansion;热力膨胀5;Thermal Expansion 5;TE5
 realistic-terrain-generation;635;RTG,rtg;真实地形生成;Realistic Terrain Generation;RTG
 mob-rebirth;636;mobrebirth;怪物重生;Mob Rebirth;
@@ -657,13 +657,13 @@ taoism;708;taoism;御灵;Taoism;
 essentialcraft-4-unofficial;709;essentialcraft;源质魔法4非官方版;EssentialCraft 4 Unofficial;
 celestial-craft;710;celestialcraft;天体;Celestial Craft;
 lost-thaumaturgy;711;;失落神秘;Pengu's Lost Thaumaturgy;
-compact-machines;712;compactmachines3,cm2,compactmachines;更多空间/压缩空间;Compact Machines;CM
+compact-machines;712;compactmachines3,cm2,compactmachines,CompactMachines;更多空间/压缩空间;Compact Machines;CM
 ;713;uc;实用煤炭;UsefulCoals;UfC
 ex-nihilo-omnia;714;exnihiloomnia;无中生有-世间万物;Ex Nihilo Omnia;
 last-sword-you-will-ever-need-mo;715;theonlychaosmodforyou;最终之剑;The Last Sword You Will Ever Need Mod;
 the-last-sword-you-will-ever-need-reboot;716;tlsywen;最终之剑：重生;The Last Sword You Will Ever Need Reboot;
 ftb-library-legacy-forge;718;ftblib,FTBL,ftbl;FTB Library（旧版）;FTB Library (Forge) (Legacy);FTBL
-;719;;库存扫描;InventoryScan;IS
+;719;InventoryScan;库存扫描;InventoryScan;IS
 ;720;;哥斯拉;Godzilla;
 thaumic-potatoes-2;721;thaumicpotatoes;神秘土豆2;Thaumic Potatoes 2;TP2
 extraplanets;722;extraplanets;额外行星;Extra Planets;EP
@@ -680,13 +680,13 @@ blocklings;729;blocklings;方块酱;Blocklings;
 sbm-wooden-shears;734;woodenshears;木剪刀;Wooden Shears;
 ;735;;神秘史记;Thaumic History;
 schools-of-magic;736;;魔法学院;Schools of Magic;
-aether-aspects;737;;天境要素扫描;Aether Aspects;
+aether-aspects;737;AetherAspects;天境要素扫描;Aether Aspects;
 arcane-arteries;738;arcanearteries;奥法献祭学;Arcane Arteries;
 thaumic-palmistry;739;thaumicpalmistry;Thaumic Palmistry;;
 one-click-crafting;740;oneclickcrafting;一键合成;One click crafting;OCC
 essential-thaumaturgy-unofficial;741;;源质神秘学（非官方版）;Essential Thaumaturgy Unofficial;
 wireless-crafting-terminal;742;wct,ae2wct;无线合成终端;Wireless Crafting Terminal;WCT
-waila-plugins;743;wailaplugins;Waila插件;Waila Plugins;WP
+waila-plugins;743;wailaplugins;Waila 插件;Waila Plugins;WP
 appleskin;744;appleskin;苹果皮;AppleSkin;AS
 tcbotaniaexoflame;745;TCBotaniaExoflame;奥术投射;TCBotaniaExoflame;TCBE
 thaumic-equivalence;746;;奥法置换;Thaumic Equivalence;
@@ -701,7 +701,7 @@ natures-compass;754;naturescompass;自然罗盘/生物群系指南针;Nature's C
 warp-theory;755;WarpTheory;神秘扭曲学;Warp Theory;
 hammer-lib;756;hammercore,hammerlib;锤子核心;Hammer Core/Hammer Lib;
 ;757;MiningTools;采掘工具;Mining Tools;
-thermal-casting;758;;热力铸造室;Thermal Casting;
+thermal-casting;758;ThermalCasting;热力铸造室;Thermal Casting;
 thermal-smeltery-redux;759;;热力冶炼厂重置版;Thermal Smeltery Redux;
 brcore;760;BRCore;BRCore;;
 industrial-expansion-te-addon;761;industrialexpansion;工业扩充（TE附属）;Industrial Expansion [TE Addon];
@@ -721,7 +721,7 @@ xnet;775;xnet;XNet;;
 wireless-crafting-grid;776;wcg;无线合成网络;Wireless Crafting Grid;WCG
 top-addons;778;topaddons;TOP Addons;;TOPA
 torchmaster;779;torchmaster;火炬大师;Torchmaster;
-ZeroCore;780;zerocore;ZeroCore;;
+zerocore;780;zerocore;ZeroCore;;
 sleeping-bag;781;SleepingBag;睡袋;Sleeping Bag;
 the-one-probe;782;theoneprobe;检测器;The One Probe;TOP
 simply-jetpacks-2;784;simplyjetpacks;简易喷气背包2;Simply Jetpacks 2;SJ2
@@ -801,13 +801,13 @@ weather-storms-tornadoes;860;weather2;局部气候&风暴;Weather, Storms & Torn
 new-things;861;newthings;New Things;;
 survivalist;862;survivalist;生存主义;Survivalist;
 mystic-divination;863;;秘契占星术;Mystic Divination;
-cofh-lib;864;;CoFH Lib;;
+cofh-lib;864;CoFHLib;CoFH Lib;;
 tabula-rasa;865;TabulaRasa;Tabula Rasa;;
 cofhtweaks;866;;CoFHTweaks;;
 ender-io-zoo;867;EnderZoo;末影动物园;Ender IO Zoo/Ender Zoo;
 simple-usage-log;868;simpleusagelog;简易日志;Simple Usage Log;SUL
-omnis-core;869;;Omnis Core;;
-auto-paths;870;;自动路径;Auto Paths;
+omnis-core;869;OmnisCore;Omnis Core;;
+auto-paths;870;AutoPaths;自动路径;Auto Paths;
 react;871;react;React;;
 shared-resource-packs;872;sharedresourcepacks;共享资源包;Shared Resource Packs;SRP
 i-know-what-im-doing;873;ikwid;我知道我在干什么;I Know What I'm Doing;IKWID
@@ -827,7 +827,7 @@ immersive-tech;885;immersivetech;沉浸科技;Immersive Technology;
 funky-locomotion;887;funkylocomotion;Funky Locomotion;;FL
 compatlayer;888;compatlayer;版本兼容;CompatLayer;
 wopper;889;wopper;木制漏斗;Wopper;
-gorgecore;890;;食用强化;GorgeCore;
+gorgecore;890;gorgecore;食用强化;GorgeCore;
 chineseworkshop;891;chineseworkshop;中式工坊;Chinese Workshop;CW
 modular-routers;892;modularrouters;模块化路由器;Modular Routers;
 darkcore;893;darkcore;暗黑核心;Darkcore;
@@ -849,7 +849,7 @@ googlyeyes;908;googlyeyes;金鱼眼;GooglyEyes;
 lycanites-mobs;909;lycanitesmobs,swampmobs,saltwatermobs,plainsmobs,mountainmobs,junglemobs,infernomobs,freshwatermobs,forestmobs,desertmobs;恐怖生物;Lycanites Mobs;LM
 back-to-eco;910;backtoeco;生态回归;Back to Eco;
 world-of-warcraft;911;wow;魔兽世界;World Of Warcraft;
-the-witcher-adventure;912;;猎魔人;The Witcher Adventure;
+the-witcher-adventure;912;thewitcheradventure;猎魔人;The Witcher Adventure;
 fancy-battleaxes;913;fancy_battleaxes;华丽战斧;Fancy Battleaxes;
 zora-no-densha;914;zoranodensha;Zora的电车;Zora no Densha;ZnD
 roguelike-dungeons;915;roguelike;冒险地牢;Roguelike Dungeons;
@@ -880,9 +880,9 @@ bookshelf;938;bookshelf,bookshelfapi;Bookshelf;;
 random-things;940;randomthings,RandomThings;随意作品;Random Things;RT
 ;941;scprein;SCP基金会2;SCP Craft 2;SCPC2
 netherex;942;nex,netherex;下界拓展;NetherEX;NEX
-engender-mod;943;ageofminecraft,ageofabyssalcraft,ageofchaos,ageofmutants;召唤师;Engender - The Age of Minecraft;
+engender-mod;943;ageofminecraft,ageofabyssalcraft,ageofchaos,ageofmutants;召唤师;The Engender Mod;
 better-questing;944;betterquesting;更好的任务;Better Questing;BQ
-;945;Enhanced Survival;石头工艺;Stone craft;
+;945;;石头工艺;Stone craft;
 ;946;;不要杀戮;Don't Slay;
 ct-mortar;947;ctmortar;CT Mortar;;
 ct-watercan;948;watercan;CT Watercan;;
@@ -902,7 +902,7 @@ solar-expansion;961;SolarExpansion;Solar Expansion;;
 blue-power;962;bluepower;蓝石力量;Blue power;
 redstone-armory;963;RArm;红石军械库;Redstone Armory;RArm
 qmunitylib;964;qmunitylib;QmunityLib;;
-;965;questforbluename;Quest Name For Blue;;
+quest-for-blue-name;965;questforbluename;Quest Name For Blue;;
 the-last-smith;966;lastsmith;最后的太刀匠人;The Last Smith;TLS
 mineamp;967;MineAmp,jukebox;我的音乐;MineAmp;
 quiverbow;968;quiverchevsky;Quiver Bow;;
@@ -918,7 +918,7 @@ refined-storage-addons;977;refinedstorageaddons;精致存储附属;Refined Stora
 foamfix-optimization-mod;978;foamfix,foamfixcore;泡沫修复;FoamFix;
 industrial-foregoing;979;industrialforegoing;工业先锋;Industrial Foregoing;IF
 expanded-armory;980;exparmory;扩展装备;Expanded Armory;EA
-voxelmap;981;VolexMap,voxelmap;体素地图;VoxelMap;
+voxelmap;981;VolexMap,voxelmap;体素地图;VoxelMap;VM
 ;982;rwbyCraft;四色战记;RWBY Craft;RWBYC
 ;983;grim3212core;Grim3212Core;;
 mowzies-mobs;984;mowziesmobs;Mowzie的生物;Mowzie's Mobs;MMobs
@@ -942,12 +942,12 @@ storage-boats-mod;1001;storageboats;存储船;Storage Boat Mod;
 mo-withers;1002;;更多凋灵;Mo' Withers;
 jingames-naruto-c;1003;;火影忍者C;Naruto C;
 the-autologin-mod-for-authme-server;1004;autologin;自动登录;AutoLogin;
-ROOST;1005;roost;鸡窝;Roost;
+roost;1005;roost;鸡窝;Roost;
 croparia;1006;croparia,Croparia;矿石作物/魔种之咏;Croparia;
 simple-corn;1007;simplecorn;简单玉米;Simple Corn;
 thaumic-jei;1008;thaumicjei;Thaumic JEI;;
 tinkers-steelworks;1009;TSteelworks;匠魂炼钢厂;Tinkers' Steelworks;TiS
-unicode-font-extension;1010;unicodefontextension;Unicode字体扩展;Unicode Font Extension;UFEX
+unicode-font-extension;1010;unicodefontextension;Unicode 字体扩展;Unicode Font Extension;UFEX
 placeable-items;1011;placeableitems;可放置物品;Placeable Items;
 compendium;1012;tinkerscompendium,tinkersdefense;工匠防御;Tinkers' Compendium (Tinkers' Defense);
 stargate-network;1013;SGCraft;格雷的星门;Greg's SG Craft;GSGC
@@ -956,7 +956,7 @@ torohealth-damage-indicators;1015;torohealth;ToroHealth 伤害显示;ToroHealth 
 omni-ocular;1016;OmniOcular;Omni Ocular;;OO
 wrapup;1017;wrapup;WrapUp;;
 nuclear-physics;1018;nuclearphysics;Nuclear Physics;;
-wither-skeleton-tweaks;1019;witherskelefix;凋灵骷髅调整;Wither Skeleton Tweaks;
+wither-skeleton-tweaks;1019;witherskelefix,wstweaks;凋灵骷髅调整;Wither Skeleton Tweaks;
 heat-and-climate;1020;dcs_climate;热量与气候;Heat And Climate;H&C
 customthings;1021;customthings;自定义物品;CustomThings;
 exgregilo;1022;exgregilo;格雷矿筛;ExGregilo;
@@ -968,8 +968,8 @@ immersive-railroading;1028;immersiverailroading;沉浸铁路;Immersive Railroadi
 ;1029;foodcraftreloaded;食物工艺重置版;FoodCraft Reloaded;FCR
 custom-main-menu;1030;custommainmenu;自定义主菜单;Custom Main Menu;CMM
 ;1031;TacticalFrame;战术框架;Tactical Frame;
-wildycraft;1032;;Wildycraft:Runescape Dimension;;
-;1033;;我的信条;MineCreed;
+wildycraft;1032;nolpfij_wildycraft;Wildycraft;;
+;1033;minecreed;我的信条;MineCreed;
 ;1034;heartwork;心血结晶;The Heartwork;THW
 my-little-mob-grinder;1035;mylittlemobgrinder;小怪物粉碎机;My Little Mob Grinder;
 resource-loader;1036;resourceloader,ResourceLoader;资源加载;Resource Loader;RL
@@ -981,7 +981,7 @@ toxicrain;1040;toxicrain;有毒的雨;ToxicRain;
 ;1042;molten;炽热基岩;Molten Bedrockium;
 cannibalism;1043;cannibalism;割肉小刀/同类相食;Cannibalism;
 quick-consume;1044;;快速消耗;Quick Consume;
-planting-dirt-for-saplings;1045;autoplanter;自动植树机;Planting dirt for saplings;
+planting-dirt-for-saplings;1045;autoplanter;自动植树机;Auto Planter / Planting dirt for saplings;
 ;1046;phtage;幻影时代;PhantomAge;PHTAGE
 custom-crosshair-mod;1047;custom-crosshair-mod;自定义准心;Custom Crosshair Mod;CCM
 better-blink;1048;betterblink;更好的传送;Better Blink;
@@ -1008,9 +1008,9 @@ omlib;1070;omlib;开放式炮台库;OMLib;
 dynamictrees;1071;dynamictrees,dynamictreestc,growingtrees;动态的树/有活力的树;Dynamic Trees;DT
 merry-christmas;1072;;圣诞箱子;Merry Christmas!;
 cloud-control;1073;;可控制的云;Cloud Control;
-zombie-ore;1074;;矿石僵尸;Zombie ore;
+zombie-ore;1074;zombieore;矿石僵尸;Zombie Ore;
 meanmobs;1075;meanmobs;残忍怪物;MeanMobs;
-zyins-hud;1076;;Zyin's HUD;;
+zyins-hud;1076;zyinhud;Zyin's HUD;;
 ;1077;negorerouse;尼格洛兹·无尽曈曚;NegoreRouse;NR
 rough-tweaks;1078;roughtweaks;难度调整;Rough Tweaks;
 ;1079;;厨艺大师;Master Chef;
@@ -1043,7 +1043,7 @@ binnies-mods;1106;Genetics,genetics;基因工程;Genetics;
 misty-world;1107;mist;朦胧世界;Misty World;MW
 ;1108;binniecore;Binnie核心;Binnie Core;
 binnies-mods;1109;Botany,botany;植物学;Botany;
-beta-kathairis;1110;kathairis;卡塞瑞斯;Kathairis/Kether;
+beta-kathairis;1110;kathairis;卡塞瑞斯;Kathairis / Kether;
 manametal;1111;manametalmod;魔法金属;ManaMetalMod;M3
 avaritiaddons;1112;avaritiaddons;无尽收容 / 更多空间箱子;Avaritiaddons;
 base;1113;base;B.A.S.E;;
@@ -1052,7 +1052,7 @@ immersive-cables;1114;immersivecables;沉浸线缆;Immersive Cables;
 better-title-screen;1116;bettertitlescreen;更好的标题页;Better Title Screen;BTS
 sound-filters;1117;soundfilters;声音滤波器;Sound Filters;
 lambda-craft;1118;lambdacraft;半条命;LambdaCraft;λC
-vivecraft;1119;vivecraftforgeextensionscore,vivecraftforgeextensions;Vivecraft;;
+vivecraft;1119;vivecraftforgeextensionscore,vivecraftforgeextensions,vivecraft;Vivecraft;;
 super-sound-muffler;1120;supersoundmuffler;超级消音器;Super Sound Muffler;
 armorplus;1121;armorplus;装备扩充;ArmorPlus;
 inspirations;1122;inspirations;灵感;Inspirations;
@@ -1070,12 +1070,12 @@ realm-of-the-dragons-rotd;1133;rotd;龙之领域;Realm Of The Dragons;ROTD
 rockhounding-mod-core;1134;rockhounding_oretiers,rockhounding_rocks,rockhounding_surface,globbypotato_rockhounding,rockhounding_chemistry,rockhounding_core;地质探秘/岩石狩猎;RockHounding;RH
 fancy-block-particles;1135;fbp;梦幻方块效果;Fancy Block Particles;FBP
 thaumic-katana;1136;thaumkatana;神秘之日本刀;Thaumic Katana;
-the-aether-ii;1137;aether;天境二;The Aether II;
+the-aether-ii;1137;aether,aether_ii;天境二;The Aether II;
 visibleraygenerator;1138;VisibleRayGenerator,vrgenerator;永久光发电机;VisibleRay Generator;
 mmmmmmmmmmmm;1139;testdummy,dummmmmmy;试验假人;MmmMmmMmmMmm / Target Dummy;
 aromabackup;1140;AromaBackup,aromabackuprecovery,aromabackup;存档备份;AromaBackup;
 ;1141;name-wakander;NameWakander;;
-orbis-lib;1142;orbis-lib;Orbis;;
+orbis-lib;1142;orbis-lib;Orbis Library;;
 the-eight-fabled-blades;1143;theeightfabledblades;八大传说之刃;The Eight Fabled Blades;
 malisisblocks;1144;malisisblocks;Malisisblocks;;
 useful-interior;1145;of;有用的内饰;Useful Interior;
@@ -1095,9 +1095,9 @@ server-properties-for-lan;1158;splan;简单联机;Server.Properties for LAN;
 jaopcaadditions;1160;;JAOPCA附属;JAOPCAAdditions;
 cloche-call;1161;;Cloche Call;;
 mouse-tweaks;1162;mousetweaks;鼠标手势;Mouse Tweaks;
-jaopcaagriculture;1163;jaopca,oredictinit;JAOPCA神秘农业附属;Just A Resource Generation Compatibility Attempt;JARGCA
+jargca;1163;jaopca,oredictinit;JAOPCA神秘农业附属;Just A Resource Generation Compatibility Attempt;JARGCA
 sky-resources;1164;skyresources;空岛资源2;Sky Resources2;SR2
-hexxit-gear;1165;;Hexxit装备;Hexxit Gear;
+hexxit-gear;1165;hexxitgear;Hexxit 装备;Hexxit Gear;
 ;1166;itemrender;渲染图片导出续作;Item Render Rebirth;IRR
 magic-clover;1167;magicclover;幸运四叶草;Magic Clover;
 inventory-crafting-grid;1168;;背包工作台;Inventory Crafting Grid;
@@ -1126,7 +1126,7 @@ controlling;1191;controlling;键位冲突显示;Controlling;
 ;1192;saligia;炼金重铸计划-七宗罪;PROJECT_saligia;
 ;1193;MemoryCleaner;内存清理;Memory Cleaner;
 simpleleather;1194;simpleleather;腐肉烧皮革;SimpleLeather;
-sync;1195;sync;克隆;Sync;
+sync;1195;sync,Sync;克隆;Sync;
 chiseled-me;1196;chiseled_me;超级变变变;Chiseled Me;
 progressive-automation-early-miner;1197;progressiveautomation;进阶自动化;Progressive Automation;
 matmos;1198;matmos;真实环境音效;MAtmos;
@@ -1142,25 +1142,25 @@ cucumber;1207;cucumber;Cucumber Library;;
 hunting-dimension;1208;huntingdim;狩猎维度;Hunting Dimension;
 runes-of-wizardry;1209;runesofwizardry;符文魔法;Runes-of-Wizardry;
 coffee-workshop;1211;coffeework;咖啡工坊;Coffee Workshop;
-in-game-account-switcher;1212;ias;游戏内账号切换;In-Game Account Switcher;ias
+in-game-account-switcher;1212;ias;游戏内账号切换;In-Game Account Switcher;IAS
 consecration;1213;consecration;圣化;Consecration;
 ignite-hud;1214;ignitehud;燃点HUD;Ignite HUD;
 mrcrayfishs-gun-mod;1215;cgm;MrCrayfish的枪;MrCrayfish's Gun Mod;CGM
-bloodmoon;1216;bloodmoon;血月;bloodmoon;BM
+bloodmoon;1216;bloodmoon;血月;Bloodmoon;BM
 obfuscate;1217;obfuscate;Obfuscate;;
 runic-dungeons;1218;runicdungeons;符文地牢;Runic Dungeon;
-poop;1219;;屎;Poop Mod;
+poop;1219;shit;屎;Poop Mod;
 slurp;1220;slurp;啜饮;Slurp;
 tough-expansion;1221;tanaddons;意志坚定：热力附属;Tough Expansion;
 mystical-agradditions;1222;mysticalagradditions;神秘农业扩展;Mystical Agradditions;
 vanillafix;1223;vanillafix;原版修复;VanillaFix;VF
 just-enough-harvestcraft;1224;jehc;更多潘马斯配方查询;Just Enough HarvestCraft;JEHC
-charcoal-pit;1225;charcoal_pit;Charcoal Pit;;
+charcoal-pit-4;1225;charcoal_pit;Charcoal Pit;;
 uncomplication;1226;Uncomplication;IC2exp还原;Uncomplication;
 the-wings-of-alfheim-1-7-10;1227;alfheimwings;亚尔夫海姆之翼;The Wings of Alfheim;
 ;1228;reversecraft;逆向合成台;ReverseCraft;
 mubble;1230;mubble;Mubble;;
-libraryex;1231;libraryex;MineEx通用库;LibraryEx;LibEx
+libraryex;1231;libraryex;MineEx 通用库;LibraryEx;LibEx
 industrial-wires;1232;industrialwires;工业线缆;Industrial Wires;IW
 mystagrad-cloche-compat;1233;mystagradcompat;MystAgrad Cloche Compat​;;
 waitingtime;1234;waitingtime;加载页面游戏;WaitingTime;
@@ -1174,7 +1174,7 @@ the-mists-of-riov;1241;RioV;神秘世界;The Mists of RioV Mod;RioV
 nsr-no-respawn-screen;1243;norespawnscreen;无重生屏幕;No Respawn Screen;NRS
 more-bees;1244;morebees;蜜蜂拓展;More Bees;
 evilnotchlib;1245;evilnotchlib;EvilNotch Lib;;
-tpalette;1246;;调色板;TPalette;
+tpalette-forge;1246;TPaletteF;调色板;TPalette;
 ;1247;gtweapons;格雷武器扩展;GregTech WeaponWorks;GTWW
 career-bees;1248;careerbees;职业蜜蜂;Career Bees;
 ;1249;levelup;升级！;Level Up!;
@@ -1183,9 +1183,9 @@ level-up-legacy;1251;levelup;升级！前版;Level Up!Legacy;
 moar-boats;1252;moarboats;模块化船;Moar Boats;
 numina;1253;numina;模块化动力装甲前置;Numina;
 tinkers-complement;1254;tcomplement;匠魂补充;Tinkers' Complement;
-everlastingabilities;1255;everlastingabilities;永恒能力;EverlastingAbilities;
+everlastingabilities;1255;everlastingabilities;永恒能力;Everlasting Abilities;
 abyssalcraft-heads;1256;acheads;深渊国度头颅;AbyssalCraft Heads;
-overlord;1257;;不死者之王;Overlord;
+overlord;1257;overlord;不死者之王;Overlord;
 multifarm-crops;1258;multifarmcrops;多功能农场兼容;Multifarm Crops;
 forestry-fermenter-addon;1259;ForestryFermenterAddon-1.7.10;更多生物质;Forestry Fermenter Addon;
 dakimakura-mod;1260;dakimakuramod;抱枕;Dakimakura Mod;
@@ -1199,12 +1199,12 @@ funnels;1268;funnels;液体漏斗;Funnels;
 advent-of-ascension-nevermine;1269;aoa3;虚无世界3;Advent of Ascension 3;AoA3
 toroquest;1270;toroquest;托罗探索;Toro Quest;TQ
 ;1271;nutrition;营养学;Nutrition;
-rikmulds-core-mod;1272;;Rikmulds Core Mod;;
+rikmulds-core-mod;1272;corerm;Rikmulds Core Mod;;
 just-enough-pattern-banners;1273;jepb;Just Enough Pattern Banners;;JEPB
-primitive-mobs;1274;primitivemobs;远古生物/原始生物;Primitive Mobs;
+primitive-mobs;1274;primitivemobs;远古生物 / 原始生物;Primitive Mobs;
 realistic-cobwebs;1275;cobwebs;Realistic Cobwebs;;
 simpleharvest;1276;simpleharvest;简单收获;Simple Harvest;
-mrcrayfishs-device-mod;1277;;MrCrayfish的设备;MrCrayfish's Device Mod;CDM
+mrcrayfishs-device-mod;1277;cdm;MrCrayfish的设备;MrCrayfish's Device Mod;CDM
 block-armor;1278;blockarmor;方块盔甲;Block Armor;
 stockpile;1279;stockpile;储物桶;Stockpile;
 loot-slash-conquer;1280;lsc;Loot Slash Conquer;;LSC
@@ -1252,7 +1252,7 @@ mekanism-generators;1323;mekanismgenerators;通用机械发电机;Mekanism Gener
 spider-queen;1324;SQ;蜘蛛女王;Spider Queen;SQ
 baublelicious;1325;baublelicious;美妙饰品;Baublelicious;
 void-monster;1326;VoidMonster;Void Monster;;VM
-shields-plus;1327;;更多盾牌;Shields Plus;SP
+shields-plus;1327;sp;更多盾牌;Shields Plus;SP
 ghost-buster;1328;ghost_buster;Ghost Buster;;
 culinary-construct;1329;culinaryconstruct;自定义三明治;Culinary Construct;
 armoreablemobs;1330;armoreablemobs;怪物装备自定义;ArmoreableMobs;
@@ -1270,7 +1270,7 @@ paragliders;1344;paraglider;滑翔伞;Paragliders;
 ender-io-endergy;1345;;末影接口：管道拓展;Ender IO:Endergy;
 bwm-suite;1346;betterwithmods;Better With Mods;;BWM
 ambience-music-mod;1347;ambience;环境音乐;Ambience;
-almost-enough-items;1348;;AEI物品管理器;Almost Enough Items;AEI
+almost-enough-items;1348;almostenoughitems;AEI物品管理器;Almost Enough Items;AEI
 mtutils;1349;;MTUtils;;
 gravestone-mod;1350;gravestone;墓碑;GraveStone;
 atlas-extras;1351;atlasextras;Atlas Extras;;
@@ -1295,13 +1295,13 @@ vanilladeathchest;1370;vanilladeathchest;原版死亡箱子;Vanilla Death Chest;
 arachnophobia;1371;arachnophobia;蜘蛛恐惧症;Arachnophobia;
 abyssalcraft-integration;1372;acintegration;深渊国度联动;AbyssalCraft Integration;
 prefab;1373;prefab;预制建筑;Prefab;
-haunch-hud;1374;;Haunch HUD;;
+haunch-hud;1374;haunchhud;Haunch HUD;;
 absent-by-design;1375;absentbydesign;Absent by Design;;
 no-nv-flash;1376;no_nv_flash;无夜视闪烁;No Night Vision Flashing;
 arcade-mod;1377;arcademod;街机;Arcade Mod;
 asmodeuscore;1378;asmodeuscore;Asmodeus Core;;
-building-gadgets;1379;buildinggadgets;建筑小帮手;Building Gadgets;
-dooglamoo-worlds;1380;;Dooglamoo的世界;Dooglamoo Worlds;
+building-gadgets;1379;buildinggadgets,buildinggadgets2;建筑小帮手;Building Gadgets;
+dooglamoo-worlds;1380;dooglamooworlds;Dooglamoo的世界;Dooglamoo Worlds;
 scp-lockdown;1381;scp;SCP基金会：封锁;SCP: Lockdown;SCPL
 middle-earth-thaumaturgy;1382;mett;中土神秘学;Middle-Earth Thaumaturgy;METT
 structpro-mod-fast-schematic-spawning-system;1383;structpro;自然神殿;Structpro;
@@ -1336,12 +1336,12 @@ crissaegrim;1413;crissaegrim;Crissaegrim;;
 ;1414;xcustomizedblade;可视化 X-客制化拔刀剑;XCustomizedBlade;XCB
 traverse-reforged;1416;traverse;遍历;Traverse;
 winter-wonder-land;1417;winterwonderland;霏雪寄语之地;Winter Wonder Land;WWL
-road-stuff;1418;roadstuff;道路2;Road Stuff2;RS2
+road-stuff;1418;roadstuff;道路;Road Stuff;RS
 ae2wtlib;1419;ae2wtlib;AE2 Wireless Terminal Library;;AE2WTLib
 real-filing-cabinet;1420;realfilingcabinet;仿真档案柜;Real Filing Cabinet;
 hycrafthds-wtf-ic2-addon;1421;wtfic2addon;WTF 工业拓展;WTF Ic2 Addon;
 u-team-core;1422;uteamcore;U Team Core;;
-ftb-quests;1423;ftbquests;FTB任务;FTB Quests;FTBQ
+ftb-quests-forge;1423;ftbquests;FTB任务;FTB Quests;FTBQ
 texfix;1424;texfix;材质修复;TexFix;
 mapmakers-gadgets;1425;mapgadgets;地图作者小帮手;Mapmaker's Gadgets;MG
 travellers-gear;1426;TravellersGear;旅者之器;Traveller's Gear;
@@ -1349,7 +1349,7 @@ ceramics;1427;ceramics;陶瓷器;Ceramics;
 slashblade-japanese-addon-pack;1428;slashblade_addon,slashblade.addonpack,flammpfeil.slashblade;拔刀剑日系附属包;SlashBlade Japanese Addon Pack;SJAP
 ;1429;4space;4-Space;;4S
 planet-progression;1430;planetprogression;星球研究;Planet Progression;
-space-advanced-addon-for-galactic-craft-3;1431;;Space Advanced;;
+space-advanced-addon-for-galactic-craft-3;1431;spaceadvanced;Space Advanced;;
 decimation-zombie-apocalypse;1432;deci;僵尸启示录;Decimation;DECI
 rift-mod-list;1433;riftmodlist;Rift Mod List;;
 forgeendertech;1434;EnderTech,forgeendertech;ForgeEndertech;;
@@ -1378,7 +1378,7 @@ thedragonlib;1456;thedragonlib;TheDragonLib;;
 repose;1457;repose;自动上坡;Repose;
 botanic-additions;1458;botanicadds;植物学拓展;Botanic Additions;BA
 ;1459;spongeforge,spongeapi,sponge;海绵端插件支持 Forge 版;SpongeForge;SF
-veggieway-fabric;1460;veggie_way;素食主义者;The Veggie Way;
+veggieway-fabric;1460;veggie_way;素食之道;The Veggie Way;
 gargoyles-mod;1461;gargoyles;石像鬼;Gargoyles;
 hydrophobia;1462;hydrophobia;恐水症;Hydrophobia;
 dimensional-edibles;1463;dimensionaledibles;维度食物;Dimensional Edibles;
@@ -1449,7 +1449,7 @@ valkyrien-warfare;1528;valkyrienskies,vs_world,vs_control;瓦尔基里天空/瓦
 item-scroller;1529;itemscroller;物品滚轮;Item Scroller;
 better-advancements;1530;betteradvancements;更好的进度;Better Advancements;
 lucraft-core;1531;lucraftcore;Lucraft: Core;;
-progressive-bosses;1532;progressivebosses;进化的BOSS;Progressive Bosses;
+progressive-bosses;1532;progressivebosses;进化的 BOSS;Progressive Bosses;
 persistent-bits;1533;persistentbits;Persistent Bits;;
 rc-roads;1534;rcroads;真实公路;RC Roads;
 emoticons;1535;emoticons;动作表情;Emoticons;
@@ -1493,7 +1493,7 @@ trashcans-reborn;1573;trashcansreborn;Garbage Bins;;
 compactdrawers;1574;compactdrawers;Compact Drawers;;
 blockdispenser;1575;;发射器放置方块;BlockDispenser;
 redstone-paste;1576;redstonepaste;爬墙红石/粘性红石;Redstone Paste;
-dynamic-trees-traverse-compat;1577;;动态的树：遍历附属;Dynamic Trees - Traverse Compat;
+dynamic-trees-traverse-compat;1577;dttraverse;动态的树：遍历附属;Dynamic Trees - Traverse Compat;
 charset-lib;1578;charset;Charset Lib;;
 betternether;1579;betternether;更好的下界;BetterNether;
 time-machine-mod;1580;timemachine;时光机;Time Machine;
@@ -1504,9 +1504,9 @@ enchantments-exchanger;1584;;便携附魔替换台;Enchantments Exchanger;
 additional-enchanted-miner;1585;quarryplus;Additional Enchanted Miner;;AEM
 treasure-bags;1586;treasurebags;宝藏袋;Treasure Bags;
 stevecraft-by-owenpsteve2;1587;stevecraft;史蒂夫工艺;SteveCraft;
-hunger-games;1588;examplemod;饥饿游戏;The Hunger Games;
+hunger-games;1588;foundations;饥饿游戏;The Hunger Games;
 tfctech-addon;1589;tfctech;群峦工业;TFCTech Addon;TFCA
-yunomakegoodmap;1590;;YUNoMakeGoodMap;;
+yunomakegoodmap;1590;YUNoMakeGoodMap,yunomakegoodmap;YUNoMakeGoodMap;;
 organic-creepers;1591;organiccreepers;苦力怕蕨;Organic Creepers;
 ;1592;flammpfeil.nihil;似蛭;Nihil;
 ;1593;flammpfeil.slashblade.zephyr;西风太刀;Blade of the Zephyr;
@@ -1516,11 +1516,11 @@ draconicadditions;1596;draconicadditions;龙之进化拓展;Draconic Additions;
 ;1597;sky_lanterns;孔明灯/天灯;Sky Lanterns;
 hated-mobs;1598;hatedmobs;令人讨厌的生物;Hated Mobs;
 ;1599;tfcprimitivetech;原始技术;Primitive Technology;
-mekanica;1600;mekanism;通用机械：DZ版;Mekanica;
+mekanica;1600;;通用机械：DZ版;Mekanica;
 littletiles;1601;littletiles;LT小方块;LittleTiles;LT
 extended-crafting;1602;extendedcrafting;合成拓展;Extended Crafting;
 prodigy-tech;1603;;奇才妙械;Prodigy Tech;PT
-;1604;;RPGapi;;
+;1604;RPG,RPGEx;RPGapi;;
 item-filters;1605;itemfilters;物品过滤器;Item Filters​;
 eblib;1606;net.blacklab.lib;EBlib;;
 notenoughcodecs;1607;notenoughcodecs,NotEnoughCodecs;NotEnoughCodecs;;
@@ -1560,7 +1560,7 @@ mobultion;1640;mobultion;进化怪物;mobultion;
 waddles;1641;waddles;Waddles;;
 project-intelligence;1642;projectintelligence;PI文档;Project Intelligence;PI
 thutcore;1643;thutcore_compat,thutcore;ThutCore;;
-resource-pack-organizer;1644;;资源包管理器;Resource Pack Organizer;
+resource-pack-organizer;1644;resourcepackorganizer;资源包管理器;Resource Pack Organizer;
 morcant-ore;1645;morcant_mod;莫桑矿石;Morcant Ore;
 force-void-world;1646;FVW;强制虚空世界;Force Void World;
 i-am-very-smart-forge;1647;iamverysmart;我很聪明;I Am Very Smart;
@@ -1580,13 +1580,13 @@ cplpibalds-tweaks;1660;pitweaks;CplPibald的微调;CplPibald's Tweaks;
 ore-biome;1661;;矿石生态群系;Ore Biome;
 farm-adventure;1662;farm_adventure_ii,farm_adventure;农场冒险;Farm Adventure;FA
 the-shadow-world;1663;shadowworld,DynamicLights;暗影世界;Shadow World;
-japaricraftmod-2;1664;japaricraftmod;加帕里公园;JapariCraftMod;
+project-306141;1664;japaricraftmod;加帕里公园;JapariCraftMod;
 mchorses-mclib;1665;mclib;McHorse's McLib;;
 musiccraft-mod;1666;musiccraft;音乐工艺;MusicCraft mod;
 hardcore-darkness;1667;hardcoredarkness;真实的黑夜;Hardcore Darkness;HD
 cola-craft;1668;colacraft;可乐工艺;Cola Craft;
 ;1669;ifaz;粒法杖;Particle Wands;
-backstab;1670;backstab;背刺;BackStab;
+backstab;1670;backstab;背刺;Backstab;
 dynamic-stealth;1671;dynamicstealth;动态潜行;Dynamic Stealth;
 ;1673;infinitesimalzeros;Infinitesimal Zeros;;
 roughly-enough-items;1674;roughlyenoughitems;REI物品管理器;Roughly Enough Items;REI
@@ -1608,11 +1608,11 @@ custom-selection-box-port;1691;csb;自定义选择框;Custom Selection Box;CSB
 librikka-api;1692;librikka;Librikka API;;
 not-enough-wands;1693;notenoughwands;更多魔杖;Not Enough Wands;
 deep-mob-learning-blood-magic-addon;1694;deepmoblearningbm;深度怪物知识-血魔法插件;Deep Mob Learning - Blood Magic Addon;
-informed-load-fabric;1695;;更多加载信息;Informed Load;
+informed-load;1695;informedload;更多加载信息;Informed Load;
 huajiage-infinite-galaxy;1696;huajiage;滑稽纪元II:无尽星河;Huaji Age II:Infinite Galaxy;
 ;1697;anothercommonbugfix;另一个通用Bug修复;Another Common Bug Fix;ACBF
 cqrepoured;1698;cqrepoured;寻找巧克力重铸版;Chocolate Quest Repoured;CQR
-fabricproxy;1699;fabricproxy;Fabric群组支持;FabricProxy;
+fabricproxy;1699;fabricproxy;Fabric 群组支持;FabricProxy;
 ex-sartagine;1700;;锅具;Ex Sartagine;
 xaeros-minimap;1701;xaerominimap,xaerominimap_core;Xaero的小地图;Xaero's Minimap;XMM
 everlastingabilities-potioncore;1702;;永恒能力-药水核心;EverlastingAbilities-PotionCore;
@@ -1643,9 +1643,9 @@ tiny-mob-farm;1727;tinymobfarm;迷你刷怪场;Tiny Mob Farm;
 soulus;1728;soulus;Soulus;;
 sanlib;1729;sanlib;SanLib;;
 ;1730;bloodblade;炼狱刀「血腥」;BloodBlade;
-;1731;;延时摄影;Camera Studio;
+;1731;CameraStudio;延时摄影;Camera Studio;
 travelers-backpack;1732;travellersbackpack,travelersbackpack;旅行者背包;Traveler's Backpack;
-gregtech-classic;1733;gregtech;格雷科技经典版;GregTech Classic;GTC
+gregtech-classic;1733;gtclassic;格雷科技经典版;GregTech Classic;GTC
 aperture;1734;aperture;Aperture;;
 combo-armors;1735;IC2CA;组合装甲;IC2ComboArmors;IC2CA
 ;1736;;源质罐子统计;Thaumcraft Jar Checker;
@@ -1675,7 +1675,7 @@ betterportals;1761;;更好的传送门;Better Portals;
 classic-combat;1762;classiccombat;经典战斗;Classic Combat;
 ;1763;AM;火影忍者;NarutoAnimeMod;
 less-lag;1764;lesslag;较少的滞后;Less Lag;
-goodbye-grass;1765;;没有草丛;Grassta la Vista;
+goodbye-grass;1765;goodbyegrass;没有草丛;Grassta la Vista;
 phosphor;1766;phosphor-lighting,phosphor;磷;Phosphor;
 clay-bucket;1767;claybucket;粘土桶;Clay Bucket;
 extra-anvils;1768;extraanvils;更多铁砧/更多砧;Extra anvils;
@@ -1690,7 +1690,7 @@ ender-compass;1776;endercompass;末影指南针;Ender Compass;
 ic2-tweaker;1777;ic2_tweaker;IC2 Tweaker;;
 thaumic-gadgets;1778;tg;神秘宝具;Thaumic Gadgets;TG
 multi-mine;1779;multimine;多人开采;Multi Mine;
-extra-foam-for-liteloader;1780;LiteLoader ObjectHolder fix;Liteloader修复;Extra Foam For LiteLoader;EFFL
+extra-foam-for-liteloader;1780;EFFLL (LiteLoader ObjectHolder fix);Liteloader 修复;Extra Foam For LiteLoader;EFFLL
 embersified;1781;embersified;余烬能量转换;Embersified;
 thaumic-grid;1783;thaumicgrid;神秘网络;Thaumic Grid;
 back-tools;1784;backtools;工具后置/后背工具展示;Back Tools;
@@ -1724,7 +1724,7 @@ crafttweaker-utils;1812;ctutils;CraftTweaker Utils;;
 ;1814;elementcore;元素核心;ElementCore;EC
 fps-reducer;1815;fpsreducer;FPS减速器;FPS Reducer;
 freelook;1816;freelook;自由视角;FreeLook;
-spacecraftx;1817;;航天高科X;SpaceCraftX;
+spacecraftx;1817;spacex;航天高科X;SpaceCraftX;
 ;1818;micdoodlecore;MicdoodleCore;;
 bamboo-everything;1819;bambooeverything;竹子制品;Bamboo Everything;
 nofog;1820;nofog;没有雾;NoFog;
@@ -1751,7 +1751,7 @@ super-factory-manager;1840;superfactorymanager,sfm;超级工厂管理;Super Fact
 sakura;1841;sakura;樱;Sakura;
 sips;1842;sips;更多液体容器;Sips;
 gregs-construct;1843;gtconstruct;格雷与匠魂;Greg's Construct;GTCon
-ultra-awesome-tools-mod;1844;stm;超级工具;Super Tools;
+ultra-awesome-tools-mod;1844;stm;超级工具;Super Tools / Ultra Awesome Tools Mod;STM
 ;1845;;Galacticraft Planets;;
 locks;1846;locks;锁;Locks;
 special-mobs;1847;specialmobs;特殊怪物;Special Mobs;
@@ -1762,7 +1762,7 @@ missingbits;1849;missingbits;MissingBits;;
 locky;1852;locky;Locky;;
 baubleshud;1853;baubleshud;BaublesHud;;
 ;1855;landcore;陆地工艺核心;LandCore;
-;1856;;陆地工艺;Land Craft;
+;1856;landcraft;陆地工艺;Land Craft;
 extra-golems;1858;golems;更多傀儡;Extra Golems;
 craftablecreativemodifier;1859;ccm;可合成的创造模式强化头颅;CraftableCreativeModifier;CCM
 ruins-structure-spawning-system;1860;ruins;遗迹;Ruins;
@@ -1773,8 +1773,8 @@ structurize;1865;structurize;结构化;Structurize;
 improvable-skills;1867;improvableskills;技能进阶;Improvable Skills 3;
 ;1868;morecrafting;更多合成;MoreCrafting;MC++
 bounding-box-outline-reloaded;1869;bbor;自然生成建筑结构显示;Bounding Box Outline Reloaded;BBOR
-sauceconstruct;1870;;Sauce Construct;;
-colorful-hearts;1871;healthoverlay;更美观的血条;Health Overlay/Colorful Hearts;
+sauceconstruct;1870;sauceconstruct;Sauce Construct;;
+colorful-hearts;1871;healthoverlay,colorfulhearts;更美观的血条;Health Overlay / Colorful Hearts;
 auto-feeder-helmet;1872;feederhelmet;自动进食头盔;Auto Feeder Helmet;
 cc-tweaked-fabric;1873;computercraft;CC: Tweaked for Fabric;;
 simple-farming;1874;simplefarming;简单农业;Simple Farming;
@@ -1784,13 +1784,13 @@ psi-combat-magic;1877;psiaddons;Psi:Combat Magic;;
 dtphc;1878;dynamictreesphc;动态的树：潘马斯附属;Dynamic Trees - Pam's Harvestcraft Compat;
 largefluidtank;1879;fluidtank;大型储罐;Large Fluid Tank;LFT
 tumbleweed;1880;tumbleweed;风滚草;Tumbleweed;
-cubicdynamictreescompat;1881;;Cubic Chunks Dynamic Trees Addon;;
+cubicdynamictreescompat;1881;dynamictreees-cubicaddon;Cubic Chunks Dynamic Trees Addon;;
 thermallogistics;1882;thermallogistics;热力物流学;Thermal Logistics;
 bithop;1883;bithop;BitHop;;
 swordskillsapi;1884;swordskillsapi;SwordSkillsAPI;;
 dynamic-sword-skills;1885;dynamicswordskills;动态剑技;Dynamic Sword Skills;DSS
 magical-instruments;1886;minst;魔法乐器;Magical Instruments;
-enderspawn;1887;;末影龙再生成;EnderSpawn;
+enderspawn;1887;enderspawn;末影龙再生成;EnderSpawn;
 animus;1888;animus;Animus;;
 scootys-scp-lockdown-extras;1889;scootys_scp_mod;SCP重型收容区扩展;SCP: Lockdown Heavy Containment Zone Expansion;
 modern-glass-doors;1890;glassdoor;时尚玻璃门;Modern Glass Doors;
@@ -1824,7 +1824,7 @@ food-editor;1917;;食物编辑器;Food Editor;
 custom-starter-gear;1918;customstartinggear;自定义初始装备;Custom Starter Gear;CSG
 ct-tinycoal;1919;cttinycoal;CT 小型煤炭;CT TinyCoal;
 tweaker-gui;1920;tweakergui;TweakerGUI;;
-crafttweaker-editor;1921;;CraftTweaker 编辑器;CraftTweaker Editor;CrTE
+crafttweaker-editor;1921;cteditor;CraftTweaker 编辑器;CraftTweaker Editor;CrTE
 unforgiving-void;1922;unforgivingvoid;不那么仁慈的虚空;Unforgiving Void;
 moretweaker;1923;moretweaker;MoreTweaker;;
 riteclicker-mod;1924;riteclicker;小石子;RiteClicker Mod;
@@ -1836,8 +1836,8 @@ prestige;1930;prestige;成就点;Prestige;
 ;1931;mmo,mcmmoplus;原版技能升级;Vanilla MMO+;VM
 energy-converters;1933;energyconverters;能量桥接器;Energy Converters;
 signpost;1934;signpost;路标;Signpost;
-diagonal-panes;1935;;对角线玻璃板;Diagonal Panes;
-forgelin;1936;;Forgelin;;
+diagonal-panes;1935;fabric-diagonal-panes;对角线玻璃板;Diagonal Panes;
+forgelin;1936;Forgelin;Forgelin;;
 alchemylib;1937;alib,alchemylib;AlchemyLib;;AL
 exp-ore-block-mod;1938;exp_ore;经验矿石;Exp Ore;
 more-glowstone;1939;moreglowstone;更多荧石;More Glowstone;
@@ -1855,13 +1855,13 @@ tf2-stuff-mod;1951;rafradek_tf2_weapons;军团要塞2;TF2 stuff mod;
 mob-control-wands;1952;micwands;怪物控制魔杖;Mob Control Wands;
 ;1953;statues;雕像模组;Statues Mod;
 athenaeum;1954;athenaeum;Athenaeum;;
-ore-excavation;1955;oreexcavation;矿石挖掘;Ore Excavation;
+ore-excavation;1955;oreexcavation;矿石挖掘;Ore Excavation;OE
 stone-chests;1956;stonechests;石箱子;Stone Chests;
 kjlib;1957;kjlib;KJ库;KJLib;
 iron-chest-minecarts;1958;ironchestminecarts;更多箱子矿车;Iron Chest Minecarts;ICM
 nether-chest;1959;netherchest;下界箱子;Nether Chest;
 mob-kill-messages;1960;;击杀信息通知;Mob Kill Messages;
-betterdispenser;1962;betterdispenser;能喂食的发射器;Better Dispenser;
+betterdispenser;1962;betterdispenser;能喂食的发射器;BetterDispenser;
 shulkerboxdisplay;1963;;潜影盒显示器;ShulkerBoxDisplay;
 mycommands;1964;mycommands;我的命令;MyCommands;
 ;1966;miecraft;羊羊工艺;Miecraft;
@@ -1869,26 +1869,26 @@ hearth-well;1968;hwell;Hearth Well;;
 ;1969;;苹果科技;Apple Tech;AT
 tea-and-biscuits;1970;teaandbiscuits;茶和饼干;Tea And Biscuits;TAB
 controllable;1971;controllable;手柄控制;Controllable;
-genetic-animals;1972;;遗传动物;Genetic Animals;
+genetic-animals;1972;eanimod;遗传动物;Genetic Animals;
 stone-chest;1973;stonechest;石头箱子;Stone Chest;
 iron-shulker-boxes;1974;ironshulkerbox;更多潜影盒;Iron Shulker Boxes;
 mob-dismemberment;1975;mobdismemberment;怪物肢解;Mob Dismemberment;
 zoo-wild-animals-rebuild;1976;zawa;野生动物园：重制版;Zoo & Wild Animals Rebuilt;ZAWA
-kottle;1977;;Kottle;;
+kottle;1977;kottle;Kottle;;
 customdrones;1978;;自定义无人机;Custom Drones;
 call-to-battle-2-authentic-world-war-2-experience;1979;ctb;战争召唤2;Call To Battle 2;CtB2
 some-like-it-dry;1980;;Some Like It Dry;;
-yungs-better-caves;1981;bettercaves;YUNG的洞穴优化;YUNG's Better Caves;
+yungs-better-caves;1981;bettercaves;YUNG 的洞穴优化;YUNG's Better Caves;
 resynth;1982;resynth;神农科技;Resynth;
 flatworld;1983;com.ch1a.flatworld,flatworld;开山棒;Flat World;
 pymtech;1984;pymtech;皮姆科技;PymTech;
-corail-tombstone;1985;tombstone;Corail的墓碑;Corail's Tombstone;
-;1986;examplemod;消失的物品;Missing Things;
+corail-tombstone;1985;tombstone;Corail 的墓碑;Corail's Tombstone;
+;1986;missing;消失的物品;Missing Things;
 ;1987;maplelib;Maple Lib;;
 arcane-archives;1988;arcanearchives;奥术档案馆;Arcane Archives;AA
 divineweapon;1989;dweapon;神兵;DivineWeapon;DW
 camera-obscura;1990;cameraobscura;朝花夕拾;Camera Obscura;
-animales;1991;tfa;动物扩充;Animales;
+animales;1991;tfa;动物扩充;Animales;TFA
 armor-underwear-mod;1992;armorunder;盔甲内衬;Armor Underwear Mod;
 assisted-progression;1993;nucleus_teambr;进度小助手;Assisted Progression;
 more-buckets;1994;morebuckets;更多桶;More Buckets;
@@ -1899,10 +1899,10 @@ mine-and-slash-reloaded;1998;mmorpg;挖矿与砍杀;Mine and Slash;MS
 ;1999;tfccellarsaddon;群峦冰窖;TFC Cellars Addon;
 monster-swarm;2000;monsterswarm;怪物云集;Monster Swarm;
 SimplePipes;2001;simple_pipes_dep_container;Simple BC Pipes;;
-;2002;;Wool;;
+;2002;fabric_wool;Wool;;
 amecs;2003;amecs;Amecs;;
 world-primer;2004;worldprimer;World Primer;;
-;2005;;自动收获;AutoHarvest;
+;2005;autoharvest;自动收获;AutoHarvest;
 bookworm;2006;;Bookworm;;
 openeye;2007;OpenEye;错误报告器;OpenEye;OE
 let-sleeping-dogs-lie;2008;dogslie;嘘，别吵醒狗狗;Let Sleeping Dogs Lie;
@@ -1928,7 +1928,7 @@ speedster-heroes;2027;speedsterheroes;闪电侠;Speedster Heroes;
 ;2028;solidcmd;地狱门输入补丁;Solid Command UI;
 curios;2029;curios;Curios API;;
 village-spawn-point;2030;villagesp,villagespawnpoint,villagespawnpoint-fabric;村庄出生点;Village Spawn Point;
-spawnercraft;2031;;刷怪笼合成;SpawnerCraft;
+spawnercraft;2031;spawnercraft;刷怪笼合成;SpawnerCraft;
 openfm;2032;openfm;开放电台;OpenFM;
 the-dalek-mod;2033;thedalekmod;Dalek Mod;;
 modular-diversity;2034;modulardiversity;模块化多样性;Modular Diversity;
@@ -1942,14 +1942,14 @@ trample-stopper;2042;tramplestopper;防止踩踏;Trample Stopper;
 macaws-roofs;2043;mcwroofs;Macaw的屋顶;Macaw's Roofs;
 shadows-of-greg;2044;gtadditions,gregtech;格雷之影;Shadows of Greg;SOG
 loottabletweaker;2045;lttweaker;LootTableTweaker;;
-rockycore;2046;;RockyCore;;RC
+rockycore;2046;rockycore;RockyCore;;RC
 tree-tweaker;2047;treetweaker;Tree Tweaker;;
 worleys-caves;2048;worleycaves;沃利的洞穴;Worley's Caves;
 additional-structures;2049;additionalstructures;失落废墟;Additional Structures/Rex's Additional Structures;AS
 ;2050;customtrees;自定义树木;Custom Trees;
 ;2051;mcmooncake;MC牌月饼;MC Moon Cake;
 ;2052;dao_za_vanillaplus;稻砸原版增强;Dao_Za_Vanillaplus;
-;2053;;Fabric OBJ Model Loader;;FOML
+;2053;foml;Fabric OBJ Model Loader;;FOML
 enhancedvisuals;2054;enhancedvisuals;增强视觉效果/拓展视觉效果;EnhancedVisuals;
 potion-fingers-redux;2055;potionfingers;药剂环/药水指环;Potion Rings;
 balloon-sheep;2056;balloonsheep;气球羊;Balloon Sheep;
@@ -1958,7 +1958,7 @@ oreexcavation-integration;2058;oeintegration;矿物开凿;Ore Excavation Integra
 engineers-workshop;2059;engineersworkshop;工程师工作站;Engineers Workshop;
 the_legend_of_the_brave;2060;thelegendofthebraveii;勇者传说;The Legend of The Brave;
 twerk-sim-2k16;2061;ts2k16;Twerk Sim 2K16;;
-fart-generator;2062;;屁能发电机;Fart Energy Generator;
+fart-generator;2062;fartgen;屁能发电机;Fart Energy Generator;
 ex-nihilo-fabrico;2063;exnihilofabrico;无中生有：Fabrico;Ex Nihilo Fabrico;
 holoinventory;2064;holoinventory;物品显示/物品清单;HoloInventory;
 reactor-stuff;2065;reactor_stuff;反应堆材料;Reactor Stuff;
@@ -1966,7 +1966,7 @@ traitors-better-swampland-mod;2066;swampland;更好的沼泽;Traitor's Better Sw
 soviet-abandoned-lab-mod;2067;soviet;苏维埃风格装饰;Soviet Era Mod(earlier Soviet Lab);SL
 ;2068;;生存必备;Survival Essentials;SuE
 charm;2069;charm;Charm;;
-village-names;2070;villagenames;村庄名字;Village Names;
+village-names;2070;villagenames;村庄名字;Village Names;VN
 advanced-rocketry-tweaker;2071;art;Advanced Rocketry Tweaker;;ART
 alternating-flux;2072;alternatingflux;交变磁通;Alternating Flux;AF
 projectextended;2073;projectextended;等价交换扩展;ProjectExtended;
@@ -1983,7 +1983,7 @@ nomadic-tents;2083;yurtmod;游牧帐篷;Nomadic Tents;NT
 zetta-industries;2084;zettaindustries;泽它重工;Zetta Industries;ZI
 kekztech;2085;;KekzTech;;
 by-the-gods;2086;btg;神迹;By The Gods;BTG
-bee-angry-est;2087;;愤怒的蜜蜂;Bee Angry-est;
+bee-angry-est;2087;beeangry-est;愤怒的蜜蜂;Bee Angry-est;
 titanium;2088;titanium;钛;Titanium;
 chemlib;2089;chemlib;Chem Lib;;
 carrots-lib;2090;carrots;胡萝卜库;Carrots Library;
@@ -2004,7 +2004,7 @@ terrafirmacraft;2104;tfc;群峦传说：次世代;TerraFirmaCraft: The Next Gene
 redstone-control;2105;rs_ctr;红石控制;Redstone Control;
 snow-real-magic;2106;snowrealmagic;雪！真实的魔法！⛄;Snow! Real Magic! ⛄;
 comforts;2107;comforts;舒适用品;Comforts;
-plasmacannon;2108;;等离子炮;PlasmaCannon;
+plasmacannon;2108;plasmacannons;等离子炮;PlasmaCannon;
 plasmaengines;2109;;等离子引擎;PlasmaEngines;
 bonny-food;2110;;Bonny Food;;
 emerging-technology-hydroponics;2111;emergingtechnology;新兴技术;Emerging Technology;
@@ -2016,12 +2016,12 @@ wesleys-roguelike-dungeons;2117;wrd;Wesley的冒险地牢;Wesley's Roguelike Dun
 xp-tome;2118;xpbook;经验之书;Xp Tome;
 varied-commodities;2119;variedcommodities;Varied Commodities;;
 tinkers-things;2120;tiths;匠魂扩增;Tinkers' Things;TITHS
-just-enough-buttons;2121;;更多的按钮;Just Enough Buttons;JEB
+just-enough-buttons;2121;justenoughbuttons;更多的按钮;Just Enough Buttons;JEB
 clock-hud;2122;clockhud;时间显示器;Clock HUD;
 tektopia;2123;tektopia;桃花源记/特克托皮亚;TekTopia;TTP
 ;2125;lolipickaxe;氪金萝莉;LoliPickaxe;
 fabric-language-kotlin;2126;fabric-language-kotlin;Fabric Language Kotlin;;
-ftb-backups;2127;ftbbackups;FTB备份;FTB Backups;
+ftb-backups-forge;2127;ftbbackups;FTB备份;FTB Backups;
 cyclopstek;2128;cyclopstek;独眼巨人;CyclopsTek;
 ;2129;;健康生活;Stay Healthy;SH
 champions;2130;champions;冠军/强敌;Champions;
@@ -2029,12 +2029,12 @@ danger-lies-ahead;2131;dangerliesahead;前路危机;Danger Lies Ahead;
 croploadcore;2132;croploadcore;CropLoadCore;;
 defiled-lands;2133;defiledlands;污秽之地;Defiled Lands;
 arcanum;2134;arcanum;奥秘;Arcanum;
-random-enchants;2135;;随机附魔;Random Enchants;
+random-enchants;2135;randomenchants;随机附魔;Random Enchants;
 much-more-spiders-v2;2136;muchmorespiders;更多种类的蜘蛛;Much More Spiders;
 compressed-items;2137;ci;Compressed Items;;
 no-tree-punching;2138;notreepunching;无树可撸;No Tree Punching;NTP
 harvest-festival-legacy;2139;harvestfestival;丰收物语移植版;Harvest Festival Legacy;HFL
-friendlymobs;2140;;友好的怪物;FriendlyMobs;
+friendlymobs;2140;friendlymobs;友好的怪物;FriendlyMobs;
 simplecore-api;2141;simplecorelib;简单前置;SimpleCore API;
 topography;2142;topography;地形;Topography;
 jei-villagers;2143;jeivillagers;JEI村民交易查看;JEI Villagers;
@@ -2060,14 +2060,14 @@ metallurgy-core;2162;MetallurgyCore;冶金核心;MetallurgyCore;
 blank-planet;2163;BlankPlanet;BlankPlanet;;
 betterachievements;2164;BetterAchievements;更好的成就;Better Achievements;
 extra-bows;2165;extrabows;更多的弓;Extra Bows;
-forgotten-relics;2166;;失落遗物学;Forgotten Relics;
+forgotten-relics;2166;ForgottenRelics;失落遗物学;Forgotten Relics;
 ore-core;2167;orecore;矿石核心;Ore Core;
 ordinary-coins;2168;ordinarycoins;普通硬币;Ordinary Coin;
 peanut-mod;2169;peanutmod;花生！;Peanuts!;
 ;2170;;蝙蝠耳;Bat's Ear;
 in-game-wiki-mod;2171;igwmod;In Game Wiki;;IGW
 betterbedrockgen;2172;;更好的基岩;Better Bedrock Gen;
-wsbim-legacy-blocks-and-items;2173;;WSBIM: Legacy Blocks and Items;;
+wsbim-legacy-blocks-and-items;2173;wsbim_legacy;WSBIM: Legacy Blocks and Items;;
 storage-items-mod;2174;sim;Storage Items Mod;;SIM
 what-should-be-in-mc-wsbim;2175;;What Should Be in MC;;WSBIM
 bluestone;2176;;Bluestone;;
@@ -2077,18 +2077,18 @@ Ic2c-Crop-Overrides;2179;;IC2经典版作物覆盖;IC2C Crop Overrides;
 ic2c-extras;2180;ic2c_extras;工业时代2经典版拓展;IC2C Extras;
 advanced-solars-classic;2181;advancedsolars;高级太阳能经典版;Advanced Solars Classic;
 power-chisels;2182;;能量凿子;Power Chisels;
-ic2c-custom-soils;2183;;IC2C Custom Soils;;
+ic2c-custom-soils;2183;ic2c_custom_soils;IC2C Custom Soils;;
 homing-exp-orbs;2184;homingexporbs;经验球归航;Homing Exp Orbs;
 enchantmentglint;2185;enchantmentglint;自定义附魔光效;Jabelar's Truly Magical Enchantment Glints;
-floricraft;2186;;花卉工艺;Floricraft;FC
+floricraft;2186;floricraft;花卉工艺;Floricraft;FC
 weisscore;2187;WeissCore;WeissCore;;
 glibys-physics;2188;glibysphysics;Gliby的物理;Gliby's Physics;
 electro-magic-tools-ic2-classic;2189;;电子神秘工具;Electro-Thaumic Tools - IC2 Classic;
 forceasciifont;2190;forceasciifont;强制ASCII字体;ForceASCIIFont;
 skewers;2191;;烤串;Skewers;
-get-in-the-bucket-mod;2192;getinthebucketmod;进入水桶;Get In The Bucket Mod;
+get-in-the-bucket-mod;2192;getinthebucketmod;进入水桶;Get In The Bucket Mod;GITBM
 fertilization;2193;fertilization;施肥;Fertilization;
-additional-banners;2194;;更多旗帜;Additional Banners;
+additional-banners;2194;additionalbanners;更多旗帜;Additional Banners;
 dropt;2195;dropt;Dropt;;
 the-elven-forest;2196;the_elven_forest;精灵森林;The Elven Forest​;EF
 the-beneath;2197;beneath;深渊世界;The Beneath;
@@ -2097,20 +2097,20 @@ not-enough-characters;2198;nechar;NEI 拼音搜索;Not Enough Characters;
 mine-addons-2;2200;mineaddons;Mine Addons 2;;
 terrafirmacraftplus;2201;terrafirmacraftplus;群峦传说 +;Terrafirmacraft +;TFC+
 quick-consume-2;2202;;快速摄入2;Quick Consume 2;
-mctitle;2203;;MCTitle;;
-mgui;2204;mgui;mutil / mGui;;
+mctitle;2203;MCTitle;MCTitle;;
+mgui;2204;mutil,mgui;mutil / mGui;;
 sublib;2205;subcommonlib;SubLib;;
 dense-ores;2206;denseores;致密矿石;Dense Ores;
 archisections;2207;ArchiSections;ArchiSections;;
 cavecontrol;2208;CaveControl;洞穴控制;Cave Control;
 expandedredstone;2209;ExpandedRedstone;红石扩展;Expanded Redstone;
-legacycraft;2210;;传统工艺;LegacyCraft;
-geostrata;2211;;GeoStrata;;
+legacycraft;2210;LegacyCraft;传统工艺;LegacyCraft;
+geostrata;2211;GeoStrata;GeoStrata;;
 territoryzone;2212;TerritoryZone;TerritoryZone;;
-loottweaks;2213;;LootTweaks;;
-critterpet;2214;;CritterPet;;
+loottweaks;2213;LootTweaks;LootTweaks;;
+critterpet;2214;CritterPet;CritterPet;;
 condensedores;2215;CondensedOres;Condensed Ores;;
-treeclimbing;2216;;Tree Climbing;;
+treeclimbing;2216;TreeClimbing;Tree Climbing;;
 more-electric-tools;2217;mets;更多电力装置;More Electric Tools;METS
 wireless-fluid-terminal;2218;wft;无线流体终端;AE2 Wireless Fluid Terminal;WFT
 wireless-interface-terminal;2219;wit;无线接口终端;AE2 Wireless Interface Terminal;WIT
@@ -2128,11 +2128,11 @@ tweakeroo;2230;tweakeroo;Tweakeroo;;
 integrated-rest;2231;integratedrest;Integrated REST;;
 citadel;2232;citadel;Citadel;;
 screenshot-browser;2233;;内置截图管理器;Screenshot Browser;
-;2235;;R键整理复兴版;Inventory Tweaks Reborn;
+;2235;invtweaks;R键整理复兴版;Inventory Tweaks Reborn;
 curio-of-undying;2236;curioofundying,charmofundying;不死图腾插槽;Curio of Undying/Trinket of Undying/Charm of Undying;
 explorercraft-worldexpansion;2237;explorercraft;探险者;Explorercraft;
 enigmatic-legacy;2239;enigmaticlegacy;神秘遗物;Enigmatic Legacy;
-end-reborn;2240;endreborn;末地：重生;End: Reborn;ER
+end-reborn;2240;endreborn;末地：重生;Endorium;ER
 ;2241;eternalfrost;永恒的冰霜;Eternal Frost;EF
 ezstorage-2;2242;;EZ存储2;EZStorage 2;EZ2
 more-chickens;2243;morechickens;更多鸡扩展;More Chickens;
@@ -2151,9 +2151,9 @@ tfc-metric;2255;tfcmetric;公制重量转换;TFC Metric;
 ;2256;;TerraMisc;;
 ;2257;lwstfc;群峦水袋;Leather Water Sac for TFC;
 ;2258;;群峦贸易;Merchants Addon for TFC;
-tfc-additions;2259;;群峦附加;TFC-Additions;
+tfc-additions;2259;tfcadditions;群峦附加;TFC-Additions;
 raolcraft-w;2260;raolcraft;RaolCraft Ω;;
-litematica-forge;2261;litematica;投影;Litematica;
+litematica;2261;litematica;投影;Litematica;
 telepastries;2262;telepastries;传送蛋糕;TelePastries;
 heroesexpansion;2263;heroesexpansion;超级英雄拓展;HeroesExpansion;HE
 attributefix;2264;attributefix;属性修复;AttributeFix;
@@ -2181,17 +2181,17 @@ jaopcasingularities;2286;jaopcasingularities;JAOPCA的奇点;JAOPCA Singularitie
 labymod;2288;labymod;LabyMod;;
 ;2289;mcty;MC牌汤圆;Tangyuan In MineCraft;MCTY
 guidebook;2291;gbook;Guidebook;;
-lithium-forge;2292;lithium;锂;Lithium;
+lithium;2292;lithium;锂;Lithium;
 left-2-mine;2293;;求生之路;Left 2 Mine;L2M
 worldeditcui-forge-edition-2;2294;worldeditcuife2;WorldEditCUI Forge Edition 2;;
 world-book;2295;worldbook;World Book;;
 uppers;2296;uppers;倒置漏斗;Uppers;
 spartan-weaponry;2297;spartanweaponry;斯巴达的武器;Spartan Weaponry;
-malilib;2298;malilib;MaLiLib;;
+malilib;2298;malilib;Masa's Litemod Library;;MaLiLib
 infraredstone;2299;infraredstone;InfraRedstone;;
 incorporeal;2300;incorporeal;幻想多媒体;Incorporeal;
 amun-ra;2301;GalacticraftAmunRa;Amun-Ra;;
-;2302;;虚拟歌姬;Vocaloid Mod;
+;2302;VocaloidMod;虚拟歌姬;Vocaloid Mod;
 mysterious-mountain-lib;2303;mmlib,mysterious_mountain_lib;妖怪之山通用库;MysteriousMountainLib;MMLib
 loottweaker;2304;loottweaker;LootTweaker;;
 rediscovered;2305;rediscovered;特性重现;Rediscovered;
@@ -2216,7 +2216,7 @@ more-flowers;2324;moreflowers;更多功能花;More Flowers;
 buzzier-bees;2326;buzzier_bees;Buzzier Bees;;
 ;2327;plne;原版一键整理;Vanilla Mod Neat;VMN
 lollipop;2328;lollipop;棒棒糖;Lollipop;
-enemyz;2329;;敌意显示;Enemyz;
+enemyz;2329;enemyz;敌意显示;Enemyz;
 thaumic-restoration;2330;thaumicrestoration;神秘复辟;Thaumic Restoration;
 ;2331;vimi;连锁矿工数据包;Vein Miner Datapack;
 ;2332;;快速落叶（伪）;Fast Leaf Decay;
@@ -2235,7 +2235,7 @@ fishs-undead-rising;2345;mod_lavacow;Fish的不死崛起/Fish的亡灵崛起;Fis
 cloth-config;2346;cloth_config;Cloth Config API;;
 just-map;2347;justmap;Just Map;;
 too-realistic-inventory;2348;noinv;真实背包;Realistic Inventory;
-mob-farm;2349;mobfarm;生物农场;Mob farm;
+mob-farm;2349;mobfarm;生物农场;Mob Farm;
 acceleratorcraft;2350;acceleratorcraft;加速器工艺;AcceleratorCraft;AC
 minecraft-spongebob-squarepants-mod-for-the-1-7-10;2351;SpongebobModAddONTwo;Minecraft Spongebob Mod 2018 New;;SBM
 utility-worlds;2352;utilityworlds;实用世界;Utility Worlds;UW
@@ -2246,7 +2246,7 @@ loot-bag-mod;2356;lootbagmod;战利品包;Loot Bag Mod;
 ;2357;customnpcsfix;自定义NPC补丁;CustomNPCsFix;NPCFix
 minecraft-dungeons-mod;2358;duneons;我的世界地下城;Minecraft Dungeons Mod;MCD
 ;2359;musicsetting;音乐控制;MusicSetting;
-seasonal-bees;2360;;季节性蜜蜂;Seasonal Bees;
+seasonal-bees;2360;seasonal_bees;季节性蜜蜂;Seasonal Bees;
 carpet;2361;carpet;地毯;Carpet;
 handmadegunsmodex;2362;handmadeguns;自定义枪械;HandmadeGuns;HMG
 equivalent-additions;2363;equivadditions;等价拓展;Equivalent Additions;
@@ -2286,7 +2286,7 @@ magic-seeds-for-electroblobs-wizardry;2396;;巫术学魔法种子;Magic seeds fo
 extra-alchemy;2397;extraalchemy;扩展炼药;Extra Alchemy;
 beyond-the-veil;2398;beyondtheveil;帷幕彼端;Beyond The Veil;BTV
 maple-syrup;2399;maplesyrup;枫糖;Maple Syrup;
-blood-particles;2400;;血液粒子效果;Blood Particles;
+blood-particles;2400;blood_particles;血液粒子效果;Blood Particles;
 nyx;2401;nyx;Nyx;;
 lieutenant;2402;lieutenant;Lieutenant;;
 matthews-difficulty-mod;2403;difficultymod;Matthew's Difficulty Mod;;
@@ -2299,11 +2299,11 @@ linear;2409;linear;线性放置;Linear;
 immersive-portals-for-forge;2410;immersive_portals;沉浸式传送门;Immersive Portals;ImmPtl
 universalbestiary;2411;universalbestiary;Universal Bestiary;;
 autumnity;2412;autumnity;秋原;Autumnity;
-worldgeneration-profiler;2413;;Worldgeneration Profiler;;
+worldgeneration-profiler;2413;worldgenerationprofiler,Worldgeneration Profiler Plugin;Worldgeneration Profiler;;
 chunk-in-a-globe;2414;globedimension;球内区块;Chunk In A Globe;
 dragon-mounts-legacy;2415;dragonmounts;龙骑士重置版;Dragon Mounts: Legacy;DML
 fruit-trees;2416;fruittrees,fruitfulfun;妙趣果园 🍊;Fruitful Fun 🍊;
-journey-into-the-light-mod;2417;journey;光明之旅·神之本质;Journey Into the Light · Essence of the Gods;JITL
+journey-into-the-light-mod;2417;journey,jitl;光明之旅·神之本质;Journey Into the Light · Essence of the Gods;JITL
 kitchen-mod;2418;kitchen;厨房;The Kitchen Mod;
 more-dungeons;2419;;更多地牢;More Dungeons;
 voyage;2420;voyage;Voyage;;
@@ -2318,13 +2318,13 @@ retrobees;2428;retrobees;RetroBees;;
 beebetteratbees;2429;;育蜂指南;BeeBetterAtBees;
 inverted-enchantments;2430;ivrench;负魔书;InvertedEnchantments;
 general-laymans-aesthetic-spying-screen-glass;2431;generallaymansaestheticspyingscreen;General Laymans Aesthetic Spying Screen Glass;;GLASS
-diy_title;2432;;自定义名称前后缀;diy_title;PPM
+diy_title;2432;diytitle;自定义名称前后缀;diy_title;PPM
 tooltweaks;2433;tooltweaks;禁用原版工具;ToolTweaks;
 atop;2434;ATOP,atop;超多生物群系护甲;Armor for Biomes O' Plenty;ATOP
 tinkers-forging;2435;tinkersforging;工匠锻造;Tinker's Forging;
 gravity-gun;2436;gravitygun;重力枪;Gravity Gun;
-mekanism-additions;2437;mekanismadditions;通用机械附加;Mekanism Addition;MekA
-signpicture;2438;;告示牌图片;Sign Picture;
+mekanism-additions;2437;mekanismadditions;通用机械附加;Mekanism Additions;MekA
+signpicture;2438;signpic;告示牌图片;Sign Picture;
 vampirism-integrations;2439;vampirism_integrations;吸血鬼联动;Vampirism Integrations;
 gottschcore;2440;gottschcore;GottschCore;;
 not-enough-crashes;2441;notenoughcrashes;崩溃优化;Not Enough Crashes;NEC
@@ -2333,37 +2333,37 @@ tinkers-jei;2443;tinkersjei;Tinker's JEI;;
 better-questing-quest-book;2445;questbook;更好的任务-任务书;Better Questing - Quest Book;
 engineers-doors;2446;engineersdoors;工程师的门;Engineer's Doors;
 tps-generator;2447;tpsgenerator;TPS发电机;TPS Generator;
-better-drowning;2448;;更好的溺水;Better Drowning;
+better-drowning;2448;betterdrowning;更好的溺水;Better Drowning;
 bibliotheca;2449;bibliotheca;Bibliotheca;;
 kubejs;2450;kubejs;KubeJS;;KJS
 tickcentral;2451;tickcentral;TickCentral;;
-lowocalizatiwn;2452;;lOwOcalizatiωn;;
+lowocalizatiwn;2452;lowocalization;lOwOcalizatiωn;;
 redlib;2453;redlib;RedLib;;
 modern-ui;2454;modernui;现代化 UI;Modern UI;MUI
 auto-config-updated-api;2455;autoconfig1u;Auto Config Updated API;;
 medieval-madness;2456;the_medieval_times;中世纪的疯狂;Medieval Madness;
 caelus;2458;caelus;Caelus API;;
-xeocore;2459;;XeoCore;;
+xeocore;2459;xeocore;XeoCore;;
 wtbw_lib;2460;wtbw_lib;WTBW Lib;;
 dev-world-fabric;2461;devworld;Dev World;;
 threecore;2462;threecore;ThreeCore;;3C
-moddirector;2463;;ModDirector;;
+moddirector;2463;moddirector;ModDirector;;
 function-api;2464;functionapi;Function API;;
 targetingapi;2465;targeting_api;TargetingAPI;;
 re-targetingapi;2466;re-targeting_api;Re-TargetingAPI;;
-dominionlib;2468;;DominionLib;;
+dominionlib;2468;mclib;DominionLib;;
 ;2469;salt_fish_craft;咸鱼工艺;Salt Fish Craft;SFC
 endergetic;2470;endergeticexpansion,endergetic;末地拓展;The Endergetic Expansion;
 swamp-expansion;2471;swampexpansion;Swamp Expansion;;
-galactictweaks;2472;gctweaks;GalacticTweaks;;GCT
+galactictweaks;2472;galactictweaks;GalacticTweaks;;GCT
 dungeon-tactics;2473;dungeontactics;地牢战术;Dungeon Tactics;
 villagers-nose;2474;VillagersNose;村民的鼻子;Villager's Nose;
 dungeons2;2475;dungeons2;自定义地牢2;Dungeons2;
-lang_tool;2476;;加长工具;lang_tool;LT
+lang_tool;2476;lengthen;加长工具;lang_tool;LT
 ;2477;;Plans API;;
 ;2478;;Labyrinths API;;
 emojiful;2479;emojiful;Emojiful;;
-item-compatibility;2480;;Item Compatibility;;
+item-compatibility;2480;itemcompat;Item Compatibility;;
 aether-lost-content;2481;lost_aether;天境: 遗失之物;Aether: Lost Content;
 gunpowderlib;2482;gunpowderlib;GunpowderLib;;
 nuclearcraft-overhauled;2483;nuclearcraft;核电工艺：重制版;NuclearCraft: Overhauled;NCO
@@ -2376,8 +2376,8 @@ beesourceful;2490;beesourceful;BeeSourceful;;
 middle-earth-industry;2491;mei;中洲工业;Middle-Earth Industry;MEI
 thut-wearables;2492;thut_wearables;Thut Wearables;;
 after-the-drizzle;2493;afterthedrizzle;细雨田园;After the Drizzle;AtD
-cmdcam;2494;cmdcam;CMD指令摄影机;CMDCam;
-climate-control-geographicraft;2495;geographicraft;气候控制/地理世界;Climate Control/Geographicraft;CC/GC
+cmdcam;2494;cmdcam;CMD 指令摄影机;CMDCam;
+climate-control-geographicraft;2495;geographicraft;气候控制 / 地理世界;Climate Control / Geographicraft;CC/GC
 cosmetic-armor-reworked;2497;cosmeticarmorreworked;时装盔甲重置版;Cosmetic Armor Reworked;CAR
 ;2498;moegadd;月蛋拓展;MoegAddon;
 efab;2499;efab;EFab;;
@@ -2388,7 +2388,7 @@ gkolivers-super-tic;2503;gk_super_tic;Gkoliver's Super TiC;;
 ;2504;;Loot Table Randomizer;;
 songs-of-war-mod;2505;sow;战争之歌;Songs of War;SoW
 fluidict;2506;fluidict;FluiDict;;
-squidcraft;2507;squidcraft;鱿鱼工艺;SquidCraft;SC
+squidcraft;2507;squidcraft;鱿鱼工艺;SquidCraft;
 clothesline;2508;clothesline;晾衣绳;ClothesLine;
 siege;2509;siege;Siege;;
 fermion-core;2510;fermion;Fermion Lib;;
@@ -2398,11 +2398,11 @@ nuclearcraft-helper;2513;nuclearcraft_helper;核电助手;NuclearCraft Helper;
 the-hive-more-bee-content;2514;thehive;The Hive! More Bee Content;;
 tinkersmiddleearth;2515;lotrtc;中洲匠魂;Tinker's Middleearth;
 inventory-pause;2516;;Inventory Pause;;
-snowy-leaves;2517;;霜花叶;Snowy Leaves;
+snowy-leaves;2517;snowy_leaves;霜花叶;Snowy Leaves;
 materialis;2518;materialis;Materialis;;
 tesseract;2519;tesseract;超立方体;Tesseract;
 carrier-bees;2520;carrierbees;物流蜜蜂;Carrier Bees;
-tinkers-reforged;2521;tinkers_reforged;工匠再锻;Tinkers' Reforged;
+tinkers-reforged;2521;tinkers_reforged;工匠再锻;Tinkers Reforged;
 mystical-world;2522;mysticalworld;魔幻世界;Mystical World;
 recipes-for-all;2523;rfa;配方书全解锁;Recipes for All;RFA
 gregicality;2524;gtadditions;Gregicality Legacy;;GCY
@@ -2421,7 +2421,7 @@ thaumcraft;2536;;神秘时代2;Thaumcraft 2;TC2
 gregtech-chill-edition;2537;gregtech;格雷科技轻松版;GregTech: Chill Edition;
 custom-player-model-cpm;2538;custommodel;自定义玩家模型;Custom Player Model;CPM
 roughly-enough-resources;2539;roughlyenoughresources;Roughly Enough Resources;;RER
-so-many-enchantments;2540;somanyenchantments;更多附魔;So Many Enchantments;
+so-many-enchantments;2540;somanyenchantments;更多附魔;So Many Enchantments;SME
 sisser;2542;sisser;Sisser;;
 hxcenchants;2543;HxCEnchants;多样化附魔;HxCEnchants;
 better-dropped-items;2544;betterdroppeditems;更好的掉落物;Better Dropped Items;
@@ -2447,7 +2447,7 @@ fission-based-neutron-collector;2563;fbnc;裂变能中子素收集器;Fission Ba
 trinity;2564;trinity;三位一体;Trinity;
 macaws-windows;2565;mcwwindows;Macaw 的窗户;Macaw's Windows;
 music-player;2566;musicplayer;音乐播放器;Music Player;
-csokicraftutil;2567;;CsokiCraftUtil;;
+csokicraftutil;2567;CsokiCraftUtil,csokicraftutil;CsokiCraftUtil;;
 large-enchants;2568;gud_largeenchants;Large Enchants;;
 angrysun;2569;angrysun;炙热太阳;AngrySun;
 its-not-long-enough;2570;itsnotlongenough;与现实相同的昼夜交替;It's Not Long Enough;INLE
@@ -2457,7 +2457,7 @@ macaws-furniture;2573;mcwfurnitures;Macaw的家具;Macaw's Furniture;
 macaws-doors;2574;mcwdoors;Macaw的门;Macaw's Doors;
 blueprint;2575;abnormals_core,blueprint;Blueprint / Abnormals Core;;
 geyser-mod;2576;geysermod;Geyser Mod;;
-not-enough-pets;2577;notenoughcats;更多宠物;Not Enough Pets;
+not-enough-pets;2577;notenoughcats;更多宠物;Not Enough Pets;NEP
 potionextension;2578;PotionExtension;PotionExtention;;
 torchslabs-mod;2579;torchslabmod;更好的火把放置;Torch Slabs Mod;
 routerrebornlib;2580;routerrebornlib;RouterReborn Lib;;
@@ -2471,7 +2471,7 @@ ic2magma;2587;ic2magma;IC2Magma;;
 iridium-source;2588;iridiumsource;铱矿产;Iridium Source;
 frogcraft-rebirth;2589;frogcraftrebirth;青蛙化工:重生;FrogCraft: Rebirth;FC
 coaxium-mod-1-12-2-ic2-addon;2590;fm;科亚烯;Coaxium Mod;
-energy-control;2591;energycontrol;能源控制;Energy Control;
+energy-control;2591;energycontrol;能源控制;Energy Control;EC
 gulliver-reborn;2592;gulliverreborn;Gulliver Reborn;;
 ;2593;;可驯服的怪物;Tamed mobs;
 rationcraft;2594;rationcraft;Rationcraft;;
@@ -2480,12 +2480,12 @@ ender-mail;2596;endermail;末影邮递;Ender Mail;
 more-overlays;2597;moreoverlays;More Overlays;;
 stefinus-3d-guns-mod;2598;stefinusguns;3D枪械;New Stefinus Guns;S3DGM
 ;2599;movement;运动渲染;Movement;
-moderncraft-core;2600;;ModernCraft|Core;;
+moderncraft-core;2600;moderncraftcore,moderncraft-core;ModernCraft|Core;;
 lang_magic;2601;;言灵;lang_magic;YL
 noexpensive;2602;noexpensive;不昂贵;NoExpensive;NE
 rough-mobs-revamped;2603;;粗暴的怪物重置版;Rough Mobs Revamped;RMR
 fullbright;2604;fullbright;充满光明;Fullbright;
-backpacks;2605;backpacks16840;背包！;backpacks!;
+backpacks;2605;backpacks16840;背包！;Backpacks!;
 ;2606;slashfortifier;拔刀强化器;Slash Fortifier Plus;
 living-enchantment;2607;livingenchantment;生命附魔;Living Enchantment;
 karat-garden;2608;karatgarden;克拉的花园;Karat Garden;
@@ -2501,7 +2501,7 @@ more-gems-fabric;2618;more_gems;更多宝石;More Gems;
 minewars;2619;minewars;MineWars;;
 gregicadditionscompatibility;2620;;Gregic Additions Compatibility;;
 combined-potions;2621;compot;组合药水;Combined Potions;
-plusticminusbad;2622;;xXx_MoreToolMats_xXx;;
+plusticminusbad;2622;plustic;xXx_MoreToolMats_xXx;;
 baileys-dailies;2623;dailies;Bailey's Dailies;;
 joshuas-christmas-mod;2624;joshxmas;Joshua's Christmas Mod;;
 enderio-fluxified;2625;enderiofluxified;EnderIO Fluxified;;
@@ -2515,7 +2515,7 @@ quirky-generators;2632;quirkygenerators;Quirky Generators;;
 megaloot;2633;megaloot;超级战利品;MegaLoot;
 ;2634;Kradxns Xray;Kradxn's X-Ray;;X-Ray
 mad-villagers;2635;mad_villagers;疯狂的村民;Mad Villagers;
-logical-drops;2636;;逻辑工艺;Logical Craft;LC
+logical-drops;2636;logicaldrops;逻辑工艺;Logical Craft / Logical Drops;LC
 drone-craft;2637;dronecraft;Dronecraft;;
 water-source;2638;watersource;水源;Water Source;WS
 hungteens-plants-vs-zombies-mod;2640;pvz;HungTeen的植物大战僵尸;HungTeen's Plants vs Zombies Mod;HTPVZ
@@ -2523,7 +2523,7 @@ pams-desertcraft;2641;desertcraft;潘马斯沙漠工艺;Pam's DesertCraft;
 pams-bonecraft;2642;bonecraft;潘马斯骨头工艺;Pam's BoneCraft;
 thermal-singularities;2643;thermsingul;热力奇点;Thermal Singularities;TS
 minejurassic;2644;minejurassic;MineJurassic;;MJ
-terraria-craft;2645;terraria;泰拉瑞亚世界;Terraria Craft;TC
+terraria-craft;2645;terraria;泰拉瑞亚世界;TerrariaCraft 🌳;TC
 colytra;2646;colytra;鞘翅胸甲;Colytra;
 insects;2647;insects;昆虫;Insects;
 sound-reloader;2648;soundreloader;声音重载;Sound Reloader;
@@ -2531,15 +2531,15 @@ tool-belt;2649;toolbelt;工具皮带;Tool Belt;
 argentina-food-mod;2650;argentina_food_mod;阿根廷的食物;Argentina Food Mod;
 pet-names;2651;petnames;宠物名字;Pet Names;
 collective;2652;collective;Collective;;
-giselbaers-durability-viewer;2653;durabilityviewer;耐久信息显示;Durability Viewer;
+giselbaers-durability-viewer;2653;durabilityviewer;耐久指示器;Durability Viewer;
 more-cookies;2654;morecookies;更多饼干;More Cookies;
 apple-carrot;2655;applecarrot;苹果胡萝卜;Apple Carrot;
 eat-yo-veg;2656;eatveg;Eat Yo' Veg!;;
 bountiful;2657;bountiful;赏金;Bountiful;
-betterenchantment;2658;;更好的附魔;BetterEnchantment;
+betterenchantment;2658;betterenchantments;更好的附魔;BetterEnchantment;
 purified-flesh-mod;2659;purifiedfleshmod;纯净的腐肉;Purified Flesh Mod;
 gotminecraftmod;2660;got;权力的游戏;Game of Thrones Mod;GOT
-nosleep;2661;;禁止睡觉;No Sleep;
+nosleep;2661;nosleep;禁止睡觉;No Sleep;
 minersadvantage;2662;minersadvantage;矿工的优势;MinersAdvantage;
 ;2663;mobbottle;生物展示瓶;MobBottle;
 simple-backpack-fabric;2664;simple_backpack;简单背包;Simple Backpack;
@@ -2549,7 +2549,7 @@ more-discs-mod;2668;more_music_disc;更多唱片;More discs mod;
 edible-honeycombs;2669;;Edible Honeycombs;;
 emerald-and-ruby;2670;emeraldandruby;Emerald And Ruby;;
 craftable-nametag;2671;craftable_nametag;可合成的命名牌;Craftable Nametag;
-dyeable-flower-pots;2672;dyeable_flower_pots;染色花盆;Dyeable Flower Pots;
+dyeable-flower-pots;2672;dyeable_flower_pots,more_flower_pots;染色花盆;More Flower Pots / Dyeable Flower Pots;
 graffiti;2673;graffiti;涂鸦;Graffiti;
 bunny-boots;2674;bunnyboots;Bunny Boots;;
 backported-flora;2675;backportedflora;Backported Flora;;
@@ -2559,9 +2559,9 @@ more-berry-uses;2678;sweetberryuses;更多浆果用途;More Berry Uses;
 elemental-blades;2679;elemental_blades;元素之刃;Elemental Blades / Elementium;
 beyond-earth;2680;boss_tools,beyond_earth;飞越地球;Beyond Earth/Space-BossTools;
 simple-planes;2681;simpleplanes;简单飞机;Simple Planes;
-world-tooltips;2682;worldtooltips;显示掉落物信息;World Tooltips;
+world-tooltips;2682;worldtooltips;掉落物信息显示;World Tooltips;
 extra-arcane-knowledge-electroblobs-wizardry;2683;ghostspells;额外巫术知识;Extra Arcane Knowledge;
-bacterium;2684;bacterium;细菌重置版;Bacterium;
+bacteriums;2684;bacterium;细菌重置版;Bacterium;
 pillagers;2685;pillagers;掠夺者;Pillagers;
 guard-villagers;2686;guardvillagers;警卫村民;Guard Villagers;
 simple-machinery;2687;simplemachinery;简单机器;Simple Machinery;
@@ -2583,7 +2583,7 @@ dynamic-surroundings-soundcontrol;2701;sndctrl;动态环境：音效控制;Dynam
 chop-down-updated;2703;chopdownupdated;Chop Down Updated;;
 aegis-weapon-system-mod;2704;AegisSystemMod;宙斯盾作战系统-战舰模组;Aegis Weapon System -Warship's Mod;ASM
 advanced-hook-launchers;2705;adhooks;高级钩爪发射器;Advanced Hook Launchers;
-vampire-magic;2706;;Vampire Magic;;
+vampire-magic;2706;vampiremagic;Vampire Magic;;
 fantasyunderworld;2707;fantasyunderworld;江湖行;fantasyunderworld;
 stacc;2708;stacc;Stacc;;
 a-riot-of-colour-craft;2709;shui;五彩斑斓工艺;a riot of colour craft;
@@ -2613,7 +2613,7 @@ screenshot-to-clipboard;2733;screenshotclipboard;截图到剪贴板;Screenshot t
 hide-armor;2734;hidearmor;隐藏盔甲;Hide Armor;
 hunterillager;2735;hunters_return,hunterillager;Hunter's Return;;
 ;2736;;僵尸启示录：语音聊天;DecimationVoiceChat;
-pocket-apocalypse-mod;2737;;便携式天灾;Pocket Apocalypse mod;
+pocket-apocalypse-mod;2737;pocalypse;便携式天灾;Pocket Apocalypse Mod;
 compass;2738;compass;指南针;compass;
 tinkers-evolution;2739;tconevo;匠魂进化;Tinkers' Evolution;TConEvo
 tinkers-exporter;2740;tic_exporter;匠魂数据导出器;Tinkers Exporter;
@@ -2662,7 +2662,7 @@ stepup;2784;stepup;平滑自动上坡;StepUp;SU
 sodium;2785;sodium;钠;Sodium;
 ;2786;sv;月光树林;Moon Woods;
 netherlicious;2787;netherlicious;Netherlicious;;
-yungs-better-mineshafts-forge;2788;bettermineshafts;YUNG的矿井优化;YUNG's Better Mineshafts;
+yungs-better-mineshafts-forge;2788;bettermineshafts;YUNG 的矿井优化;YUNG's Better Mineshafts;
 terrible-chest;2789;terrible_chest;可怕的箱子/可怖箱子;Terrible Chest;
 spartan-shields;2790;spartanshields;斯巴达之盾;Spartan Shields;
 silent-gear;2791;silentgear;寂静装备;Silent Gear;SGear
@@ -2694,12 +2694,12 @@ ama-damage-indicator;2815;damage_indicator;Ama's Damage Indicator;;
 magic-circle;2817;magiccircle;阵法;Magic Circle;
 crash-utilities;2818;crashutilities;Crash Utilities;;CU
 eldritch-mobs;2819;eldritch_mobs;Eldritch Mobs;;
-farmers-delight;2820;farmersdelight;农夫乐事;Farmer's Delight;
+farmers-delight;2820;farmersdelight;农夫乐事;Farmer's Delight;FD
 artifacts;2821;artifacts;奇异饰品;Artifacts;
-dynamictreestfc;2823;dynamictreestfc;动态的树：群峦传说附属;Dynamic Trees-TFC;
-lucky-block-avaritia;2824;;无尽幸运方块;Lucky block avaritia;
+dynamictreestfc;2823;dynamictreestfc,dttfc;动态的树：群峦传说附属;Dynamic Trees-TFC;
+lucky-block-avaritia;2824;;无尽幸运方块;Avaritia Lucky Block;
 dynamic-trees-the-twilight-forest;2825;dynamictreesttf;动态的树：暮色森林附属;Dynamic Trees-The Twilight Forest;
-drp-global-datapack;2826;drpglobaldatapack,globaldataandresourcepacks;全局数据包;DRP - Global Data Pack;
+drp-global-datapack;2826;drpglobaldatapack,globaldataandresourcepacks,globalpacks;全局数据包;Global Data & Resourcepacks;
 mob-farm-nerfer;2827;mob_farm_nerfer;Mob Farm Nerfer;;
 blood-in-the-water;2828;;Blood in the Water;;
 bio-technik;2829;biotechnik;Bio Technik;;
@@ -2725,17 +2725,17 @@ camera-mod;2848;camera;照相机;Camera Mod;
 heartdrops;2849;heartdrops;生命汲取;Heart Drops;
 observerlib;2850;observerlib;ObserverLib;;
 zen-summoning;2851;zensummoning;Zen Summoning;;
-campanion;2852;campanion;野营物品;Campanion;
+campanion-forge;2852;campanion;野营物品;Campanion;
 wolves-with-armor;2853;wolveswitharmor;狼铠;Wolves With Armor;
-get-exp-for-everything;2854;;万物皆可获得经验;Get exp for everything;
-jei-enchantment-info;2855;jeienchantmentinfo;JEI附魔信息;JEI Enchantment Info;
+get-exp-for-everything;2854;getexpforeverything;万物皆可获得经验;Get exp for everything;
+jei-enchantment-info;2855;jeienchantmentinfo;JEI 附魔信息;JEI Enchantment Info;
 project-red-core;2856;projectred-core;红石计划：核心;Project Red - Core;
 project-red-fabrication;2857;projectred-fabrication;红石计划：制作;Project Red - Fabrication;
 project-red-integration;2858;projectred-integration,projectred-transmission;红石计划：集成;Project Red - Integration;
 project-red-illumination;2859;projectred-illumination;红石计划：照明;Project Red - Illumination;
 project-red-world;2860;projectred-exploration;红石计划：探索;Project Red - Exploration;
 project-red-compat;2861;;红石计划：兼容性;Project Red - Compat;
-canvas-renderer;2862;canvas;Canvas渲染器;Canvas Renderer;
+canvas-renderer;2862;canvas;Canvas 渲染器;Canvas Renderer;
 coolfood;2864;kur;冷饮;CoolFood;
 infinitevillagertrading;2865;infinitevillagertrading;无限村民交易;InfiniteVillagerTrading;
 infinite-trading;2866;infinitetrading,infinitetrading-fabric;无限交易;Infinite Trading;
@@ -2747,7 +2747,7 @@ allure;2871;;诱惑;Allure;
 ;2872;honkaiimpact;崩坏;Honkai Impact;
 glibys-voice-chat-reloaded;2873;gvc;Gliby的语音聊天重置版;Gliby's Voice Chat Reloaded;
 greater-eye-of-ender-fabric;2874;greater_eye;高级末影之眼;Greater Eye of Ender;
-project-red-mechanical;2875;projectred-expansion,projectred-relocation,projectred-transportation;红石计划：机械;Project Red - Mechanical;
+project-red-mechanical;2875;projectred-expansion,projectred-relocation,projectred-transportation;红石计划：机械;Project Red - Expansion / Project Red - Mechanical;
 neon-craft-mod;2876;neoncraft;霓虹灯艺;Neon Craft Mod;NC
 arrows-ignite-tnt;2877;;Arrows Ignite TNT;;
 enderite-mod-for-forge;2878;enderitemod;末影合金;Enderite Mod;
@@ -2761,17 +2761,17 @@ lingering-loot;2885;lingeringloot;Lingering Loot;;
 ugraded-netherite;2886;upgradednetherite;下界合金增强;Upgraded Netherite;
 ;2887;dreamer;空想家;Dreamer;DM
 inventory-profiles;2888;inventoryprofiles;一键背包整理;Inventory Profiles;
-slimevoid-library;2889;;Slimevoid Library;;
+slimevoid-library;2889;SlimevoidLib;Slimevoid Library;;
 kotlin-for-forge;2890;kotlinforforge;Kotlin for Forge;;KFF
 fabric-zero;2891;;Fabric Zero;;
 towers-of-the-wild;2892;;旷野之塔;Towers Of The Wild;
 sausagecore;2893;sausage_core;香肠核心;SausageCore;
-shadowlands;2894;;暗影之地;Shadowlands;
+shadowlands;2894;shadowlands;暗影之地;Shadowlands;
 polymorph;2895;polymorph;多态合成;Polymorph;
 scalable-cats-force;2896;scala-library-object;Scalable Cat's Force;;
 otyacraft-engine;2897;;Otyacraft Engine;;
 omega-craft-mod;2898;omegacraft;Omega Craft Mod;;
-custom-ports;2899;;自定义局域网端口;Custom LAN Ports;
+custom-ports;2899;lan;自定义局域网端口;Custom LAN Ports;
 decorative-blocks;2900;decorative_blocks;装饰方块;Decorative Blocks;
 music-layer;2901;musiclayer;Music Layer;;
 colored-lux;2902;lux;彩色照明;Colored Lux;Lux
@@ -2786,7 +2786,7 @@ base-metals;2910;basemetals;基础金属;Base Metals;
 mmdlib;2912;mmdlib;MMDLib;;
 just-poop-mod;2913;poop,pm;屎!;Poop Mod!;
 costumes;2914;costumes;服装;Costumes;
-eyemod-a-phone-mod;2915;eyemod;EyeMod;;
+eyemod-phone;2915;eyemod;EyeMod;;
 upgrade-aquatic;2916;upgrade_aquatic;碧海新生;Upgrade Aquatic;
 tfc-ambiental;2917;tfcambiental;TFC Ambiental;;
 macaws-trapdoors;2918;mcwtrpdoors;Macaw的活板门;Macaw's Trapdoors;
@@ -2802,9 +2802,9 @@ heaven-earth-ring;2928;heavenearthring;乾坤戒指;Heaven Earth Ring;HER
 ;2929;hnkinvention;奇妙发明;Wonderful Invention;
 pams-harvestcraft-2-food-extended;2930;pamhc2foodextended;潘马斯农场2 - 食物拓展;Pam's HarvestCraft 2 - Food Extended;PHC2FE
 pams-harvestcraft-2-trees;2931;pamhc2trees;潘马斯农场2 - 果树;Pam's HarvestCraft 2 - Trees;PHC2T
-minecart-direction-follow;2933;lock_minecart_view;Better Minecart Rotation;;
+better-minecart-rotation-forge;2933;lock_minecart_view;Better Minecart Rotation;;
 modern-metals;2934;modernmetals;现代金属;Modern Metals;
-block-renderer;2935;block_renderer,blockrenderer;Block Renderer;;
+blockrenderer;2935;block_renderer,blockrenderer;Block Renderer;;
 blockus;2936;blockus;Blockus;;
 conjurers-cookbook;2937;conjurerscookbook;Conjurer's Cookbook;;
 color-unchained;2938;colorunchained;Color Unchained;;
@@ -2823,7 +2823,7 @@ better-ping-display;2950;betterpingdisplay;更好的延迟显示;Better Ping Dis
 turned-the-changed-mod;2951;turned_remaster;Turned: The Changed Mod;;
 survival-tweaks;2952;survivaltweaks;生存微调;Survival Tweaks;
 melon-slabs;2953;melonslabs;西瓜台阶;Melon Slabs;
-lambdynamiclights;2954;lambdynlights;Lambda的动态光源;LambDynamicLights;LDL
+lambdynamiclights;2954;lambdynlights;Lambd的动态光源;LambDynamicLights;LDL
 realistic-torches;2955;realistictorches;真实火把;Realistic Torches;
 ;2956;;跳舞的线;Dancing Line For Minecraft;DLMC
 durability-viewer;2957;Durability Viewer;耐久显示器;Durability Viewer;
@@ -2833,12 +2833,12 @@ ground-item-highlighting;2961;grounditemhighlighting;地面物品高光显示;Gr
 ;2962;opengldrawing;绘画;OpenGL Drawing;OD
 real-survivor;2963;realsurvivor;幸存者;RealSurvivor;
 armor-toughness-bar;2964;toughnessbar;盔甲韧性显示;Armor Toughness Bar;
-block-meter;2965;;Block Meter;;
+block-meter;2965;blockmeter;Block Meter;;
 time-to-live;2966;;Time To Live;;TTL
 dual-hotbar-1-12-2;2967;dualhotbar;双重快捷栏1.12.2;Dual Hotbars 1.12.2;
 cha-s;2968;craftablehorsearmour;可合成的马铠和鞍;Craftable Horse Armour & Saddle;CHA&S
 dual-hotbar;2969;dualhotbar;双重快捷栏;Dual Hotbars;
-travellers-boots;2970;travellersboots;Traveller's Boots;;
+travellers-boots;2970;travellersboots,travellersbootsreloaded;Traveller's Boots;;
 ;2971;wfs;伍德的时装精选;Woody's Fashion Selection;WFS
 cofh-vanilla-satchels;2972;vanillasatchels;CoFH：Vanilla+ Satchels;;
 betteranimalsplus;2973;betteranimalsplus;更多动物;Better Animals Plus;BA+
@@ -2851,7 +2851,7 @@ conquest-reforged;2979;conquest,blockpalette,connect;征服者;Conquest Reforged
 steelseries-gamesense;2980;gamesense;Steelseries Gamesense;;
 pizzaatimes-timber-mod;2981;timber;pizzaatime's Timber Mod;;
 tellme;2982;tellme;TellMe;;
-minerva-library;2983;;Minerva library;;
+minerva-library;2983;minerva;Minerva library;;
 ;2984;chromeball;土球;ChromeBall;
 ;2985;godblessing;神佑;God Blessing;
 ;2986;hamburger;老八秘制小汉堡;The Hamburger Of LaoBa;
@@ -2880,7 +2880,7 @@ ring-of-the-miner-fabric;3008;ring_of_miner;矿工戒指;Ring of the Miner;
 instant-bubble-studio;3009;instantbubblestudio;瞬息气泡工坊;Instant Bubble Studio;
 ;3010;rpgmaths;RPG数学家;RPG Maths;
 ;3011;unexpectedteleport;未曾设想的传送方式;Unexpected Teleport;
-;3012;vacation_diary;度假日记·随想;Vocation Diary;
+;3012;vacation_diary;度假日记;Vacation Diary;
 ;3013;bananacraft;香蕉工艺;BananaCraft;
 kaleido;3015;kaleido;Kaleido 🎨;;
 ;3016;arcaneart;奥法艺术;Arcane Art;
@@ -2909,7 +2909,7 @@ tumat;3040;tumat;TUMAT;;
 riddle-chests;3041;riddlechests;谜题箱;Riddle Chests;
 ;3042;cinfinitelib;CinfiniteLib;;CiL
 totem-plus;3043;;图腾增强;Totem Plus;
-blockmeterfabric;3044;blockmeter;方块计量表;BlockMeterFabric;
+blockmeterfabric;3044;blockmeter;方块计量表;Block Meter Fabric;
 ;3045;kamenrider3dmod;假面骑士（3D版）;KamenRider3D;KR3D
 fluid-drawers;3046;fluiddrawers;储液抽屉;Fluid Drawers;
 creepypastacraft-reborn;3047;creepypastacraft;蠕动意面重置版;CreepyPastaCraft Reborn;
@@ -2938,7 +2938,7 @@ refined-pipes;3070;refinedpipes;精致管道;Refined Pipes;
 singularities;3071;singularities;奇点;Singularities;
 better-spawner-control;3072;betterspawnercontrol,betterspawnercontrol-fabric;更好的刷怪笼控制;Better Spawner Control;
 crying-ghasts;3073;cryingghasts;哭泣的恶魂;Crying Ghasts;CG
-dynamic-fps;3074;dynamicfps;动态FPS;Dynamic FPS;
+dynamic-fps;3074;dynamicfps,dynamic_fps;动态 FPS;Dynamic FPS;
 compact-ores;3075;compactores;致密矿石;Compact Ores;
 thaumic-additions;3076;thaumadditions;神秘领域：重构;Thaumic Additions：Reconstructed;TAR
 fabric-disable-custom-worlds-advice;3077;disable_custom_worlds_advice;禁用自定义世界警告;Disable Custom Worlds Advice;DCWA
@@ -2947,7 +2947,7 @@ fast-furnace-for-fabric;3079;fastfurnace;熔炉性能优化 Fabric 版;Fast Furn
 diggus-maximus;3080;diggusmaximus;连锁挖掘;Diggus Maximus;
 super-sentai-craft;3081;supersentaicraft;超级战队工艺;Super Sentai Craft;SSC
 wildly-eat;3082;wildly_eat;狼吞虎咽;Wildly Eat;
-gotta-climb-fast;3083;;快速爬梯;Gotta Climb Fast!;
+gotta-climb-fast;3083;gottaclimbfast;快速爬梯;Gotta Climb Fast!;
 can-i-mine-this-block;3084;can-i-mine-this-block;我­­ 能 挖 它 吗？;cAn i MiNe thIS bLOCk?;cimtb
 rotten-creatures;3085;rotten_creatures;腐烂生物;Rotten Creatures;
 fairy-lights;3086;fairylights;圣诞彩灯;Fairy Lights;
@@ -2958,7 +2958,6 @@ better-questing-triggerer;3090;bqt;Better Questing Triggerer;;
 Broken-Wings;3091;brokenwings;Broken Wings;;
 ;3092;;ChickenASM;;
 compacter;3093;compacter;压缩者;Compacter;
-simple-cc;3094;;简单清除聊天;Simple Clear Chat;
 not-enough-potions;3095;nep;Not Enough Potions;;NEP
 framed-compacting-drawers;3096;framedcompactdrawers;镶框压缩抽屉;Framed Compacting Drawers;FCD
 discordsuite;3097;discordsuite;DiscordSuite;;
@@ -2979,28 +2978,28 @@ origins;3111;origins;起源;Origins (Fabric);
 alexiillib;3112;alexiillib;AlexiiLLib;;
 feed-a-friend;3113;feedafriend;Feed A Friend;;
 ;3114;;斗地主;Minecraft Dou Dizhu;
-;3115;;Item Render Async Reloaded;;IRAR
+;3115;irar;又一个IRR重制版;Item Render Async Reloaded;IRAR
 the-legend-of-herobrine;3116;herobrine;The Legend of Herobrine;;
 extra-origins;3117;extraorigins;起源扩展;Extra Origins;
-caves-and-cliffs;3118;caves_and_cliffs,cavesandcliffs;Caves and Cliffs Mod, 1.17 concept;;CC
+caves-and-cliffs;3118;caves_and_cliffs,cavesandcliffs;Caves and Cliffs Mod, 1.17 backport;;CC
 miner-golems;3119;minergolems;矿工傀儡;Miner Golems;
-;3120;bakadanmaku;直播弹幕模组;BakaDanmaku;
+bakadanmaku;3120;bakadanmaku;直播弹幕模组;BakaDanmaku;
 online-card;3121;onlinecard;网络卡片;Online Card;
 felling;3122;felling;连锁砍树;Felling;
 extra-player-render;3123;extra_player_renderer;额外玩家渲染;Extra Player Renderer;
 fabric-api;3124;fabric,fabric-api;Fabric API;;
 coloredlanterns;3125;coloredlanterns;多彩灯笼;ColoredLanterns;
 ae2-fluid-crafting;3126;ae2fc;AE2流体合成套件;AE2 Fluid Crafting;ae2fc
-cardinal-energy;3127;;能量基本;Cardinal Energy;
-travel-anchors;3128;travel_anchors;旅行锚;Travel Anchors;
+cardinal-energy;3127;cardinalenergy;能量基本;Cardinal Energy;
+travel-anchors;3128;travel_anchors,travelanchors;旅行锚;Travel Anchors;
 bnbgaminglib;3129;bnbgaminglib;BnBGamingLib;;
 triumph;3130;triumph;Triumph;;
 overloaded-armor-bar;3131;overloadedarmorbar;护甲上限突破;Overloaded Armor Bar;
 toomanydanyores;3132;TooManyDanyOres;TooManyDanyOres;;
 glass-pipe;3133;;玻璃管道;Glass Pipe;
 origins-classes;3134;origins-classes;起源：职业;Origins: Classes;
-plonk;3135;;世界内物品放置;Plonk;
-baritone-1-18-2;3136;baritone;Baritone;;BT
+plonk;3135;plonk;世界内物品放置;Plonk;
+baritone-simply;3136;baritone;Baritone;;BT
 potionsmaster;3137;potionsmaster;魔药大师;Potions Master;
 tinkered-hegemony;3138;tinkeredhegemony;匠器主导;Tinkered Hegemony;
 better-impaling;3139;betterimpaling;更好的穿刺附魔;Better Impaling;
@@ -3013,7 +3012,7 @@ demagnetize;3142;demagnetize;消磁;Demagnetize;
 cinderscapes;3147;cinderscapes;余烬奇景;Cinderscapes;
 tfc-homestead;3148;tfcstorage,tfchomestead;TFC Homestead / TFC Storage;;
 tfctinkers;3149;tfc_tinkers;群峦与匠魂;TFC Tinkers;
-thick-font-fix;3150;thick;Thick Font Fix;;
+thick-font-fix;3150;thick,thickfontfix;Thick Font Fix;;
 ;3151;;LEGENDS CORE;;
 dynamic-trees-traverse;3152;dttraverse;动态的树：遍历附属;Dynamic Trees - Traverse;
 mcmt-multithreading;3153;jmt_mcmt,mcmtfabric;Minecraft Multi-Threading;;MCMT
@@ -3062,7 +3061,7 @@ soul-shards-the-old-ways;3197;soulshardstow;Soul Shards: The Old Ways;;
 ;3198;mwaw;元素女巫;Elemental Witches;
 the-flying-things;3199;flying_things;The Flying Things;;
 ftb-ranks;3200;ftbranks;FTB Ranks;;FTBR
-ftb-chunks-forge;3201;ftbchunks;FTB Chunks;;FTBC
+ftb-chunks-forge;3201;ftbchunks;FTB 区块;FTB Chunks;FTBC
 ftb-essentials;3202;ftbessentials;FTB Essentials;;FTBE
 silveroak-outpost;3203;silveroakoutpost;银橡前哨;Silveroak Outpost;
 pehkui;3204;pehkui;Pehkui;;
@@ -3087,13 +3086,13 @@ boatload;3222;extraboats;额外船只;Extra Boats / Boatload;
 outvoted;3223;outvoted;落选生物;Outvoted;
 ;3224;collision;粒子碰撞;Collision;
 attribute;3225;attributefix;属性修复 - Fabric版;Attribute Fix {FABRIC};
-packmodemenu;3226;;PackMode菜单;PackModeMenu;
+packmodemenu;3226;packmodemenu;PackMode 菜单;PackModeMenu;
 simple-gamemodes;3227;;游戏模式短指令;Simple Gamemodes;
 uniq;3228;uniq;流体统一/物品统一;UniQ;
 ;3229;render-layer-trans;Render Layer Transformer;;
 harder-ores;3230;harderores;更难的矿物处理;Harder Ores;
 rune-craft;3231;runecraft;Rune Craft;;
-geckolib;3232;geckolib3,geckolib;GeckoLib;;
+geckolib;3232;geckolib;GeckoLib;;
 memory-cleaner-mod;3233;memorycleaner;内存自动清理;Memory Cleaner Mod;
 ore-flowers;3234;oreflowers;矿物花卉;Ore Flowers;
 aqua-creepers;3235;aqua_creepers;水下苦力怕;Aqua Creepers!;
@@ -3107,7 +3106,7 @@ vm-computers;3242;mcvmcomputers;虚拟电脑;VM Computers;
 inventory-free;3243;inventory_free;无物品栏;Inventory-Free;
 ;3244;oreplus;矿物加强;OrePlus;
 randompatches-integration;3245;rpintegration;RandomPatches Integration;;
-bubble-column-elevator-backport;3246;113_water_mechanics;1.13水域机制;1.13 Water Mechanics;
+bubble-column-elevator-backport;3246;113_water_mechanics;1.13水域机制;1.13 Bubble Columns for 1.12;
 basic-nether-ores;3247;bno;基础下界矿石;Basic Nether Ores;BNO
 nuclearcraft-reactor-builder;3248;reactorbuilder;核电工艺反应堆建造机;NuclearCraft Reactor Builder;NCRB
 pams-harvestcraft-2-food-core;3249;pamhc2foodcore;潘马斯农场2 - 食物核心;Pam's HarvestCraft 2 - Food Core;
@@ -3144,7 +3143,7 @@ twitch-chat-integration;3279;twitchintegration;Twitch信息显示;Twitch Chat In
 ;3280;time;时间传说：重生;TIME: Reborn;TIME
 avaritia-lite;3282;avaritia;无尽贪婪精简版;Avaritia Lite;
 packmenu;3283;packmenu;PackMenu;;
-console-hud;3285;consolehud;原主机版界面特性;Console Experience;
+console-experience;3285;consolehud;原主机版界面特性;Console Experience;
 ;3286;such_metal,such_metal_;晶体;Crystal;
 ;3287;legendarybeasts;幻想怪物;Legendary Beasts;
 mite-reborn;3288;fiveminsurvival;MITE：重生;MITE:Reborn;
@@ -3168,23 +3167,23 @@ shoulder-surfing-reloaded;3305;shouldersurfing;越肩视角重制;Shoulder Surfi
 aqua-acrobatics;3306;aquaacrobatics;水游技艺;Aqua Acrobatics;
 silents-mechanisms;3307;silents_mechanisms;寂静机械;Silent Mechanisms;SM
 project-potman;3308;proj_pot;背锅人计划;ProjectPotman;
-nbt-crafting;3309;nbtcrafting;数据包NBT合并;Nbt Crafting;
+nbt-crafting;3309;nbtcrafting;数据包 NBT 合并;Nbt Crafting;
 diregoo;3310;diregoo;DireGoo;;
 ogdragon;3311;ogdragon;OG龙+;OGDragon+;
 sevtweaks;3312;sevtweaks;SevTweaks;;
 journeymapstages;3313;jmapstages;旅行地图阶段控制;JourneyMapStages;
-textile-backup;3314;textile_backup;Textile备份;Textile Backup;
+textile-backup;3314;textile_backup;Textile 备份;Textile Backup;
 goopers;3315;goopers;Goopers;;
-mob-drops;3316;;自定义生物战利品;Mob Drops Your Way;
+mob-drops;3316;md;自定义生物战利品;Mob Drops Your Way;
 ;3317;gtcefe;GTCE/BC能源拓展;Gregic Power;
 alexs-mobs;3318;alexsmobs;Alex 的生物;Alex's Mobs;AM
 all-stackable;3319;allstackable;可堆叠物品自定义;All Stackable;
 thermal-mj;3320;thermal_mj;热力MJ支持;Thermal MJ;
-ctd-core;3321;;CTD Core;;
+ctd-core;3321;ctdcore;CTD Core;;
 time-speed-mod;3322;B3M;Minecraft地球自转/真实昼夜循环;Вращение Земли Майнкрафтская (Accurate day/night-cycles Mod);ВЗМ
 ;3323;devops;冒险岛;Maple Story;MS
 mineral-tracker;3324;mineraltracker;Mineral Tracker;;
-carpet-extra;3325;carpet-extra;Carpet拓展;carpet-extra;
+carpet-extra;3325;carpet-extra;Carpet 拓展;Carpet Extra;
 ;3326;ctrl;热加载合成表;CraftTweakerReload;CTRL
 viafabric;3327;viafabric;ViaFabric;;
 double-slabs;3328;doubleslabs;双重台阶;Double Slabs;
@@ -3196,7 +3195,7 @@ shulkerboxviewer;3333;shulkerboxviewer;ShulkerBoxViewer;;
 gameinfo;3334;gameinfo;游戏信息;GameInfo;
 arcaea;3335;mukaimods;Arcaea韵律源点;Arcaea;
 advanced-tfc-tech;3336;att;进阶群峦科技;Advanced TFC Tech;ATT
-vanilla-enhanced;3337;enriched;原版增强;Enriched/Vanilla Enhanced;
+enriched;3337;enriched;原版增强;Enriched/Vanilla Enhanced;
 satisforestry;3338;Satisforestry;Satisforestry;;SF
 asmc;3339;asmc;ASMC;;
 simple-generators;3340;simplegenerators;简易发电机;Simple Generators;
@@ -3204,9 +3203,9 @@ tfc-bonsai;3341;tfc_bonsai;群峦盆栽;TFC Bonsai;
 tfc-drying-rack;3342;tfc_drying_rack;群峦晾干架;TFC Drying Rack;
 ;3343;mcbbswiki;MCBBS Wiki 模组;MCBBS Wiki Mod;MBW
 lumen;3344;lumen;流明;Lumen 🔥;
-openblocks-elevator;3345;elevatorid;开放式电梯;OpenBlocks Elevator;
+openblocks-elevator;3345;elevatorid;开放式电梯;OpenBlocks Elevator / ElevatorMod;
 crafttweaker-integration;3346;ctintegration;CrT集成;CraftTweaker Integration;CTIG
-spiders-2-0;3348;;蜘蛛行为增强;Spiders 2.0;
+spiders-2-0;3348;spiderstpo;蜘蛛行为增强;Spiders 2.0;
 hammer-metals;3350;hammermetals;锤子材料;Hammer Metals;
 bunch-of-biomes;3351;bunchofbiomes;生物群系扩充;Bunch Of Biomes!;
 ;3352;sword_shura,swordshura;修罗之剑;Sword: Shura;
@@ -3247,7 +3246,7 @@ time-travel-mod;3388;timetravelmod;时间旅行;Time Travel Mod;
 backslotaddon;3389;backslotaddon;背用武器拓展;BackSlotAddon;
 optifabric-1-8-9;3390;optifabric;OptiLegacy;;
 ;3391;fabricloader;Legacy Fabric;;
-gt6-ore-helper;3392;gt6orehelper;GT6矿石助手;GT6 Ore Helper;
+gt6-ore-helper;3392;gt6orehelper;GT6 矿石助手;GT6 Ore Helper;
 applied-integrations;3393;appliedintegrations;应用集成;Applied Integrations;AI
 ;3394;noitemrest;不剩魔法;NoItemRest;NIR
 inventory-hud-forge;3395;inventoryhud;物品栏HUD+;Inventory HUD+;
@@ -3256,7 +3255,7 @@ langsplit;3397;langsplit;LangSplit;;
 legacy-fabric-api;3398;legacy-fabric-api;Legacy Fabric API;;
 krypton;3399;krypton;氪;Krypton;
 mana-gear;3400;managear;Mana Gear;;
-not-enough-enchantments;3401;nee;Not Enough Enchantments;;NEE
+not-enough-enchantments;3401;nee,notenoughenchantments;Not Enough Enchantments;;NEE
 bon-appetit-forge;3402;bonappetit;祝您好胃口;Bon Appetit;
 gugu-utils;3403;gugu-utils;咕咕工具;GuGu Utils;
 scuba-gear;3404;scuba_gear;潜水装备;Scuba Gear;
@@ -3312,7 +3311,7 @@ plus-tweaks;3456;plustweaks;Plus Tweaks;;
 global-gamerules;3457;globalgamerules;全局游戏规则;Global GameRules;
 ;3458;mineshot;高清截图;Mineshot;
 save-my-stronghold-fabric;3459;savemystronghold;Save My Stronghold!;;
-physics-mod;3460;physicsmod;真实物理;Physics mod;
+physics-mod;3460;physicsmod;真实物理;Physics Mod;
 bluemap;3461;bluemap;BlueMap;;
 dregora;3462;dregora;德雷戈拉;Dregora;
 k4lib;3463;k4lib;K4Lib;;
@@ -3332,17 +3331,17 @@ better-animal-models;3476;betteranimals;更真实的动物;Better animal models;
 ;3477;minelp;我的小马驹;Mine Little Pony;MineLP
 druidcraft;3479;druidcraft;德鲁伊工艺;Druidcraft;
 berry-good;3480;berry_good;Berry Good;;
-savage-and-ravage;3481;savageandravage;残暴与掠夺;Savage & Ravage;
+savage-and-ravage;3481;savageandravage,savage_and_ravage;残暴与掠夺;Savage & Ravage;
 jade;3482;jade;玉 🔍;Jade 🔍;
 somnia;3483;somnia;梦醒时分;Somnia Awoken;
-industrial-reborn;3484;indreb;Industrial Reborn;;
+industrial-reborn;3484;indreb,industrialreborn;Industrial Reborn;;
 mo-structures-forge;3485;mostructures;更多自然生成结构;Mo' Structures;
 wallpapercraft-a-fresh-roll;3486;wallpapercraft;墙纸创造;Wallpapercraft - A Fresh Roll;
 clear-despawn;3487;cleardespawn;Clear Despawn (Forge);;
 ;3488;moddd;Overlord in Minecraft;;OiM
 ;3489;bedrockworkshop;基岩工坊;Bedrock Workshop;BW
 unionlib;3490;unionlib;UnionLib;;
-botany-trees;3491;botanytrees;Botany Trees;;
+botany-trees;3491;botanytrees;植树盆栽;Botany Trees;
 better-third-person;3492;betterthirdperson;Better Third Person;;
 survive;3493;survive;生存要素;Survive;
 wallpapercraft-a-fresh-roll-stairs;3494;wallpapercraftstairs;墙纸创造：楼梯;Wallpapercraft - A Fresh Roll (Stairs!);
@@ -3378,7 +3377,7 @@ ultimate-car-mod;3523;car;终极汽车;Ultimate Car Mod;
 craft-time;3524;timecraft;耗时合成;Craft Takes Time;CTT
 betterf3;3525;betterf3,betterf3forge;更好的F3;BetterF3;
 ;3526;ArknightsBlade,arknightsblade;方舟拔刀;ArknightsBlade;AB
-the-abyss-chapter-ii;3527;theabyss;深渊：第二章;The Abyss: Chapter II / The Abyss II - The Other Side;
+the-abyss-chapter-ii;3527;theabyss;深渊：第二章;The Abyss: Chapter II / The Abyss II - The Other Side;TATOS
 mapper-base;3528;mapperbase;Mapper Base;;
 bedrockify;3529;bedrockify;BedrockIfy;;
 ;3530;minecraft_tag;Minecraft-凝胶测试轨道;Minecraft Tag-Gel test track;MT
@@ -3415,7 +3414,7 @@ bedrock-b-gone;3560;betterbedrock;Bedrock B Gone;;
 ;3561;last_minute;最后时刻;Lastminute;LMNT
 elemental-creepers;3562;elementalcreepers;元素爬行者;Elemental Creepers;
 gymcraft;3563;gymcraft;GymCraft;;
-infernal-expansion;3564;infernalexp;地狱扩展;Infernal Expansion;
+infernal-expansion;3564;infernalexp;地狱扩展;Infernal Expansion;IE
 ;3565;ng;更多装备与工具;;MEaT
 ;3566;Manymonsters;独立：更多妖怪;Manymonsters;myms
 configurable-mob-potion-effects;3567;configurablemobpotioneffects;怪物药水效果自定义;Configurable Mob Potion Effects;CMPE
@@ -3434,7 +3433,7 @@ xnicex;3579;nice;xNICEx;;
 krate;3580;krate;Krate;;
 chickensshed;3581;chickensshed;鸡棚重置版;ChickensShed;
 chickenshed;3582;ChickenShed;ChickenShed;;
-expanded-storage-fabric;3583;expandedstorage;扩展存储;Expanded Storage;
+expanded-storage;3583;expandedstorage;扩展存储;Expanded Storage;ES
 project-mmo;3584;pmmo;Project MMO;;PMMO
 abnormals-delight;3585;abnormals_delight;Abnormals Delight;;
 jojos-bizarre-survival;3586;jojomod;JoJo's Bizarre Survival;;
@@ -3446,12 +3445,12 @@ environmental;3591;environmental;自然环境;Environmental;
 ;3592;slashblade.qian;魔刀千刃;Qian The mighty Blade;
 golden-airport-pack-immersive-vehicles-content;3593;ivairlinerpack;Golden Airport Pack;;GAP
 hole-filler-mod;3595;hole_filler_mod;洞口填充器;Hole Filler;
-;3596;gdzb;更多装备;More Equipment;mqt
+;3596;gdzb;更多装备;More Equipment;MQT
 simply-tea;3597;simplytea;简单的茶！;Simply Tea!;ST
 buttermilk;3598;buttermilk;Buttermilk;;
 diet;3599;diet;均衡饮食;Diet;
 brazilian-fields;3600;brazilian_fields;巴西风情;Brazilian Fields;
-ae2-extras;3601;ae2extras;AE2附加;AE2 Extras;
+ae2-extras;3601;ae2extras;AE2 附加;AE2 Extras;
 animalium;3602;animalium;动物;Animalium;
 mob-origins;3603;moborigins;生物起源;Mob Origins;
 better-default-biomes;3604;betterdefaultbiomes;更好的默认生物群系;Better Default Biomes;
@@ -3463,7 +3462,7 @@ wiki-zoomer;3609;wikizoomer;Wiki Zoomer;;
 personality;3610;personality;Personality;;
 allurement;3611;allurement;Allurement;;
 dwarf-miner-totem;3612;dwarf_miner;矮人矿工;Dwarf Miner Totem;
-yungs-better-portals;3613;betterportals;YUNG的传送门机制重构;YUNG's Better Portals;
+yungs-better-portals;3613;betterportals;YUNG 的传送门机制重构;YUNG's Better Portals;
 german-road-signs-mod;3614;schildermod;德国交通标志;German Road Signs Mod;
 iguana-in-a-blanket;3615;iguana-blanket;真实调整;Iguana in a Blanket;
 anthill-inside;3616;anthillinside;蚂蚁物流;Anthill Inside;
@@ -3499,7 +3498,7 @@ improved-mobs;3645;improvedmobs;怪物增强;Improved Mobs;
 limitless;3646;limitless;无上限附魔;Limitless;
 vpn-blocker;3647;vpnblocker;禁用VPN;VPN Blocker;
 premium-wood;3648;premium_wood;Premium Wood;;
-tenshilib;3649;;Tenshilib;;
+tenshilib;3649;tenshilib;TenshiLib;;
 randomportals;3650;randomportals;随意传送门;RandomPortals;
 configured;3651;configured;配置界面;Configured;
 ;3652;siwangyinyve;专业团队music;siwangyinyve;
@@ -3516,11 +3515,11 @@ wool-temples;3662;wooltemples;羊毛神殿;Wool Temples;
 exp-bottling;3663;exp_bottling;经验装瓶;EXP Bottling;
 buildersaddition;3664;buildersaddition;Builders Crafts & Additions;;
 gt-remastered;3665;gtr;格雷科技重制版;GT: Remastered;GTR
-tips;3666;tips;提示;Tips;
+tips;3666;tips,tipsmod;提示;Tips;
 Interactio;3667;interactio;Interactio;;
 advancement-book;3668;advancementbook;进度之书;Advancement Book;
 drawers-tooltip;3669;drawerstooltip;抽屉提示;Drawers Tooltip;
-paradise-lost;3670;;天境：重生;Paradise Lost;
+paradise-lost;3670;paradise_lost;天境：重生;Paradise Lost;
 ;3671;extended;拓展;Extended;EX
 ;3672;gregfood;格雷的食物;GregFood;GF
 more-jellyfish;3673;more_jellyfish;更多水母;More Jellyfish;
@@ -3529,12 +3528,12 @@ beta-dannys-expansion;3675;dannys_expansion;Danny's Expansion;;
 inventory-tweaks-renewed;3676;invtweaks;Inventory Tweaks Renewed;;
 arrp;3677;advanced_runtime_resource_pack;高级运行时资源包;Advanced Runtime Resource Packs;ARRP
 tougher-glass-forge;3678;tougherglass;Tougher Glass;;
-differentiate;3679;;Differentiate;;
+differentiate;3679;differentiate;Differentiate;;
 cookie-core-fabric;3680;;Cookie Core;;
 image-world-generator;3681;imggen;图片地图转换器;Image World Generator;
 inductive-logistics;3682;indlog;集成物流;Inductive Logistics;
 ;3683;crystal_two;晶体2;;
-automatic-path;3684;;Automatic Path;;
+automatic-path;3684;autopath;Automatic Path;;
 ;3685;useful_coals_2;实用煤炭2;Useful Coals 2;UfC2
 morevanillalib;3686;morevanillalib;MoreVanillaLib;;
 vanilla-excavators;3687;vanillaexcavators;Vanilla Excavators;;
@@ -3545,7 +3544,7 @@ tipline;3691;tipline;TipLine;;
 ultimate-plane-mod;3692;plane;终极飞机;Ultimate Plane Mod;
 simple-voice-chat;3693;voicechat;简单的语音聊天;Simple Voice Chat;SVC
 not-enough-milk;3694;notenoughmilk;Not Enough Milk;;
-ewewukeks-musket-mod;3695;musketmod;ewewukek的火枪模组;ewewukek's Musket mod;
+ewewukeks-musket-mod;3695;musketmod;ewewukek 的火枪模组;ewewukek's Musket mod;
 irisshaders;3697;iris;Iris Shaders;;
 ;3698;dimthread;世界多线程化;DimensionalThreading;
 chambers;3699;chambers;处理仓;Chambers;
@@ -3569,8 +3568,8 @@ random-title;3717;randomtitle;随机标题;Random Title;
 astikorcarts;3718;astikorcarts;AstikorCarts;;
 ;3719;invsync;背包同步;InvSync;
 jea;3720;jea;JEI进度;Just Enough Advancements;JEA
-et-futurum-requiem;3721;etfuturum;Et Futurum Requiem;;
-better-op;3722;better-op;更好的OP;Better Op;
+et-futurum-requiem;3721;etfuturum;把未来带回现实;Et Futurum Requiem;EFR
+better-op;3722;better-op;更好的 OP;Better Op;
 fastworkbench-minus-replacement;3723;fastbenchminusreplacement;FastWorkbench Minus Replacement;;
 crimson-compass;3724;crimsoncompass;绯红指南针;Crimson Compass;
 tinkers-construct;3725;tconstruct;匠魂3;Tinkers' Construct 3;TiC3
@@ -3593,12 +3592,11 @@ whoosh;3741;whoosh;Whoosh;;
 gregtech-intergalactical;3742;gti,gregtech,gtu;泛银河系格雷科技;GregTech Intergalactical;GTI
 catalogue;3743;catalogue;模组目录;Catalogue;
 libblockattributes;3744;libblockattributes;Lib Block Attributes;;
-balance-of-exile;3745;anti_mob_farm;Balance of Exile/Anti Mob Farm;;
-dungeons-of-exile;3746;;Dungeons of Exile;;
-more-food-addon-bedrock;3747;morefood;Lot's More Food;;
+dungeons-of-exile;3746;world_of_exile;Dungeons of Exile;;
+lots-more-food-forge;3747;morefood;Lot's More Food;;
 pe-superheroes-mod;3748;;SuperHeroes Mod;;
 necromancy;3749;necromancy;Necromancy;;
-library-of-exile;3750;;Library of Exile;;
+library-of-exile;3750;library_of_exile;Library of Exile;;
 ;3751;;Mite-打破一切;MITE-Break Everything;
 variegated;3752;variegated;Variegated;;
 chest-cavity;3753;chestcavity;胸腔;Chest Cavity;
@@ -3619,7 +3617,7 @@ mattdahepic-core;3767;mdecore;MattDahEpic Core;;MDECore
 mob-farm-helpers-forge;3768;mobfarmutilities;刷怪塔小帮手;Mob Farm Helpers;
 metal-bushes;3769;metalbushesmod;金属灌木;Metal Bushes;
 ;3770;no cheating;禁止作弊;No cheating;
-;3771;;附加包模板;Bedrock Add-On Sample Files;
+;3771;Vanilla Behavior Pack;附加包模板;Bedrock Add-On Sample Files;
 the-vanilla-experience;3772;thevanillaexperience;The Vanilla Experience;;TVE
 flower-seeds;3773;flowerseeds;Flower Seeds;;
 ;3774;impact;Impact;;
@@ -3629,19 +3627,19 @@ astromine-foundations;3778;astromine;天体矿工：基础;Astromine: Foundation
 create-stuff-additions;3779;create_stuff_additions,create_sa;机械动力：物品附加;Create Stuff & Additions;
 slab-machines;3780;slabmachines;台阶型设备;Slab Machines;
 more-create-stuffs;3781;morecreatestuffs;更多机械动力物品;More Create Stuffs;
-rsinfinitybooster;3782;rsinfinitybooster;RS无限范围增幅卡;RSInfinityBooster;
+rsinfinitybooster;3782;rsinfinitybooster;RS 无限范围增幅卡;RSInfinityBooster;
 cuneiform;3783;cuneiform;Cuneiform;;
 terraincognita;3784;terraincognita;Terra Incognita: The Unknown Land;;
 cloth-api;3785;cloth-api;Cloth API;;
 ingameime;3786;ingameime;游戏内输入法;IngameIME;
-yungs-better-strongholds;3787;betterstrongholds;YUNG的要塞优化;YUNG's Better Strongholds;
+yungs-better-strongholds;3787;betterstrongholds;YUNG 的要塞优化;YUNG's Better Strongholds;
 mojangdark;3788;mojangdark;暗色加载;MojangDark;
 astromine-technologies;3789;astromine;天体矿工：科技;Astromine: Technologies;
 astromine-transportations;3790;astromine;天体矿工：运输;Astromine: Transportaions;
 azuredooms-chunk-loader;3791;chunk;AzureDoom's Chunk Loader;;
 creeper-spores;3792;creeperspores;苦力怕孢子;Creeper Spores;
 more-dragon-eggs;3793;moredragoneggs;更多的龙蛋;More Dragon Eggs;
-more-red;3794;More_Red;更多红石;More Red;
+more-red;3794;More_Red,morered;更多红石;More Red;
 ;3795;herobrine;Herobrine;;
 craftable-items;3797;;Un-Craftable;;
 ex-nihilo-sequentia-mekanism-addon;3798;exnihilomekanism;无中生有：传承 - 通用机械扩展;Ex Nihilo: Sequentia - Mekanism Addon;
@@ -3679,11 +3677,11 @@ communism-life-and-art;3830;communism_lifeandart,communism_life_and_art_backtrac
 project-war-dance;3831;wardance;战舞计划;Project: War Dance;PWD
 faster-ladder-climbing;3832;fasterladderclimbing;更快的爬梯;Faster Ladder Climbing;
 infinitymending;3833;infinitymending;无限+经验修补;InfinityMending;
-better-than-mending;3834;;更好的经验修补;Better Than Mending;
+better-than-mending;3834;betterthanmending;更好的经验修补;Better Than Mending;
 elenai-dodge-2;3835;elenaidodge2,elenaidodge;Elenai Dodge 2;;
 taterzens;3837;taterzens;Taterzens;;
 dragons-survival;3838;dragonsurvival;龙之生存;Dragon Survival;DS
-;3839;modmenu;Legacy Mod Menu;;
+;3839;;Legacy Mod Menu;;
 no-lan-cheats;3840;nolancheats;禁用局域网作弊;No LAN Cheats;
 dashloader;3841;dashloader;疾速加载;DashLoader;
 caveworld-2;3842;caveworld;洞穴世界;Caveworld 2;
@@ -3734,19 +3732,19 @@ entity-nan-health-fix;3887;nanfix;假死修复;Entity NaN Health Fix;
 ferritecore;3888;ferritecore;铁氧体磁芯;FerriteCore;FC
 thaumcraft-research-patcher;3889;tcresearchpatcher;Thaumcraft Research Patcher;;
 masterful-machinery;3890;masterfulmachinery;Masterful Machinery;;MM
-minecraft-earth-mod;3891;minecraft_earth_mod;Derec的地球生物;Derec's Earth Mobs;
+minecraft-earth-mod;3891;minecraft_earth_mod;Derec 的地球生物;Derec's Earth Mobs;
 scotts-essential;3892;scessential;Scott's Essential;;
 drawerfps;3893;drawerfps;储物抽屉渲染配置;DrawerFPS;
 ;3894;touhou_craft;東方幻想鄉;TouhouCraft;
 cursed-earth;3895;cursedearth;Cursed Earth;;
 sll;3896;villagers;逆向交易;sɹǝƃɐllᴉΛ;
 lagmeter;3897;lagmeter;延迟表;LagMeter;
-hexxit-gear-2;3898;hexxitgear;Hexxit装备2;Hexxit Gear 2;
+hexxit-gear-2;3898;hexxitgear;Hexxit 装备 2;Hexxit Gear R;
 scootys-plants-vs-zombies;3899;scootys_pvz;Scooty的植物大战僵尸重生;Scootys Plants Vs. Zombies Regrown;SPVZR
 ;3900;;BulletCart;;
 ;3901;quilt_loader;Quilt Loader;;
 ;3902;fabricloader;Cursed Legacy Fabric;;
-custom-machinery;3903;custommachinery;Custom Machinery;;
+custom-machinery;3903;custommachinery;Custom Machinery;;CM
 bonsai-tree-crops;3904;arcadialbonsaitrees;Bonsai Tree Crops;;
 rpgz;3905;rpgz;RpgZ;;
 ;3907;xiuxian,xiuxianchengzhen,xiuxianlianqi,xiuxianyaoshou,xiuxianliandan;原初修真1.15.2;xiuxian;
@@ -3763,8 +3761,8 @@ amaleafs-expantion-world-mod;3918;aewmod;Amaleaf's Expantion World Mod;;
 the-elemelon-mod;3919;elemelon;元素西瓜;The Elemelon Mod;
 dcsp;3920;diamondscompressorsp;钻石压缩;Diamonds Compressor SP;
 corpse-complex;3921;corpsecomplex;Corpse Complex;;
-modularvoicechat;3922;;模块化语音聊天;ModularVoiceChat;
-curious-elytra;3923;curiouselytra,elytratrinket,elytraslot;鞘翅插槽;Curious Elytra / Elytra Trinket / Elytra Slot;
+modularvoicechat;3922;modularvc;模块化语音聊天;ModularVoiceChat;
+elytra-slot;3923;curiouselytra,elytratrinket,elytraslot;鞘翅插槽;Curious Elytra / Elytra Trinket / Elytra Slot;
 ;3924;our;时间纪元;Time Era;
 tconstructcompatible;3925;ticc,tconstruct_compatible;匠魂兼容;TConstructCompatible;TiCC
 ;3926;Your Records Mod;自定义唱片;Your Records Mod;
@@ -3773,7 +3771,7 @@ incubation;3927;incubation;Incubation;;
 ;3930;nanzhi_grave;南织鸽子的坟墓模组;;NZGrave
 create-goggles;3931;createplus,creategoggles;Create Goggles;;
 ;3932;strange_ingot;奇奇怪怪的锭;Strange ingot;
-coloured-tooltips;3933;colouredtooltips;Coloured Tooltips;;
+coloured-tooltips;3933;colouredtooltips;彩色提示框;Coloured Tooltips;
 magicraft-magic;3934;magicfoods;魔法材料;Magical Materials;
 glowstone-ores;3935;gom;荧石矿石;Glowstone Ores;
 more-wires;3936;morewire,morewires;More Wires;;
@@ -3796,7 +3794,7 @@ farplanetwo;3952;fp2;远平面2;Far Plane Two;FP2
 xenoclus-one;3953;xenoclus_v;Xenoclus One;;
 satako-library;3954;satako;Satako Library;;
 unique-enchantments-utils;3955;;独特的附魔：效用扩展;Unique Enchantments - Utils;
-ae2ao;3956;ae2ao;AE2 Additional Opportunity;;AE2AO
+forge-ae2-additional-opportunity;3956;ae2ao;AE2 Additional Opportunity;;AE2AO
 iconexporter;3957;iconexporter;IconExporter;;
 curious-shulker-boxes;3958;curiousshulkerboxes;潜影盒插槽;Shulker Box Slot;
 xenoclus-2;3959;xenoclustwo;Xenoclus 2;;
@@ -3815,15 +3813,15 @@ time-in-a-bottle-standalone;3971;tiab;时间之瓶;Time in a bottle standalone;
 compressed-grass;3973;gm;压缩草;Compressed Grass;
 applepie;3974;ApplePie;苹果派;ApplePie;
 doles-mod;3975;firstmod;Dole's Mod;;
-ex-nihilo-sequentia-thermal-addon;3976;;无中生有：传承 - 热力扩展;Ex Nihilo: Sequentia - Thermal Addon;
+ex-nihilo-sequentia-thermal-addon;3976;exnihilothermal;无中生有：传承 - 热力扩展;Ex Nihilo: Sequentia - Thermal Addon;
 ex-naturae;3977;exnaturae;无中生有：传承 - 植物魔法扩展;Ex Naturae;
 ex-nihilo-sequentia-tinkers-addon;3978;;无中生有：传承 - 匠魂扩展;Ex Nihilo: Sequentia - Tinkers Addon;
-iron-jetpacks;3979;ironjetpacks;Iron Jetpacks;;
+iron-jetpacks;3979;ironjetpacks,iron-jetpacks;Iron Jetpacks;;
 custom-discs;3980;discs;自定义唱片;Custom Discs;
 playtime-counter-fabric;3981;playtime_count;游戏时长计数器;Playtime Counter;
 entity-banners;3982;entitybanners;实体旗帜;Entity Banners;
 curious-jetpacks;3983;curiousjetpacks;Curious Jetpacks;;
-curious-armor-stands-fabric;3984;curious_armor_stands;Curious Armor Stands;;CAS
+curious-armor-stands;3984;curious_armor_stands;Curious Armor Stands;;CAS
 trinkets-fabric;3985;trinkets;Trinkets;;
 occultism;3986;occultism;神秘学;Occultism;
 stray-spawn;3987;strayspawn,strayspawn-fabric;流浪者生成微调;Stray Spawn;
@@ -3833,7 +3831,7 @@ cardinal-components;3989;cardinal-components;Cardinal Components API;;CCA
 ;3991;nsn;不那么新;Not So New;NSN
 integrated-proxy;3992;integrated_proxy;集成代理器;Integrated Proxy;
 a-cobblestone-crafting-table;3993;cw;圆石工作台;A Cobblestone Crafting Table;
-colored-iron;3994;examplemod;Colored Iron;;
+colored-iron;3994;ColoredIron;Colored Iron;;
 final-kobold;3995;fk;Final Kobold;;
 ears;3996;ears;耳朵;Ears;
 wildfires-female-gender-mod-forge;3997;wildfire_gender;Wildfire's Female Gender Mod;;
@@ -3851,7 +3849,7 @@ alwayseat;4005;salwayseat;吃不停;AlwaysEat;
 aquarium;4009;aquarium;深海;Aquarium;
 mixin-booter;4010;mixinbooter;MixinBooter;;
 ;4011;;一个物品格的生存;One Item Only;OIO
-jrds-moneymod;4012;;jrd's MoneyMod;;
+jrds-moneymod;4012;moneymod;jrd's MoneyMod;;
 skeletdimension;4013;SkeletonModID;骷髅维度;SkeletDimension;
 sushigocrafting;4014;sushigocrafting;巧制寿司;Sushi Go Crafting;
 shrines-structures;4015;shrines;Shrines Structures;;
@@ -3886,27 +3884,27 @@ wasteland-reborn;4044;wastelands;不毛之地：重生;Wastland Reborn;
 skds-core;4045;skds-core;SKDS Core;;
 endertech;4046;EnderTech;末影科技;Ender Tech;ET
 enderpig-mod;4047;enderpig;末影猪;Enderpig Mod;
-;4048;examplemod;矿石树;TreeOres;
-;4049;spider2fix;镇压前端召唤;No No-AI Spawn;
+;4048;treeores;矿石树;TreeOres;
+no-no-ai-spawn;4049;spider2fix;镇压前端召唤;No No-AI Spawn;
 atomic-bomb-1-16;4050;nuclear_craft;枪，炮，原子弹！;Guns, Rockets and Atomic Explosions;
 se-sign-shop;4051;sesignshop;简单经济：牌子商店;SE: Sign Shop;
 ;4052;technical_engineering;科能工程2;Technical Engineering 2;TEN2
-fancymenu-forge;4053;fancymenu;FancyMenu;;FM
-halogen;4054;sodium;卤素;Halogen;
-zetamod;4055;zetamod;泽塔;ZetaForged/Zeta's Mod;
+fancymenu;4053;fancymenu;FancyMenu;;FM
+halogen;4054;;卤素;Halogen;
+zetamod;4055;zetamod;泽塔;ZetaForged / Zeta's Mod;
 ;4056;pixelmon;宝可梦 世代;Pixelmon Generations;PG
 ;4057;xianjiange;仙剑阁;;
 wholetreeaxe;4058;WholeTreeAxe;Whole Tree Axe;;
 fabrishot;4059;fabrishot;高清截图Fabric;Fabrishot;
 materialisation;4060;materialisation;物质化;Materialisation;
 recipebuffers;4061;recipebuffers;配方缓冲;RecipeBuffers;
-;4062;mineshotrevived;Mineshot Revived;;
+;4062;mineshotrevived;高清截图：复生;Mineshot Revived;
 portal-gun-fabric;4063;portalgun;传送枪 Fabric;Portal Gun Fabric;
 incendium;4064;incendium;Incendium;;
 ;4065;nfc;New Frontier Craft;;NFC
 cooperative-advancements;4066;cooperativeadvancements;合作进度;Cooperative Advancements;
 lightstones;4067;lightstones;Lightstones;;
-openbackup;4068;;OpenBackup;;
+openbackup;4068;openbackup;OpenBackup;;
 fat-experience-orbs;4069;fatxporbs;肥胖经验球;[Fabric] Fat Experience Orbs;
 better-pipes;4070;betterpipes;更好的管道;Better Pipes;
 truetype-font-replacement;4071;BetterFonts;TrueType Font Replacement;;TTFR
@@ -3931,11 +3929,11 @@ afkpeace;4090;afkpeace;AFKPeace;;
 ;4091;stop_hostname_leak;Stop HostName Leak;;
 ;4092;secretrooms;Secret Rooms Fabric;;
 smooth-chunks;4093;smooth-chunks;平滑区块加载;Smooth Chunks;
-saturationoverflow;4094;zenny3d.saturationoverflow;饱和度溢出;Saturation Over flow;
+saturationoverflow;4094;zenny3d.saturationoverflow;饱和度溢出;SaturationOverflow;
 ;4095;;艾玛的起源;Emma's origins;EO
 phantom-blood;4096;phantomblood;幻影之血;Phantom Blood;PB
 ;4097;;洞穴与山崖扩展包;Caves & Cliffs Expansion Pack;
-searchable-containers;4098;;可搜索容器;Searchable Containers;
+searchable-containers;4098;searchablecontainers;可搜索容器;Searchable Containers;
 ;4099;original_development;原版扩展;Original Development;
 ;4100;conranel;卡莱内尔;Conranel;CRN
 integrated-additions;4101;integratedadditions;集成扩展;Integrated Additions;
@@ -3953,30 +3951,30 @@ village-employment;4111;village_employment;村庄就业;Village Employment;
 deathlog;4113;deathlog;死亡日志;Deathlog;
 automatic-elytra;4114;;自动鞘翅;Automatic Elytra;
 axolotl-bucket-fix;4115;axolotlitemfix;美西螈桶修复;Axolotl Bucket Fix;
-xks-decoration;4116;xkdeco;XK的装饰;XK's Deco;
+xks-decoration;4116;xkdeco;XK的装饰;XK's Decoration;
 endgame-materials-addons;4117;endgamematerialsgalaxyaddon;更多终局材料;Endgame Materials Addons;
 ravage-and-cabbage;4118;ravageandcabbage;Ravage & Cabbage;;
 stackup;4119;stackup;StackUp!;;
 simple-anti-x-ray;4120;;Simple Anti X-Ray;;
 breakme;4121;breakme;BreakMe;;
-mod-info-command;4122;;Mod Info Command;;
+mod-info-command;4122;mod-info-cmd;Mod Info Command;;
 hexxit-gear-fabric;4123;hexxitgear;Hexxit Gear (Fabric);;
 buffed-tools;4124;buffedtools;属性工具;Buffed Tools;
 thaumcraft-nei-plugin;4125;thaumcraftneiplugin;神秘时代NEI插件;Thaumcraft NEI Plugin;
 moarrecipes;4126;MoarRecipes;更多的配方;MoarRecipes;
-luminium;4127;luminium;luminium;;
+luminium;4127;luminium;Luminium;;
 better-nether-map-port;4128;nethermap;Better Nether Map;;
 ;4129;mcs;多重压缩物品;MultipleCompressedStuffs;mcs
-iguanatweaks-reborn;4130;iguanatweaks;生存重构/蜥蜴微调重生;Survival Reimagined/IguanaTweaks Reborn;
-enter-the-void;4131;thevoidsshadow;进入虚空;Enter the void;
+iguanatweaks-reborn;4130;iguanatweaks;生存重构/蜥蜴微调重生;Survival Reimagined / IguanaTweaks Reborn;
+enter-the-void;4131;thevoidsshadow;进入虚空;Enter The Void;
 tensura-mod-that-time-i-got-reincarnated-as-a-slime;4132;ttigraas;关于我转生变成史莱姆这档事;Tensura Mod -That time I got reincarnated as a Slime;
 ;4133;deep_dark_layer;深暗层;Deep dark layer;DDL
 speedometer;4134;speedometer;速度表;Speedometer;
-falling-leaves-forge;4135;fallingleaves;落叶;Falling Leaves (Forge);
+falling-leaves-forge;4135;fallingleaves;落叶;Falling Leaves (NeoForge/Forge);
 ;4136;mcef;MCEF 非官方版本;MCEF-Unofficial;MCEF
 ;4137;god_metal;神之金属;God Metal;GM
 custom-entity-models-cem;4138;cem;自定义实体模型;Custom Entity Models;CEM
-tweakmyclient;4139;tweakmyclient;TweakMyClient;;
+tweakmyclient;4139;tweakmyclient;TweakMyClient;;TMC
 lovely-snails;4140;lovely_snails;可爱蜗牛;Lovely Snails;
 ;4141;oursemod;Ourse MOD;;
 clipboard;4142;clipboard;备忘录;Clipboard;
@@ -3984,21 +3982,21 @@ crimson-nbt-tags;4143;;Crimson NBT Tags;;
 ;4144;cabo;随意弓数据包;Casual Bow Datapack;
 water-physics-overhaul;4145;wpo;Water Physics Overhaul;;WPO
 netherless;4146;Netherless;Netherless;;
-auto-ore-dictionary-converter;4147;autooredictconv;Auto Ore Dictionary Converter;;
+auto-ore-dictionary-converter;4147;autooredictconv;Auto Ore Dictionary Converter;AODC;
 elytraboosters;4148;elytraboosters;Elytra Boosters;;
 cobblegenrandomizer;4149;cobblegenrandomizer;CobbleGenRandomizer;;
 unified-resources;4150;unified_resources;Unified Resources;;
 wooden-buckets;4151;woodenbuckets;木桶;Wooden Buckets;
-no-nether-portals;4152;nonetherportals;No Nether Portals;;
+no-nether-portals;4152;nonetherportals;没有下界传送门;No Nether Portals;
 beehivetooltips;4153;beehivetooltips;蜂巢工具提示;BeehiveTooltips;
 buddycards;4154;buddycards;巴迪卡牌;Buddycards;
-extended-caves;4155;extcaves;Expanded Caves;;
+extended-caves;4155;extcaves;Extended Caves / Expanded Caves [Forge];;
 inventorio;4157;inventorio;Inventorio;;
 more-curios-totems-of-undying;4158;morecuriostotemsofundying:;More Curios Totems of Undying;;
-selene;4159;moonlight;Moonlight Lib/Selene;;
+selene;4159;moonlight,selene;Moonlight Lib/Selene;;
 compatibilitylayerforcustomskinloader;4160;CompatibilityLayerForCustomSkinLoader;万用皮肤补丁兼容层;CompatibilityLayerForCustomSkinLoader;CLFCSL
 no-potion-shift;4161;nopotionshift;No Potion Shift;;
-no-potion-offset;4162;;No Potion Offset;;
+no-potion-offset;4162;no-potion-offset-forge,no-potion-offset;No Potion Offset;;
 demonslayer;4163;kimetsunoyaiba;鬼灭之刃;Kimetsu no Yaiba;
 nautilium;4164;Nautilium;鹦鹉螺;Nautilium;
 auto-attack;4165;auto attack;自动攻击;Auto Attack;
@@ -4010,7 +4008,7 @@ timeless-and-classic-guns;4170;tac;永恒枪械工坊;Timeless and Classics Guns
 tool-progression;4171;toolprogression;工具进阶;Tool Progression;
 ;4173;;棘羽「毕方」;BirdBlade;B.B
 a-paimon;4174;apaimon;派蒙;A Paimon;
-;4175;creative;Creative;;
+;4175;creative;BH Creative;;
 music-maker-mod;4176;xercamusic;Music Maker Mod;;
 penguin-lib;4177;penguinlib;Penguin-Lib;;
 flywheel;4178;flywheel;飞轮;Flywheel;
@@ -4018,7 +4016,7 @@ flywheel;4178;flywheel;飞轮;Flywheel;
 coralreef;4180;coralreef;珊瑚礁;CoralReef;
 ;4181;jewelry_bar_core;简易饰品;Simple Accessories;SAC
 simply-seasons;4182;simplyseasons;简单季节;Simply Seasons;
-bclib;4183;bclib:;BCLib;;
+bclib;4183;bclib;BCLib;;
 actually-baubles;4184;actuallybaubles;实用拓展饰品;Actually Baubles;
 alexs-mobs-battle-music;4185;;♪ Alex's Mobs Battle Music ♪;;
 lava-waders-bauble;4186;lavawaderbauble;熔岩魔靴饰品;Lava Waders Bauble;
@@ -4044,7 +4042,7 @@ hot-or-not-plus;4205;hotornot;Hot or Not +;;
 macaws-furniture-tfc;4206;mcwfurnituretfc;Macaw's Furniture for TFC;;
 tfc-florae;4207;tfcflorae;TFC Florae;;
 tfc-elementia;4208;tfcelementia;TFC Elementia;;
-infinity-water-bucket;4209;;无限水桶;Infinity Water Bucket;
+infinity-water-bucket;4209;infinitywaterbucket;无限水桶;Infinity Water Bucket;
 tfc-caffeine-addon;4210;ca;TFC Caffeine Addon;;
 tfc-cellars-add-on;4211;cellars;TFC: TNG Cellars Add-on;;
 boats-and-beeps;4212;boats-and-beeps;Boats and Beeps;;
@@ -4072,7 +4070,7 @@ its-the-little-things;4234;itlt;It's The Little Things;;itlt
 fruitful;4235;fruitful;硕果累累;Fruitful;
 environmental-energy;4236;enviroenergy;环境科技-发电机;Environmental Energy;EnE
 nakranoths-herdcraft;4237;herdCraft;群兽行为;Nakranoth's Herdcraft;
-lambdabettergrass;4238;lambdabettergrass;Lambda的更好的草方块;LambdaBetterGrass;LBG
+lambdabettergrass;4238;lambdabettergrass;Lambd 的更好的草方块;LambdaBetterGrass;LBG
 ;4239;clientcommands;clientcommands;;
 bright-ore;4240;bright-ore;矿石高亮;Bright Ore;
 chinese-style-sword;4241;chinese_sword;中式剑;Arsenal Core;
@@ -4089,7 +4087,7 @@ mr-pineapples-food-mod;4249;pinesfoodmod;Mr. Pineapple's Food Mod;;
 legacyvault;4252;legacyvault;Legacy Vault;;
 shopaholic;4253;shopaholic;Shopaholic;;
 ;4254;mooncake;月饼;Moon Cake;MMC
-ok-zoomer;4255;okzoomer;Ok Zoomer;;
+ok-zoomer;4255;okzoomer,ok_zoomer;Ok Zoomer;;
 untitled-duck-mod-forge;4256;untitledduckmod;无题鸭;Untitled Duck;
 v-tweaks;4257;vtweaks;V-Tweaks;;
 fairenchanting;4258;fairenchanting;公平附魔;FairEnchanting;
@@ -4100,7 +4098,7 @@ x-hp;4262;x-hp;x-hp;;
 ;4263;kaimyentity;KAI我的实体 - 修改版;KAIMyEntity - Modify;
 mr-pineapples-toy-guns;4264;toyguns;Mr Pineapple's Toy Guns;;
 magickcore;4265;magickcore;魔法核心;MagickCore;
-feywild;4266;feywild;Feywild;;
+feywild;4266;feywild;仙灵荒野;Feywild;
 The-final-sword;4267;finalsword;最终之剑重置版;The final sword;
 ;4268;benchworks;做功台;Benchworks;
 gog-skybox;4269;gogskybox;GoG Skybox;;
@@ -4118,7 +4116,7 @@ special-ai;4280;specialid;特殊AI;Special AI;
 dream-waifu-mod;4281;waifucraft;梦中情人;Dream Waifu mod;
 help-wanted;4282;helpwanted;求助;Help Wanted;
 off-hand-combat;4283;offhandcombat;副手战斗;Off Hand Combat;
-reaping-mod-fabric;4284;reapingmod;收割;Reaping Mod;
+reaping-mod-fabric;4284;reapingmod,reaping;收割;Reaping;
 gilding;4285;gilding;镀金;Gilding;
 grims-transportables;4286;transportables;格里姆的便捷交通工具;Grim's Transportables;
 reroll;4287;reroll;刷新附魔;Reroll;
@@ -4147,7 +4145,7 @@ softer-hay-bales;4309;softerhaybales,softerhaybales-fabric;柔软的干草块;So
 portable-jukebox-forge;4310;portablejukebox;便携式唱片机;Portable Jukebox;
 spiders-produce-webs;4311;spidersproducewebs,spidersproducewebs-fabric;蜘蛛吐网;Spiders Produce Webs;
 assassins-creed-blocklegend;4312;acbl;刺客信条：方块传奇2;Assassin's Creed Blocklegend II;ACBL2
-gravestone-mod-graves;4313;gravestone;墓碑坟墓;Gravestone mod Graves;
+gravestone-mod-graves;4313;gravestone,GraveStone;墓碑坟墓;Gravestone mod Graves;
 the-earth-mod;4314;earth;地球;The Earth Mod;
 lifts;4315;lifts;电梯;Lifts;
 corail-recycler;4316;corail_recycler;Corail的回收站;Corail Recycler;
@@ -4166,7 +4164,7 @@ inventory-tabs;4328;inventorytabs;Inventory Tabs;;
 bottle-your-xp;4329;bottleyourxp,bottleyourxp-fabric;装瓶你的经验;Bottle Your Xp;
 gravestone-mod-extended;4330;gravestone-extended;墓碑坟墓 - 拓展;Gravestone mod - Extended;
 better-enchanted-books;4331;bebooks;更好的附魔书;Better Enchanted Books;BEB
-easy-steel-forge;4332;easy_steel;Easy Steel & More;;
+easy-steel-forge;4332;easy_steel;简单的钢;Easy Steel & More;
 fabric-waystones;4333;fwaystones;Fabric版传送石碑;Fabric Waystones;
 ;4334;ire;铁块电梯;Iron Elevators;
 ;4335;seedcracker;SeedCracker;;
@@ -4184,7 +4182,7 @@ vanilla-builders-extension;4346;vbe;Vanilla Builders Extension;;VBE
 big-beacons;4348;bigbeacons;大信标;Big Beacons;
 wooden-hopper;4349;woodenhopper;木漏斗;Wooden Hopper;
 ;4350;pvz;植物大战僵尸2;Plants vs Zombies 2;
-ages-api;4351;;Ages API;;
+ages-api;4351;ages_api;Ages API;;
 fancyhud;4352;fancyhud;Spiffy HUD / FancyHUD;;
 advanced-compass;4353;advancedcompass;高级指南针;Advanced Compass;
 salutem;4354;salutem;Salutem;;
@@ -4204,7 +4202,7 @@ simple-ambients;4366;ambients;Simple Ambients;;
 ;4368;cam;乡野与魔法;Countryside And Magic;CAM
 modern-loading-screen;4370;modernloadingscreen;现代加载界面;Modern Loading Screen;MLS
 ;4371;zyfdroid-myessentialx;MyEssentialX;;
-;4372;dongdongmod;冬冬的随意创作;Dong Dong's random creation;DDRC
+dong-dongs-random-creation;4372;dongdongmod;冬冬的随意创作;Dong Dong's random creation;DDRC
 ;4373;threebody;三体;ThreeBody;
 transliterationlib;4374;transliterationlib;TRansliterationLib;;
 ;4375;loan;借贷;Loan;
@@ -4212,7 +4210,7 @@ rpmtw-update-mod;4376;rpmtw_update_mod,rpmtw_platform_mod;RPMTW平台模組;RPMT
 farsight-spyglasses;4377;farsight_spyglasses;Farsight: Spyglasses;;
 not-enough-animations;4378;notenoughanimations;更多动画;Not Enough Animations;
 better-beacon;4379;betterbeacon;更好的信标与潮涌核心;Better Beacon / Conduit;
-dungeon-now-loading;4381;;Dungeon Now Loading;;DNL
+dungeon-now-loading;4381;dungeonnowloading;地牢进行时;Dungeon Now Loading;DNL
 simple-emerald-tools-fabric;4382;easy_emerald;Easy Emerald Tools & More;;
 cold-sweat;4383;cold_sweat;冷汗;Cold Sweat;
 witchery-rewitched;4384;witchery_rewitched;巫术：重生;Witchery: Rewitched;
@@ -4259,7 +4257,7 @@ terracore;4424;terracore;TerraCore;;
 seeker-compass;4426;seeker_compass;Seeker Compass;;
 ghosts-explosives;4427;ghostsexplosives;Ghost's Explosives;;
 power-drop;4428;powerdrop;蓄力投掷;Power Drop;
-yungs-better-dungeons;4429;betterdungeons;YUNG的地牢优化;YUNG's Better Dungeons;
+yungs-better-dungeons;4429;betterdungeons;YUNG 的地牢优化;YUNG's Better Dungeons;
 ;4430;;社会人梗图;peduncle;SHR
 ore-controller;4431;ore_controller;Ore Controller;;
 morechickens;4432;chickens;更多鸡;MoreChickens;
@@ -4274,7 +4272,7 @@ dungeons-mobs;4436;dungeons_mobs;地下城生物;Dungeons Mobs;
 ;4441;flycycle;Flycycle;;
 ;4442;civilizationswars;三体工业（TeaCon预览版）;Civilizations Wars;
 ;4443;king_and_knight;明日方舟;King and knight;
-;4444;ashihara;苇原（序章 ~ 稻生草子）;Ashihara;ASHR
+;4444;ashihara;苇原（芝之章~百里乡野行纪）;Ashihara;ASHR
 uusi-aurinko;4445;uusi-aurinko;新日;Uusi Aurinko;
 ;4446;serializableconsciousness;Serializable Consciousness;;SeriCons
 ;4448;elytra_booster;推进鞘翅;Elytra Booster;
@@ -4297,13 +4295,13 @@ just-enough-professions-jep;4464;justenoughprofessions;JEI工作方块;Just Enou
 ;4465;norecipebook;没有配方书非官方版;No Recipe Book;
 paimonfood;4466;paimonfood;应急食品;PaimonFood;
 plumed-belt;4467;plumedbelt;Plumed Belt;;
-better-with-minecolonies;4468;;Better With Minecolonies;;
+better-with-minecolonies;4468;betterwithminecolonies;Better With Minecolonies;;
 calemis-utilities;4469;calemiutils;Calemi的实用设备;Calemi's Utilities;
 botanical-cowardice;4470;botanicalcowardice;Botanical Cowardice;;
-travelers-titles;4471;travelerstitles;Traveler's Titles;;
+travelers-titles;4471;travelerstitles;旅人标题;Traveler's Titles;
 expand-chinese-sword;4472;expand_chinese_sword;中式剑拓展;Arsenal Integration;ECS
 ;4473;;空城魔法;;
-littleframes;4474;littleframes;小画;LittleFrames;
+littleframes;4474;littleframes;小画;LittlePictureFrames;
 lavalogged-blocks;4475;lavalogging;岩浆充填;Lavalogged blocks;
 awoken-world;4476;awokenworld;Awoken World;;
 gt4-reimagined;4477;gt4r;格雷科技4：重构想;GregTech 4 Reimagined;GT4R
@@ -4358,7 +4356,7 @@ pharmacist;4526;pharmacist;药师;Pharmacist;
 kappa;4527;kappa;Kappa;;
 equivalent-integrations;4528;equivalentintegrations;等价集成;Equivalent Integrations;
 keep-equipment;4529;keepequipment;保留装备;Keep Equipment;
-herobrines-origin;4530;herobrine;Herobrine的起源;Herobrine's Origin;
+herobrines-origin;4530;herobrine;Herobrine 的起源;Herobrine's Origin;
 the-abyss;4531;theabyss;深渊：远古;The Abyss: Legacy;
 sekiro-sense-symbols;4532;sekiro_kanji;Sekiro Sense Symbols;;
 lurker;4533;lurkermod;Cold的潜伏者;Colds: Lurker;
@@ -4396,7 +4394,7 @@ farmers-extra-foods;4564;farmers_extra_foods;农夫的拓展食物;Farmer's Extr
 tinkers-delight;4565;thinkers_delight,tdelight;工匠乐事;Tinker's Delight;
 ;4566;sic;锻铁工艺;Strike Iron Craft;SIC
 ;4567;FlashFreeze;FlashFreeze;;
-majruszs-accessories;4568;majruszs_accessories;Majrusz的配件;Majrusz's Accessories;
+majruszs-accessories;4568;majruszs_accessories,majruszsaccessories;Majrusz的配件;Majrusz's Accessories;
 water-2-mana;4569;water2mana;Water 2 Mana;;
 ;4570;;工程师板鱼;Engineer Slabfish;
 ;4571;item_export;Item Export;;IEx
@@ -4408,7 +4406,7 @@ playing-cards;4576;playingcards;扑克牌;Playing Cards;
 rainbow-oak-trees-2;4577;rainbowoaks;彩虹橡树2;Rainbow Oak Trees 2;
 mapfrontiers;4578;mapfrontiers;地图边界;MapFrontiers;
 customizable-elytra;4579;customizableelytra;可自定义鞘翅;Customizable Elytra;
-puzzles-lib;4580;puzzleslib;Puzzles Lib;;
+puzzles-lib;4580;puzzleslib;Puzzles Lib;;PL
 unique-enchantments-base;4581;uniquebase;独特的附魔：基础;Unique Enchantments Base;
 ore-stages;4582;orestages;矿石阶段;Ore Stages;
 krays-magic-candles;4583;krayscandles;Kray's Magic Candles;;
@@ -4418,11 +4416,11 @@ emerald-tools-armour;4586;emerald_armor_and_tools;Emerald Tools/Armour;;
 hidden-recipe-book;4587;hiddenrecipebook;隐藏配方书;Hidden Recipe Book;
 kibe;4588;kibe;羊肉面饼实用设备;Kibe Utilities;
 poisoncraft;4589;poisoncraft;毒药工艺;PoisonCraft;
-detail-armor-bar;4590;detailab;细节盔甲;Detail Armor Bar;
+detail-armor-bar-forge;4590;detailab;细节盔甲;Detail Armor Bar;
 wings-horns-hooves-the-ultimate-unicorn-mod;4591;ultimate_unicorn_mod;Wings Horns & Hooves, the Ultimate Unicorn Mod;;
 project-rankine;4592;rankine;兰金计划;Project Rankine;
 tinkers-mechworks;4593;tmechworks,TMechworks;Tinkers' Mechworks;;
-qdc-quantum-dis-assembly-craft;4594;qdc_mod;量子拆解工艺;Quantum Dis-Assembly Craft;QDC
+qdc-core-4-0;4594;qdc_mod;量子拆解工艺;Quantum Dis-Assembly Craft;QDC
 william-wythers-overhauled-overworld;4595;william-wythers-overhauled-overworld,wwoo;William Wythers' Overhauled Overworld/William Wythers' Expanded Ecosphere;;WWOO/WWEE
 infinite-music;4596;infinitemusic;Infinite Music;;
 cobbler;4597;cobbler;可靠的潜影贝工厂;Shulker's Faithful Factories/Cobbler;SFF
@@ -4450,17 +4448,17 @@ all-the-discs;4619;allthediscs;唱片大全;All the Discs;
 cryptic-cosmos;4620;crypticcosmos;Cryptic Cosmos;;
 bayou-blues;4621;bayou_blues;长沼蓝调;Bayou Blues;
 hex-lands;4622;hexlands;六边形地貌;Hex Lands;
-fixrtm;4623;fix-rtm;FixRTM;;
+fixrtm;4623;fix-rtm;fixRTM;;
 serene-tweaks;4624;serenetweaks;Serene Tweaks;;
 ScalingGuis;4625;ScalingGUIs;界面缩放;ScalingGUIs;
 ide-better-command-block-forge-editor;4626;bettercommandblock;更好的命令方块;Better Command Block IDE;
-;4627;breakfree;自由破坏;Break Free;
+breakfree;4627;breakfree;自由破坏;Break Free;
 tinkers-mechworks-fork;4628;tmechworks;Tinkers Mechworks Fork;;
 extended-nether-backport;4629;extendednether;Extended Nether Backport;;
 borderless;4630;borderlesswindow;无边框全屏;Borderless Window;
 lifted-restrictions-structure-block;4631;better_structure;更好的结构方块;Better Structure Block;
-entity-model-json;4632;;实体模型JSON;Entity Model JSON;
-death-coords;4633;;死亡坐标显示;Death Coords;
+entity-model-json;4632;entitymodeljson;实体模型 JSON;Entity Model JSON;
+death-coords;4633;deathcoords;死亡坐标显示;Death Coords;
 ;4634;ultimatec;终极合金2;Ultimatec2;ult
 never-enough-currency;4635;currency;货币多多;Never Enough Currency;NEC
 never-enough-currency-lite;4636;currency;货币多多：精简版;Never Enough Currency Lite;NECL
@@ -4479,15 +4477,15 @@ maidens-marvelous-materials;4648;maidensmaterials;Maiden's Marvelous Materials;;
 nekoration;4649;nekoration;猫咪装饰;Nekoration;
 tomb-many-graves-2;4650;tombmanygraves;Tomb Many Graves 2;;
 fins-and-tails;4651;finsandtails;鳍和尾巴;Fins and Tails;F&T
-smarter-farmers-farmers-replant;4652;farmersreplant,smarterfarmers;更聪明的农夫;Smarter Farmers/Farmers Replant;
+smarter-farmers-farmers-replant;4652;farmersreplant,smarterfarmers;更聪明的农夫;Smarter Farmers / Farmers Replant;
 peculiars;4653;peculiars;独特风味;Peculiars;
 draggable-resource-packs;4654;draggable-resource-packs;可拖动列表/可拖动资源包;Draggable Lists/Draggable Resource Packs;DRP
 fastchest;4655;fastchest;快速箱子渲染;FastChest;
-yuushya-townscape-fabric;4656;yuushya;方块小镇;Yuushya Townscape;
+yuushya-townscape;4656;yuushya;方块小镇;Yuushya Townscape;
 architects-palette-fabric;4657;architects_palette;建筑师的调色板;Architect's Palette;
 whisperwoods;4658;whisperwoods;低语之森;Whisperwoods;
 dimensional-dungeons;4659;dimdungeons;维度地牢;Dimensional Dungeons;
-bosses-of-mass-destruction;4660;bosses_of_mass_destruction;Bosses of Mass Destruction;;BOMD
+bosses-of-mass-destruction;4660;bosses_of_mass_destruction;祸乱鬼魅;Bosses of Mass Destruction;BOMD
 neoelfeos-medieval-pub-decoration;4661;nefdecomod;Nef's Medieval decoration;;
 dustrial-decor;4662;dustrial_decor;'Dustrial Decor;;
 feders-scarecrows;4663;feders_scarecrows;Feder的稻草人;Feder's Scarecrows;
@@ -4517,7 +4515,7 @@ increasemobs;4686;increasemobs;IncreaseMobs;;
 scarecrows-territory;4687;scarecrowsterritory;稻草人领域;Scarecrows' Territory;
 ;4688;borderremover;Border Remover;;
 dungeons-mod;4689;dungeonsmod;Dungeons Mod;;
-loot-beams;4690;lootbeams;战利品光束;Loot Beams;
+loot-beams;4690;lootbeams;战利品光束;Loot Beams: Relooted!;
 theurgy;4691;theurgy;Theurgy;;
 better-badlands;4692;better_badlands;恶地改善;Better Badlands;
 ;4693;;按键显示1.16+;Keystrokes;
@@ -4548,7 +4546,7 @@ llama-steeds-forge;4718;llamasteeds;骑羊驼;Llama Steeds;
 levellib;4719;levellib1562,levellib12484;LevelLib;;
 enigmatic-graves;4720;enigmaticgraves;Enigmatic Graves;;
 boat-item-view-forge;4721;boatiview;边划边看;Boat Item View;
-forge-creeper-heal-unofficial;4722;creeperheal;Forge苦力怕坑修复[非官方版];Forge Creeper Heal [Unofficial];
+forge-creeper-heal-unofficial;4722;creeperheal;Forge 苦力怕坑修复[非官方版];Forge Creeper Heal [Unofficial];
 desolation-forge;4723;desolation;荒芜;Desolation;
 ma-astral;4724;astral;Miner Arcana - Astral;;
 zaraklib;4725;zaraklib;ZarakLib;;
@@ -4648,18 +4646,18 @@ presence-footsteps-forge;4819;presencefootsteps;脚步声Forge版;Presence Foots
 aardvarks-weird-wonderful-wild;4820;weird_wonderful_wild;Aardvark's Weird Wonderful Wild;;
 ;4821;lmmx;LittleMaidMob Enhanced;;
 ;4822;lmreengaged;LittleMaidReengaged Firis's Patch;;
-;4823;littledelicacies;Little Delicacies;;
+little-delicacy-cafes;4823;littledelicacies;Little Delicacy Cafes;;LDC
 ee3-helper;4824;EE3HELP;EE3 Helper;EE3H;
 save-your-pets;4825;syp;拯救你的宠物;Save Your Pets;
 main-menu-scale;4826;mainmenuscale;Main Menu Scale;;
 potion-fingers;4827;potionfingers;Potion Fingers;;
 reload-audio-driver-rad;4828;rad;音频驱动重载;Reload Audio Driver;RAD
 shieldbreak;4829;shieldbreak;ShieldBreak;;
-holiday-helper;4830;;Holiday Helper;;
+holiday-helper;4830;holidayhelper;Holiday Helper;;
 fabric-tickratechanger-mod;4831;;Fabric版运算变速;Fabric TickRateChanger;
 observable;4832;observable;可视性能侦测;Observable;
 disenchantment-edit-table;4833;editenchanting;祛魔编辑台;Disenchantment Edit Table;
-;4834;;LMLibrary;;
+;4834;lmlibrary;LMLibrary;;
 cit-resewn;4835;citresewn;CIT Resewn;;
 lazy-language-loader;4836;lazy-language-loader;Lazy language loader;;
 clef;4837;clef;Clef;;
@@ -4678,7 +4676,7 @@ ender-ring;4850;ender_ring;末影环;Ender Ring;
 milk-all-the-mobs;4851;milkallthemobs;Milk All The Mobs;;
 roadrunner;4852;roadrunner;RoadRunner;;
 pokecube-aoi;4853;pokecube;Pokecube AIO;;
-grim-statues;4854;;Grim的雕像;Grim Statues;
+grim-statues;4854;statues;Grim的雕像;Grim Statues;
 oauth;4855;oauth,oauth-fabric;OAuth;;
 omaypaty-japan-mod;4856;omaypatys_japan_mod_new;OmayPaty's Japan mod;;
 demon-slayer-mod-kimetu-no-yaiba;4857;kimetsu_no_yaiba;鬼灭之刃;DEMON SLAYER MOD;
@@ -4718,16 +4716,16 @@ underground-loot-crates;4890;dungeoncrates;地下战利品箱;Underground Loot C
 ;4891;virus;病毒;virus;vs
 smooth-scrolling-everywhere;4892;smoothscrollingeverywhere;平滑滚动;Smooth Scrolling Everywhere;
 sword-blocking;4893;swordblocking;持剑格挡;Sword Blocking;
-better-mount-hud;4894;bettermounthud;更好的骑乘HUD;Better Mount Hud;
+better-mount-hud;4894;bettermounthud;更好的骑乘 HUD;Better Mount HUD;
 fire-overlay-controller;4895;fireoverlaycontroller;火焰叠加层调整;Fire Overlay Controller;
 ;4896;thedesolat;The Desolat;;
 particle-rain;4897;particlerain;粒子雨;Particle Rain;
-sodium-reforged;4898;sodium;镁;Magnesium/Sodium Reforged;
+sodium-reforged;4898;;镁;Magnesium / Sodium Reforged;
 phosphor-reforged;4899;phosphor;硫;Sulfuric/Phosphor Reforged;
 hydrogen-reforged;4900;hydrogen;氦;HeIium;
 xl-food-mod-plus;4901;xlfoodmod;超多食物+;XL Food Mod+;
 ;4902;cthulhu_mythos;克苏鲁世界;Cthulhu Mythos;
-botconnect;4903;mcbot;群服互联🔗;McBot🔗;
+mcbot;4903;mcbot;群服互联🔗;McBot🔗;
 ice-and-fire-dragonseeker;4904;dragonseeker;Ice and Fire: Dragonseeker;;
 reeses-sodium-options;4905;reeses-sodium-options;Reese的钠视频界面;Reese's Sodium Options;RSO
 continuity;4906;continuity;Continuity;;
@@ -4759,11 +4757,11 @@ forge-snad;4931;snad;子沙1.14+;Snad;
 ;4932;JiuCore;JiuCore;;JC
 opentoall;4933;opentoall;OpenToALL;;
 ;4934;better_cauldrons;更好的炼药锅;BetterCauldrons;
-;4935;netmusic;网络音乐机;Net Music;
+net-music;4935;netmusic;网络音乐机;Net Music;
 torchbowmod;4936;torchbowmod;火把弓;TorchBowMod;
 esencia;4937;esencia;Esencia;;
 weirdmobs;4938;weirdmobs;YDM's WeirdMobs;;
-enchantment-level-language-patch;4939;enchlevel-langpatch;附魔等级语言补丁;EnchLevel-LangPatch;
+enchantment-level-language-patch;4939;enchlevel-langpatch,enchlevellangpatch;附魔等级语言补丁;EnchLevel-LangPatch;
 open-to-lan;4940;open2lan;Open2Lan;;
 simple-translation;4941;simpletranslation;简单翻译;Simple Translation;
 fx-control;4942;fxcontrol;效果控制;Fx control;
@@ -4796,8 +4794,8 @@ kvc-blocks;4968;kvc-blocks;蛋挞君的原版补全方块篇;KVCBlocks;
 enigtech2-util;4969;etutil;EnigTech2 Util;;
 environmental-creepers;4970;;环保型苦力怕;Environmental Creepers;
 ;4971;coding-lib;CodingLib;;
-look-at-that;4972;;Look At That;;LAT
-advanced-peripherals;4973;advancedperipherals;Advanced Peripherals;;
+look-at-that;4972;lookatthat;Look At That;;LAT
+advanced-peripherals;4973;advancedperipherals;高级外设;Advanced Peripherals;AP
 nether-chest-fabric;4974;netherchest;Nether Chest Fabric;;
 ;4975;essentialaddons;EssentialAddons;;
 levelz;4976;levelz;LevelZ;;
@@ -4826,26 +4824,26 @@ chalk-fabric;4997;chalk;Chalk (Fabric);;
 yarcf;4999;recipehandler;合成冲突消除;Yet Another Recipe Conflict Fixer;YARCF
 drones;5000;drones;Drones;;
 ticbc;5001;bettercompat;Tinkers Better Compat;;TiCBC
-;5002;www.yunmouren.top;WEB-UI;;
+;5002;web;WEB-UI;;
 meetle;5003;marquot;Meetle!;;
 tarot;5004;tarot;塔罗;Tarot;
 forcecraft;5005;forcecraft;力量工艺;ForceCraft;
 right-click-harvest;5006;right-click-harvest;右击收割;Right-Click-Harvest;
 custom-content-packs;5007;ccpacks;Custom Content Packs;;CCPacks
 cake-chomps;5008;cakechomps;Cake Chomps;;
-lod-level-of-detail;5009;lod;Distant Horizons: A Level of Detail mod;;DH
+distant-horizons;5009;lod,distanthorizons;Distant Horizons: A Level of Detail mod;;DH
 betterp2p;5010;betterp2p;更好的P2P支持;Better P2P;
-ob-aquamirae;5011;ob_aquamirae;海灵物语;Aquamirae Mod;
+ob-aquamirae;5011;ob_aquamirae,aquamirae;海灵物语;Aquamirae;
 nuclear-tfc;5012;nucleartfc;Nuclear TFC;;
 just-more-cakes;5013;jmc;只是更多的蛋糕！;Just More Cakes!;JMC
 image-mod;5014;imagemod;Image Mod;;
 reinforced-barrels;5015;reinfbarrel;增强木桶;Reinforced Barrels;
-spyglass-zoom;5016;spyzoom,原版拓展;望远镜变焦;Spyglass Zoom;
+spyglass-zoom;5016;spyzoom;望远镜变焦;Spyglass Zoom;
 npc-variety-port;5017;npcvariety;NPC变体;NPC Variety;
 just-enough-effects;5018;effectinfo;Just Enough Effects;;
 incorporeal-2-rhododendrite;5019;incorporeal,rhododendrite;幻想多媒体2;Incorporeal 2 + Rhododendrite;
 ;5020;ex.invoker;祈雨三叉戟;Invoker Trident;
-einsteins-library;5021;;Einstein's Library;;
+einsteins-library;5021;einsteins_library;Einstein's Library;;
 worldshape;5022;worldshape;Worldshape;;
 rslargepatterns;5023;rslargepatterns;精致存储大样板;Refined Storage Large Patterns;
 gendustry-jei-addon;5024;gendustryjei;Gendustry JEI Addon;;
@@ -4855,7 +4853,7 @@ mutant-more;5026;mutantmore;更多突变生物;Mutant More;
 just-enough-keg;5028;just_enough_keg;Just Enough Keg;;
 paleolithic-revolution;5029;revolution;Paleolithic Revolution;;
 better-shields;5030;bettershields;更好的盾牌;Better Shields;
-yungs-bridges;5031;yungsbridges;YUNG的桥;YUNG's Bridges;
+yungs-bridges;5031;yungsbridges;YUNG 的桥;YUNG's Bridges;
 project-red-transmission;5032;projectred-transmission;红石计划：传导;ProjectRed - Transmission;
 day-dream;5033;day_dream;Day Dream;;
 savage-ender-dragon;5034;dragonfight;更凶猛的末影龙;Savage Ender Dragon;
@@ -4900,7 +4898,7 @@ item-borders;5073;itemborders;物品边框;Item Borders;
 iceberg;5074;iceberg;冰山;Iceberg;
 ;5075;voyager;Voyager;;
 enhanced-farming;5077;enhancedfarming;增强农业;Enhanced Farming;EF
-;5078;chunkmod;ChunkMod;;
+;5078;chunkmod;Chunk Mod;;
 ;5079;tiny_coals;小型煤炭;Tiny Coals;TC
 lava-clear-view;5080;clearview;熔岩下清晰视野;Lava Clear View;
 global-xp;5081;globalxp;Global XP;;
@@ -4921,7 +4919,7 @@ fantastic-fish-alpha-v1-4;5095;;神奇的鱼;Fantastic Fish;
 ;5096;reiminimap;Rei的小地图;Rei's Minimap;
 ;5097;extvil;扩展村庄;Extended Villages;extvil
 more-mounted-storages;5098;moremountedstorages;更多存储挂载;More Mounted Storages;
-minecraft-comes-alive-testing;5099;mca;凡家物语：重生;MCA Reborn;MCAR
+minecraft-comes-alive-reborn;5099;mca;凡家物语：重生;MCA Reborn;MCAR
 noodles-apex;5100;apex;面条的Apex系列;Noodles'Apex Series;
 ftb-beast-coin-miner;5101;ftb_beast_coin_miner;货币矿机;Beast Coin Miner;BCM
 scape-and-run-parasites-addon-by-nocube;5102;nocubessrpaddon,nocubessrparmory;Scape and Run: Parasites Combat Addon;;
@@ -4931,7 +4929,7 @@ metallurgy-4-reforged;5105;metallurgy;冶金4：重铸;Metallurgy 4: Reforged;
 harder-natural-healing;5106;hardernaturalhealing;Harder Natural Healing;;
 extra-bit-manipulation;5107;extrabitmanipulation;Extra Bit Manipulation;;EBM
 spartan-weaponry-twilight-forest;5108;spartantwilight;斯巴达的武器：暮色森林;Spartan Weaponry: Twilight Forest;
-iris-reforged;5109;pupil;Lilac/Pupil;;
+iris-reforged;5109;pupil;Lilac / Pupil;;
 additional-lanterns;5110;additionallanterns;更多灯笼;Additional Lanterns;
 bottled-air;5111;bottledair-fabric,bottledair;瓶装空气;Bottled Air;
 fabricproxy-lite;5112;fabricproxy-lite;FabricProxy-Lite;;
@@ -4941,7 +4939,7 @@ budschies-morph-mod;5115;bmorph;Budschie's Morph Mod;;
 pswg;5116;pswg;帕尔奇的星球大战;Parzi's Star Wars Mod;PSWG
 aquatic-abyss;5117;aquaticabyss;Aquatic Abyss;;
 slimier-slimes;5118;slimier-slimes;Slimier Slimes;;
-wacky-weapons;5119;stupid_weapons;Stupid Weapons;;
+stupid-weapon;5119;stupid_weapons;Stupid Weapons;;
 slime-carnage;5120;SlimeCarnage;史莱姆杀戮;Slime Carnage;
 portal-tags;5121;portaltags;Portal Tags;;
 eden-ring;5122;edenring;伊甸星环;Eden Ring;
@@ -4952,12 +4950,12 @@ improvedbackpacks;5126;improvedbackpacks;改良背包;Improved Backpacks;
 ender-skills;5127;enderskills;末影技能;Ender Skills;ES
 useful-railroads;5128;usefulrailroads;实用铁轨;Useful Railroads;
 voluminous-energy;5129;voluminousenergy;Voluminous Energy;;
-flaminco;5130;;Flaminco;;
+flaminco;5130;flaminco;Flaminco;;
 simple-graves;5131;gravestones;Simple Graves;;
 ;5132;pixel_tarot;像素塔罗牌;Pixel Tarot;
-wi-zoom;5134;wi_zoom;WI变焦;WI Zoom;
+wi-zoom;5134;wi_zoom,wi-zoom;WI变焦;WI Zoom;
 forge-carpet;5135;carpet;Forge Carpet;;
-;5136;anc;铁砧工艺;AnvilCraft;anc
+;5136;anc;铁砧工艺：数据包版;AnvilCraft;anc
 fabric-tree-chopper;5137;fabric-tree-chopper;砍树;Fabric Tree Chopper;
 i-see-lava;5138;iseelava;I See Lava;;
 dual-riders;5139;dual_riders;Dual Riders;;
@@ -4970,7 +4968,7 @@ koopas-critters;5145;koopascritters;Koopa's Critters;;
 krypton-reforged;5146;kryptonreforged;氪Forge版;Krypton Reforged;
 item-counter;5147;item_counter;物品计数器;Item Counter;
 ;5148;candiedmedicine;药糖;Candied Medicine;
-reality-check-real-life-timer;5149;;Reality Check;;
+reality-check-real-life-timer;5149;reality_check;Reality Check;;
 retail;5150;retail;Eric's Retail;;
 ;5151;;魔力结界(UHC);;UHC
 time-core-lib;5152;timelib;Time Lib;;
@@ -4987,7 +4985,7 @@ starter-kit;5162;starterkit;初始套件;Starter Kit;
 stacker;5164;stacker;Stacker;;
 gcm;5165;gcm;GCM;;
 ocean-floor-clay-sand-and-dirt;5166;oceanfloor;Ocean Floor - Clay Sand and Dirt;;
-linfox-stacked-dimensions-warden-edition;5167;stacked_dimensions_warden;Deeper in the Caves - Warden Mod;;
+linfox-stacked-dimensions-warden-edition;5167;stacked_dimensions_warden;Deeper in the Caves - RESTART (+ 1.12.2 Version);;
 experience-bottler;5168;experiencebottler;Experience Bottler;;
 gregicality-ore-addon;5169;gregicalityoreaddon;Gregicality矿物拓展;Gregicality Ore Addon;GAOE
 gregtech-battery-buffer-driver-for-opencomputers;5170;BatteryBufferDriver;格雷科技电池箱的开放式电脑驱动;GregTech Battery Buffer Driver for OpenComputers;
@@ -5002,7 +5000,7 @@ gtce2oc;5178;energy_container;格雷科技开放式电脑兼容;gtce2oc;
 azure-rpg-items;5179;azurerpgitems;Azure的RPG风格物品;Azure RPG Items;
 mine-and-slash-expansion;5180;mineandslashexpansion;挖矿与砍杀拓展;Mine and Slash - Expansion Mods;
 devil-may-cry-weapons;5181;dmcweapons;鬼泣武器;Devil May Cry Weapons;
-craft-to-exile-custom-uniques;5182;;放逐之路定制物品;Craft to Exile Custom Uniques;
+craft-to-exile-custom-uniques;5182;ctecu;放逐之路定制物品;Craft to Exile Custom Uniques;
 terraria-arsenal;5183;terrariaarsenal;泰拉瑞亚装备;Terraria Arsenal;T.A.
 world-of-warcraft-weapons;5184;wowweapons;魔兽世界装备;World of Warcraft Weapons;
 mcdoom;5185;doom;MC 毁灭战士;MCDoom;
@@ -5010,7 +5008,7 @@ bleach-weapons;5186;;死神装备;Bleach Weapons;
 behgameon;5187;behgameon;Behgameon RPG Additions;;
 into-the-maelstrom;5188;mm;冒险漩涡;Into The Maelstrom;ITM
 create-deco;5189;createdeco;Create Deco;;
-warp-pipes;5190;;Warp Pipes;;
+warp-pipes;5190;warppipes;Warp Pipes;;
 fertile-farmland;5191;fertile_farmland;沃壤千里;Fertile Farmland;FF
 luckperms;5192;luckperms;LuckPerms;;
 inv-view;5193;invview;Inv View;;
@@ -5022,7 +5020,7 @@ omnipotent-card;5197;omni_card;万用卡牌;Omnipotent Card;
 does-it-tick;5199;kotrt_core;Does It Tick? / KoTRT Core;;DIT
 public-gui-announcement;5200;publicguiannouncement;公开GUI显示;Public Gui Announcement;PGA
 wet-lava-sponge;5201;wetlavasponge;Wet Lava Sponge;;
-ripples-of-the-past;5202;jojo;Ripples of the Past;;ROTP
+ripples-of-the-past;5202;jojo;Ripples of the Past;;RotP
 ;5203;casual_bows;随意弓;Casual Bows;
 cursor-mod;5204;customcursormod;自定义光标;Cursor Mod;
 amplified-nether;5205;amplified_nether,amplifiednether;放大化下界;Amplified Nether;
@@ -5036,7 +5034,7 @@ calcium;5212;calcium;钙;Calcium;
 from-the-shadows;5213;fromtheshadows;From the shadows;;
 l_ender-s-cataclysm;5214;cataclysm;灾变;L_Ender 's Cataclysm;
 brighter-block-light;5215;brighter;亮光;Brighter;
-pick-up-notifier;5216;pickupnotifier;拾取提示;Pick Up Notifier;
+pick-up-notifier;5216;pickupnotifier;拾取提示;Pick Up Notifier;PN
 ;5217;fix4log4j;Log4J修复补丁;Fix4Log4J;
 talkbubbles;5218;talkbubbles;TalkBubbles;;
 servux;5219;servux;Servux;;
@@ -5048,7 +5046,7 @@ farsight;5224;farsight,farsight_view;Farsight;;
 ;5225;;额外的主世界;An Extra Overworld;
 atlantis;5226;atlantis;亚特兰蒂斯;Atlantis;
 gaia-dimension;5227;gaiadimension;Gaia Dimension;;
-pwem;5228;pwem;Weapon editor for Vic's Modern Warfare;;PWEM
+pwem;5228;pwem;Panda's Weapon Editor;;PWEM
 akisephilas-bosses;5229;akisephilas_bosses;Akisephila's Bosses;;
 ;5230;fixlog4j214;FixLog4j214;;
 ;5231;ExploitFix;ExploitFix;;
@@ -5056,12 +5054,12 @@ fluffys-farming;5232;flavourfull;Fluffy's Farming | Flavourfull;;
 aquatic-odyssey-mod;5233;aquaticabyssmod;Aquatic Odyssey;;
 vanilla-cookbook;5234;vanillacookbook;原版烹饪书;Vanilla Cookbook;
 edible-nether-wart;5235;edible_netherwart;可食用下界疣;Edible Nether Wart;
-plasmo-voice;5236;plasmo_voice;Plasmo语音;Plasmo Voice;
+plasmo-voice;5236;plasmo_voice;Plasmo 语音;Plasmo Voice;
 armor-sound-tweak;5237;armorsoundtweak;盔甲音效调整;Armor Sound Tweak;
 hexerei;5238;hexerei;魔法巫师;Hexerei;
 morerefinedstorage;5239;refinedstorage;More Refined Storage;;
 give-me-water-or-give-me-death;5240;waterordeath;Give Me Water Or Give Me Death;;
-lost-and-found;5241;;Lost and Found;;
+lost-and-found;5241;lostandfound;Lost and Found;;
 better-fps-render-distance;5242;betterfpsdist;Better Fps - Render Distance;;
 armor-chroma-for-fabric;5243;armorchroma;盔甲颜色显示Fabric版;Armor Chroma for Fabric;
 ore-reeds;5244;ore_reeds;矿石甘蔗;Ore Reeds;
@@ -5113,16 +5111,16 @@ upgraded-shulkers;5289;upgradedshulkers;更多潜影盒;Upgraded Shulkers;
 ;5290;seedcrackerx;SeedCrackerX;;
 bobby;5291;bobby;服务器区块缓存;Bobby;
 boosted-brightness;5292;boostedbrightness;亮度增强;Boosted Brightness;
-effective;5293;effective;Effective 💦;;
+effective;5293;effective,effective_fg;Effective 💦;;
 ;5294;merchants;回收商;Merchants;
 voidtotem;5295;voidtotem;虚空图腾;Void Totem;
-tool-leveling-plus;5296;toolleveling;Tool Leveling+;;
+tool-leveling-plus;5296;toolleveling;工具升级;Tool Leveling+;
 mythicmetals;5297;mythicmetals;神话金属;Mythic Metals;
 creeper-firework;5298;creeper_firework;烟花苦力怕;Creeper Firework;
 second-chance;5299;secondchance,secondchanceforge;Second Chance;;
 promenade;5300;promenade;Promenade;;
-london-underground;5301;londonunderground;伦敦地铁;The London Underground;LU
-dynamiclights-reforged;5302;dynamiclightsreforged;镁/铷：动态光源;Embeddium/Rubidium Dynamic Lights;
+london-underground;5301;londonunderground;伦敦地铁;MTR London Underground Addon;LU
+dynamiclights-reforged;5302;dynamiclightsreforged,sodiumdynamiclights;钠/Embeddium：动态光源;Sodium/Embeddium Dynamic Lights;
 the-wild-mod;5303;twm,the_wild_update;荒野更新;The Wild Mod;TWM
 tuff-depth;5304;tuffdepth;凝灰岩深度;Tuff Depth;
 minefantasy-reforged;5305;minefantasyreforged;我的幻想重铸版;MineFantasy Reforged;MFR
@@ -5131,10 +5129,10 @@ framework;5307;framework;Framework;;
 ;5308;nzpigeon_chairs;南织鸽子的椅子;Nzpigeon chairs;
 ;5309;applied_create;应用机械;applied_create;
 anointed-items;5310;anointeditems;Anointed Items;;
-golden-age-combat;5311;goldenagecombat;黄金时代的战斗;Golden Age Combat;
-magnesium-extras;5312;magnesium_extras,rubidium_extras;镁/铷：附属;Magnesium/Rubidium Extras;
+golden-age-combat;5311;goldenagecombat;黄金时代的战斗;Golden Age Combat;GC
+magnesium-extras;5312;magnesium_extras,rubidium_extras,sodiumextras,embeddiumextras;钠/Embeddium：附属;Sodium/Embeddium Extras;
 chest-tracker;5313;chesttracker;箱子追踪;Chest Tracker;
-advancementinfo;5314;advancementinfo;进度信息展示;Advancementinfo;
+advancementinfo;5314;advancementinfo;进度信息展示;AdvancementInfo;
 animatica;5315;animatica;Animatica;;
 all-dimension-height-increase;5316;dimheight;全维度建筑高度提升;All Dimension Height Increase;
 merchant-markers;5317;merchantmarkers;商人标记;Merchant Markers;
@@ -5145,41 +5143,41 @@ not-enough-gamerules;5321;not_enough_gamerules;Not Enough Gamerules;;
 ;5322;jsonem;Json格式化实体模型;Json Entity Models;JsonEM
 speedrunigt;5323;speedrunigt;SpeedRunIGT;;IGT
 archmagus;5324;archmagus;Archmagus;;
-slimyboyos;5325;;SlimyBoyos;;
+slimyboyos;5325;slimyboyos;SlimyBoyos;;
 fireplace-lib;5326;fireplacelib;Fireplace Lib;;
 immersive-geology;5327;immersive_geology;沉浸地质学;Immersive Geology;IG
-wool-tweaks;5328;;羊毛调整;Wool Tweaks;
+wool-tweaks;5328;wooltweaks;羊毛调整;Wool Tweaks;
 tools-complement;5329;tools_complement;Tool's Complement;;
 adventtic;5330;adventtic;AdventTiC;;
 questionably-immersive;5331;questionablyimmersive;Questionably Immersive;;
 long-fall-boots;5332;longfallboots;Long Fall Boots;;
 total-darkness;5333;totaldarkness;Total Darkness;;
 true-darkness;5334;darkness;True Darkness;;
-starlight-x-create;5335;starlight;Starlight x Create;;
+starlight-x-create;5335;;Starlight x Create;;
 grand-economy;5336;grandeconomy;Grand Economy;;
 chinacraft2;5337;chinacraft;华夏文明2;ChinaCraft2;CC2
 interactic;5338;interactic;Interactic;;
 fnars-roguelike-dungeons;5339;roguelike;冒险地牢-Fnar版;Roguelike Dungeons -- Fnar's Edition;
 playerex;5340;playerex;PlayerEx;;
 data-attributes;5341;dataattributes;Data Attributes;;
-hardcore-buoyance;5342;;Hardcore Buoyance;;
+hardcore-buoyance;5342;hcbuoy;Hardcore Buoyance;;
 gregtech-ce-unofficial;5343;gregtech;格雷科技社区版：非官方版;GregTech CE: Unofficial;GTCEu
 eggtab-fabric;5344;eggtab;独立刷怪蛋列表;Egg Tab;
 always-a-wither-skull;5345;alwaysawitherskull;必得凋灵骷髅头颅;Always a Wither Skull;
-anvil-restoration-fabric;5346;;铁砧修复;Anvil Restoration;
+anvil-restoration;5346;anvilrestoration;铁砧修复;Anvil Restoration;
 hide-hands-fabric;5347;hidehands;隐藏主副手;Hide Hands;
-better-beacon-placement-fabric;5348;betterbeaconplacement;更好的信标放置;Better Beacon Placement;
+better-beacon-placement;5348;betterbeaconplacement;更好的信标放置;Better Beacon Placement;
 dead-totems;5349;deadtotems;Dead Totems;;
 functional-storage;5350;functionalstorage;功能性存储;Functional Storage;
-the-wild-update;5351;the_wild_update;荒野更新1.19;The Wild Update 1.19;
+the-wild-update;5351;the_wild_update;荒野更新 1.19;The Wild Update 1.19;
 archeology;5352;archeology;考古学;CapsLock Archeology;
 ;5353;child-folder-mods-scaner;子文件夹Mod扫描器;child folder mods scaner;CHMS
 trinkets-and-baubles;5354;xat;饰品与小玩意;Trinkets and Baubles;
 ;5355;;雪王;Snow King;
 rope-ladders;5356;ropeladders;绳梯;Rope Ladders;
 skewers-updated;5357;skewers;烤串更新版;Skewers Updated;
-keep-my-soil-tilled-fabric;5358;keepmysoiltilled;保持肥沃;Keep My Soil Tilled;
-double-doors-fabric;5359;slopes;双开门;Double Doors;
+keep-my-soil-tilled;5358;keepmysoiltilled;保持肥沃;Keep My Soil Tilled;
+double-doors;5359;slopes,doubledoors;双开门;Double Doors;
 expanded-armor-enchanting;5360;expanded_armor_enchanting;盔甲附魔扩展;Expanded Armor Enchanting;
 expanded-weapon-enchanting;5361;expanded_weapon_enchanting;武器附魔扩展;Expanded Weapon Enchanting;
 expanded-axe-enchanting;5362;expanded_axe_enchanting;斧附魔扩展;Expanded Axe Enchanting;
@@ -5191,10 +5189,10 @@ wizard-staff;5367;wizard-staff;Wizard Staff;;
 kambrik;5368;kambrik;Kambrik;;
 additional-bars;5369;additionalbars;更多的栏杆;Additional Bars;
 leap;5370;leap;Leap;;
-cameraoverhaul;5371;cameraoverhaul;CameraOverhaul;;
+cameraoverhaul;5371;cameraoverhaul;Camera Overhaul;;
 enchantment-id-extender;5372;eide;Enchantment ID Extender;;
 creeper-overhaul;5373;creeperoverhaul;苦力怕改革/苦力怕革新;Creeper Overhaul;
-cool-elytra-roll;5374;;Cool Elytra Roll;;
+cool-elytra-roll;5374;cool_elytra;Cool Elytra Roll;;
 camera-overhaul-forge;5375;cameraoverhaul;CameraOverhaul (Forge);;
 blame;5376;blame;Blame;;
 patboxs-banhammer;5377;banhammer;BanHammer!;;
@@ -5216,17 +5214,17 @@ mekanism-matter;5392;mekanismmatter;通用机械：物质拓展;Mekanism Matter;
 inzhefop-core;5393;inzhefopcore;inzhefop's Core;;
 ;5394;milky;Milky;;
 ;5395;slopes;Slopes;;
-legendary-tooltips;5396;legendarytooltips;传说工具提示;Legendary Tooltips;
+legendary-tooltips;5396;legendarytooltips;传说提示框;Legendary Tooltips;
 myrtrees;5397;myrtrees;Myrtrees;;
 ;5398;;Nameless v1.1;;
 tiny-redstone;5399;tinyredstone;Tiny Redstone;;
 ;5400;blooddisplayer;血量显示器;BloodDisplayer;
-icarus-fabric;5401;icarus;伊卡洛斯之翼Fabric版;Icarus (Fabric);
+icarus;5401;icarus;Icarus;;
 the-splash-milk;5402;splash_milk;喷溅牛奶;Splash Milk;
 fastbench-for-fabric;5403;fastbench;工作台性能优化Fabric版;FastBench for Fabric;
 mob-buckets-fabric;5404;;生物桶;Mob Buckets;
 ;5405;er_bot;额外原神学;Ex_genshin_er_botonia;ERBOT
-;5406;;Type-32的枪械数据包;;
+;5406;vng;Type-32的枪械数据包;;
 enchantable;5407;enchantable;Enchantable;;
 glass-doors;5408;glassdoors;玻璃门;Glass Doors;
 glasscutter;5409;glasscutter;玻璃切割器;Glass Cutter;
@@ -5272,9 +5270,9 @@ collision-damage;5449;collisiondamage;Collision Damage;;
 project-74246;5450;dldungeonsjbg;毁灭地牢;Doomlike Dungeons;
 dynamic-trees-defiled-lands;5451;dynamictreesdefiledlands;动态的树：污秽之地附属;Dynamic Trees - Defiled Lands;
 xaero-map-addition;5452;xaero_map_addition;Xaero Map Addition;;XMA
-lambdacontrols;5453;lambdacontrols;Lambda 的控制优化;LambdaControls;
+lambdacontrols;5453;lambdacontrols;Lambd 的控制优化;LambdaControls;
 ducky-mod;5454;duckymod;Ducky Mod;;
-;5455;craftgr;幻想乡电台;CraftGR;
+craftgr;5455;craftgr;幻想乡电台;CraftGR;
 quartz;5456;quartz;Quartz;;
 all-the-blocks;5457;;All The Blocks;;
 allthemodium;5458;allthemodium;Allthemodium;;
@@ -5283,15 +5281,15 @@ just-enough-effect-descriptions-jeed;5460;jeed;JEI药水效果;Just Enough Effec
 hostile-neural-networks;5461;hostilenetworks;Hostile Neural Networks;;
 mo-cakes;5462;mocake;更多蛋糕;Mo' Cake;
 fishing-made-better;5463;fishingmadebetter;更好的钓鱼;Fishing Made Better;FB
-neon-craft-2-mod;5464;neoncraft2;霓虹灯艺2;Neon Craft 2 Mod;NC2
+neon-craft-ultimate;5464;neoncraft2;霓虹灯艺2;Neon Craft Ultimate/Neon Craft 2 Mod;NC2
 architects-dream;5465;architectsdream;建筑师之梦;Architect's Dream;
 ignition-enderbags;5466;enderbags;Ignition: EnderBags;;
 correlated;5467;correlated;Correlated;;
-;5468;ender_bags;EnderBags;;
+enderbags;5468;ender_bags;EnderBags;;
 no-mob-spawning-on-trees;5469;nmsot;No Mob Spawning on Trees;;NMSOT
 rf-lux;5470;rflux;RF Lux;;
 ;5472;roughly-enough-characters;Roughly Enough Characters;;RECh
-;5473;registrate;Registrate;;
+;5473;registrate,registrate-fabric;Registrate;;
 easy-normal-and-magic-foods;5474;foodplus;Easy Normal and Magic Foods;;
 tiefix;5475;tiefix;TieFix;;
 more-chat-history;5476;morechathistory;更多聊天记录;More Chat History;
@@ -5313,7 +5311,7 @@ bilibili;5491;bilibilitianlovol;Bilibili;;
 ;5492;;连锁挖矿轻量版;;
 creatures;5493;creatures;Frikinzi's Fauna;;
 mcdw;5494;mcdw;我的世界：地下城武器;MC Dungeons Weapons;MCDW
-;5495;tooltipinjector;Tooltip注入器;Tooltip Injector;
+;5495;tooltipinjector;Tooltip 注入器;Tooltip Injector;
 beta-creepers;5496;beta_creepers;Beta Creepers;;
 ;5497;more_plentiful_vanilla;更丰富的原版;More Plentiful Vanilla;MPV
 macaws-paintings;5498;mcwpaintings;Macaw的画;Macaw's Paintings;
@@ -5328,7 +5326,7 @@ domum-ornamentum;5506;domumornamentum,domum_ornamentum;Domum Ornamentum;;
 methodicalmilking;5507;methodicalmilking;MethodicalMilking;;
 ;5508;modmdo;ModMdo;;
 save-and-load-inventories-fabric;5509;saveandloadinventories;Save and Load Inventories;;
-forge-config-api-port-fabric;5510;forgeconfigapiport;Forge Config API Port;;
+forge-config-api-port-fabric;5510;forgeconfigapiport;Forge Config API Port;;FC
 pams-cookables;5511;pamscookables;Pam's Cookables;;
 end-metals;5512;;End Metals;;
 vitality;5513;;Vitality;;
@@ -5338,10 +5336,10 @@ mercurius;5516;mercurius;Mercurius;;
 all-the-swords;5517;alltheswords;All The Swords;;
 pams-simple-recipes;5518;simplerecipes;Pam's Simple Recipes;;
 bow-infinity-fix;5519;bowinfinityfix;无限附魔修复;Bow Infinity Fix;BIF
-enchanting-infuser-forge;5521;enchantinginfuser;附魔灌注台;Enchanting Infuser;
+enchanting-infuser-forge;5521;enchantinginfuser;附魔灌注台;Enchanting Infuser;EI
 menumobs;5522;menumobs;主菜单生物渲染;MenuMobs;
 ;5523;heq,hexerei;坚硬装备;HarderEquipments;
-tiny-skeletons-forge;5524;tinyskeletons;小骷髅变种;Tiny Skeletons;
+tiny-skeletons-forge;5524;tinyskeletons;小骷髅变种;Tiny Skeletons;TS
 ;5525;topfix;TOP修复;TOP Fix;
 matter-overdrive-community-edition;5526;matteroverdrive;超能物质社区版;Matter Overdrive: Community Edition;MOCE
 cavetweaks;5527;cavetweaks;洞穴调整;CaveTweaks;
@@ -5350,7 +5348,7 @@ cosmetic-armor-fabric;5528;cosmetic-armor;时装盔甲;Cosmetic Armor;
 ;5530;ems;更多寂静材料;Extra Material Spieces;EMS
 crimson-chickens;5531;crimsonchickens;Crimson Chickens;;
 drippy-loading-screen;5532;fancymenu,drippyloadingscreen;自定义游戏加载界面;Drippy Loading Screen;
-extreme-sound-muffler;5533;extremesoundmuffler;ExtremeSoundMuffler;;ESM
+extreme-sound-muffler;5533;extremesoundmuffler;Extreme Sound Muffler;;ESM
 dragonloot;5534;dragonloot;龙战利品;DragonLoot;
 wtfcore;5535;WTFCore;WTFCore;;
 ore-remover;5536;ore_remover;Ore Remover;;
@@ -5358,14 +5356,13 @@ betweenlands-redstone;5537;betweenlandsredstone;Betweenlands Redstone;;
 more-peripherals;5538;peripherals;More Peripherals;;
 ageing-spawners;5539;ageingspawners;Ageing Spawners;;
 loot-extra;5540;loot_extra;战利品表拓展;LootExtra;LX
-cloud-boots-mod;5541;cloudboots;云靴;Cloud Boots Mod!;
+cloud-boots-mod;5541;cloudboots;云靴;Cloud Boots;
 better-compatibility-checker;5542;bcc;Better Compatibility Checker;;
 fastfurnace-minus-replacement;5543;fastfurnaceminusreplacement;Fast Furnace minus Replacement;;
 harvest;5544;harvest;Harvest;;
 craftpresence;5545;craftpresence;CraftPresence;;
 stonecutter-recipe-tags;5546;stonecutter_recipe_tags;Stonecutter Recipe Tags;;
 customnpcsreborn;5547;customnpcs;自定义NPC：重生;Custom NPCs Reborn;
-nightmare-craft-survival;5548;nightmarecraft;梦魇工艺：生存;Nightmare Craft: Survival;
 brassamberbattletowers;5549;ba_bt;BrassAmber BattleTowers;;
 jags;5550;jags;Just Another Grass Seed;;JAGS
 sedna;5551;sedna;Sedna;;
@@ -5387,7 +5384,7 @@ creatures-and-beasts;5566;cnb;动物和野兽;Creatures and Beasts;
 dead-guys-deep-dark;5567;dead_guys_untitled_deep_dark_;Dead Guys Untitled Deep Dark;;
 towers-of-the-wild-reworked;5568;;旷野之息高塔：重制;Towers of the Wild: Reworked;
 towers-of-the-wild-reloaded;5569;towers_of_the_wild;旷野之塔：重置;Towers of the Wild: Reloaded;
-bansoko;5570;bansoukou;创可贴;Bansōkō;
+bansoko;5570;bansoukou;创可贴;Bansoukou;
 ;5571;;MITE：破晓;MITE:Dawn;
 inventory-backpack;5572;inventory_backpack;Inventory Backpack;;
 ;5573;;比狼好BC兼容;Better Then Buildcraft;BTB
@@ -5405,7 +5402,7 @@ no-null-processors;5585;no_null_processors;No Null Processors;;
 ;5586;jm;果汁贩卖机;Juice Vending Machine;JVM
 ma-enchants;5587;maenchants;Ma 附魔;Ma Enchants;
 bits-and-chisels;5588;bitsandchisels;Bits and Chisels;;
-trading-post;5589;tradingpost;交易站;Trading Post;
+trading-post;5589;tradingpost;交易站;Trading Post;TP
 phantasmic;5590;nourished_nether;Nourished Nether/Phantasmic/Netherific;;
 furnus;5591;furnus;Furnus;;
 permanent-light-generator;5592;plg;恒久光发电机;Permanent Light Generator;PLG
@@ -5421,8 +5418,8 @@ crapping-copper;5602;crappingcopper;压缩升级铜;Crapping Copper;
 botany-pots-ore-planting;5603;botany_pots_ore_planting;植物盆栽矿石种植;Botany Pots Ore Planting;BPOP
 ;5604;transformers;变形金刚;Transformers Mod;TFmod
 satin-api;5605;satin;Satin API;;
-easy-magic;5606;easymagic;简易附魔台;Easy Magic;
-enlightend;5607;nourished_end;Enlightend/Enlightened End/Nourished End;;
+easy-magic;5606;easymagic;简易附魔台;Easy Magic;EM
+enlightend;5607;nourished_end,enlightened_end;末地启明;Enlightend/Enlightened End/Nourished End;
 rubidium;5608;rubidium;铷;Rubidium;
 cultural-delights;5609;culturaldelights,cultural_delights;多元乐事;Cultural Delights;
 ;5610;;我的世界，但是没有含水层;Minecraft, but there are NO AQUIFERS;
@@ -5435,15 +5432,15 @@ vein-mining;5616;veinmining;连锁采集;Vein Mining;
 ars-creo;5617;ars_creo;Ars Creo;;
 it-fell-from-the-sky;5618;ItFellFromTheSky;It Fell From The Sky;;
 ;5619;;友好世界;FriendlyCraft;FC
-;5620;;弯刀;Scimitar Mod;
-;5621;;魔法曲奇;Magic Cookie Mod;
-;5622;;常见的绿宝石;Common Emeralds Mod;
-;5623;;鸡笼;Chicken Cage Mod;
-;5624;;Leather Armor Plus Mod;;
-;5625;;撑竿与羽翼;Pole Vault Mod;
+;5620;integerarray_scimitar;弯刀;Scimitar Mod;
+;5621;integerarray_magiccookie;魔法曲奇;Magic Cookie Mod;
+;5622;integerarray_commonemerald;常见的绿宝石;Common Emeralds Mod;
+;5623;integerarray_chickencage;鸡笼;Chicken Cage Mod;
+;5624;integerarray_leatherarmor;Leather Armor Plus Mod;;
+;5625;integerarray_leatherarmor;撑竿与羽翼;Pole Vault Mod;
 lyonheart;5626;lyonheart;Lyonheart;;
 genshin-12;5627;genshin12;原神12;Genshin 12;
-ae-additions-extra-cells-2-fork;5628;aeadditions;AE Additions - ExtraCells2 Fork;;EC2F
+ae-additions-extra-cells-2-fork;5628;aeadditions,ae2additions;AE Additions - ExtraCells2 Fork;;EC2F
 silent-addons;5629;silentaddons;Silent Addons;;SA
 ars-arsenal;5630;arsarsenal;Ars Arsenal;;
 gps-mod-stalker-mod;5631;gps;GPS Mod / Stalker mod;;
@@ -5461,22 +5458,22 @@ blaze-gear;5642;blazegear;烈焰装备;Blaze Gear;
 ;5643;aier;反内能革命;Anti-internal Energy Revolution;AIER
 rhodonite-tools-armour;5644;rhodonite;Rhodonite;;
 more-minecarts;5645;moreminecarts;More Minecarts and Rails;;
-corn-delight;5646;corn_delight;玉米乐事;Corn Delight;
+corn-delight;5646;corn_delight,corndelight;玉米乐事;Corn Delight;
 ;5647;auto_login;自动登录指令;Auto Login Command;
 ;5648;ro_ss;懒狗生存;Simple Survival;RO_SS
 blast-craft;5649;blastcraft;防爆工艺;Blastcraft;
 zdgx;5650;zdgx;mod自动更新;zdgx-AutoUpdateMod;
 ;5651;polymc;PolyMc;;
-tinkers-construct-bedrock-edition;5652;;匠魂：基岩版;Tinkers' Construct: Bedrock Edition;
+tinkers-construct-bedrock-edition;5652;;匠魂2：基岩版;Tinkers' Construct: Bedrock Edition;
 ore-highlight;5653;light_ore;矿石发亮;Ore Highlight;
 sodium-shadowy-path-blocks;5654;sspb;钠 · 土径阴影;Sodium Shadowy Path Blocks;SSPB
 ;5655;slashblade.twilighttsuki;暮色月光;Slashblade-TwilightTsuki;
-polymer;5656;ploymer;Polymer;;
+polymer;5656;ploymer,polymer_bundled;Polymer;;
 elytra-bombing;5657;ebb;鞘翅轰炸;Elytra Bombing;EBB
 cuboiddroids-support-mod;5658;;CuboidDroid's Support Mod;;
 ;5659;newyeartaste,firecracker;年味;firecrackers/New Year TASTE;
 ;5660;liver_exhaustion_reincarnation;肝尽轮回;Liver Exhaustion Reincarnation;LER
-litematica-tool;5662;litematicatool;投影工具;litematica tool;
+litematica-tool;5662;litematicatool;投影工具;Litematica Tool;
 frozen-up;5663;frozenup;千里冰封;Frozen Up;
 carpet-tis-addition;5664;carpet-tis-addition;Carpet TIS Addition;;
 ;5665;solomon;所罗门之钥;The Solomon Key;TSK
@@ -5513,7 +5510,7 @@ cancel-block-update;5695;cancelblockupdate;取消方块更新;Cancel Block Updat
 franciscofunari;5696;medieval_craft;中世纪工艺;Medieval Craft;
 d3core;5697;d3core;D3Core;;
 green-thumb-v1-2-03;5698;GreenThumb;Green Thumb - Nature Overhaul;;
-greenthumb;5699;;GreenThumb;;
+greenthumb;5699;GreenThumb;GreenThumb;;
 tfc-adventure;5700;tfc_adventure;群峦冒险;TFC+ Adventure;TFCA
 just-zoom-forge;5701;justzoom;Just Zoom;;JZ
 ;5702;holograms;全息图;Holograms;
@@ -5536,12 +5533,12 @@ platypuses;5719;platypus;Platypuses;;
 hostile-villages;5720;hostilevillages;敌对村庄;Hostile Villages;
 throwability;5721;throwability;投掷;Throwability;
 biomeinfo;5722;biomeinfo;生物群系信息;BiomeInfo;
-clickable-advancements;5723;clickadv;可点击的进度;Clickable advancements;
+clickable-advancements;5723;clickadv;可点击的进度;Clickable Advancements;
 factory0-resources;5724;;Factory0 Resources;;
 epic-knights-armor-and-weapons;5725;magistuarmory;史诗骑士：盾牌，盔甲和武器;Epic Knights: Shields, Armor and Weapons;EK
 youre-an-expert-harry;5726;youre_an_expert_harry;你是个专家，哈利！;You're an Expert, Harry!;YEAH
 dragon-mounts-3;5727;dragonmounts;龙骑士3;Dragon Mounts 3;DM3
-viaforge;5728;viaversion,viaforge;ViaForge;;
+viaforge;5728;viaforge;ViaForge;;
 happy-trails;5729;happytrails;快乐小径;Happy Trails;
 naturesaura_tweaker;5730;naturesaura_tweaker;Natures Aura Tweaker;;
 death-finder;5731;deathfinder;死亡溯源;Death Finder;
@@ -5566,7 +5563,7 @@ enchanting-convergence;5750;enchanting_convergence;Enchanting Convergence;;
 magical-psideas-model-replacer;5751;magipsi;Magical Psideas Model Replacer;;
 psio;5752;psicosts;Psio;;
 ;5753;fabricloader;Fabric Loader (Alpha 1.2.2a);;
-;5754;modmenu;Mod Menu (Alpha 1.2.2a);;
+;5754;;Mod Menu (Alpha 1.2.2a);;
 ;5755;extradebug;Extra Debug;;
 ;5756;seedselector;Seed Selector;;
 ;5757;movementhacks;Movement Hacks;;
@@ -5590,12 +5587,12 @@ creatures-of-the-snow;5774;creatures_of_the_snow;雪地里的生物！;Creatures
 collisions-lib;5775;collisionslib;Collisions Lib;;
 wooled-boots;5776;wooledboots;羊毛靴子;Wooled Boots;
 zawa-evolved;5777;zawa;野生动物园：进化;Zoo and Wild Animals: Evolved;ZAWA
-bongo;5778;bongo;Bongo;;
+bongo;5778;bongo;宾果游戏;Bongo;
 impersonate;5779;impersonate;Impersonate;;
 calemi-core;5780;calemicore;Calemi Core;;CCore
 ;5781;zaomengxiyou;造梦西游模组;;
 ;5782;skyland;AnvilCraft SkyLandMod;;AncSL
-visual-workbench;5783;visualworkbench;可视化工作台;Visual Workbench;
+visual-workbench;5783;visualworkbench;可视化工作台;Visual Workbench;VW
 stylish-effects;5784;stylisheffects;Stylish Effects;;
 death-compass-forge;5785;deathcompass;Death Compass;;
 portable-stonecutter;5786;portable_stonecutter;便携式切石机;Portable Stonecutter;
@@ -5614,12 +5611,12 @@ bumpkinbatch;5799;bumpkinbatch;BumpkinBatch;;
 beekeeper;5800;bk;养蜂人;Beekeeper;BK
 some-assembly-required;5801;some_assembly_required,someassemblyrequired;Some Assembly Required;;SAR
 ladylucs-critters-mod;5802;ladys_critter_mod;LadyLucs' Critters Mod;;
-;5803;modmenu;Mod Menu (Beta 1.7.3);;
+;5803;;ModMenu Beta;;
 ;5804;quitbutton;Quit Button;;
 better-signs;5805;bettersigns;Better Signs;;
 ;5806;glsl,macula;Macula / GLSL Shaders (Fabric Beta 1.7.3);;
 ;5807;hmi;HowManyItems;;HMI
-;5808;hmifabric;HowManyItems-SL-Unofficial;;
+;5808;hmifabric;HowManyItems Fabric;;
 ;5809;manymoreblocks-test,manymoreblocks;ManyMoreBlocks;;
 ;5810;gcapi;Glass Config API;;GCAPI
 ;5811;translatedbeta;Translated Legacy;;
@@ -5650,13 +5647,13 @@ refined-cooking;5836;refinedcooking;精致厨房;Refined Cooking;
 jade-addons;5837;jadeaddons;Jade Addons;;
 feature-nbt-deadlock-be-gone;5838;feature_nbt_deadlock_be_gone;Feature NBT Deadlock Be Gone;;
 ;5839;decoaddon;Deco Addon;;
-real-infinity-bow-allow-inf-mending;5840;;真正的无限弓;Real Infinity Bow;
+real-infinity-bow-allow-inf-mending;5840;rib;真正的无限弓;Real Infinity Bow;
 drink-it-forge;5841;drinkit;喝！;Drink It!;
 foxlib;5842;foxlib;FoxLib;;
-tails;5843;;Tails;;
+tails;5843;Tails;Tails;;
 howling-moon-rebooted-forge;5844;howlingmoon;Howling Moon - Rebooted;;
 ;5845;24-hour-time-format;24-Hour Time Format;;
-;5846;;Knoothing;;
+;5846;knoothing;Knoothing;;
 ;5847;dustrial_decor;'Dustrial Decor Fabric;;
 furnish;5848;furnish;Furnish;;
 iammusicplayer;5849;iammusicplayer;Iam Music Player;;IMP
@@ -5666,14 +5663,14 @@ comics-bubbles-chat;5852;comicsbubbleschat;Comics Bubbles Chat;;
 fabric-extended-armor-bars-forked;5853;extendedarmorbars;Extended Armor Bars Forked;;
 eating-animation-forge;5854;eatinganimation,eatinganimationid;进食动画;Eating Animation;
 waterdripsound;5855;waterdripsound;Drip Sounds;;
-better-horse-hud;5856;bhh;更好的骑马HUD;Better Horse Hud;
-thermopolium;5857;Thermopolium;汤饮铺;Thermopolium;THP
+better-horse-hud;5856;bhh;更好的骑马 HUD;Better Horse Hud;
+thermopolium;5857;thermopolium;汤饮铺;Thermopolium;THP
 ;5858;taiga;匠魂合金附加重栽版;TAIGA Replant;TAIGAR
 ;5859;auto-fishing;轻松钓鱼;Auto-fishing;
 orderly-fabric-2-0;5860;orderly;Orderly 2.0;;
 ;5861;orderly;Orderly (Fabric 1.17+);;
-entity-texture-features-fabric;5862;entity_texture_features;Entity Texture Features;;ETF
-sculk-plus;5863;;Sculk Plus;;
+entity-texture-features-fabric;5862;entity_texture_features;实体纹理特性;Entity Texture Features;ETF
+sculk-plus;5863;skulk-plus;Sculk Plus;;
 creeper-confetti-fabric;5864;creeperconfetti;烟花苦力怕Fabric版;Creeper Confetti Fabric;
 double-jump-attribute;5865;doublejumpattribute;Double Jump Attribute;;
 overweight-farming;5866;overweight_farming;Overweight Farming;;
@@ -5681,16 +5678,16 @@ healthcare;5867;healthcare;HealthCare;;
 betterloadingscreen;5868;better_loading_screen;加载画面改良;Better Loading Screen;
 fabric-title-changer;5869;ftc;Fabric Title Changer;;
 window-title-changer;5870;window_title_changer;Window Title Changer;;
-;5871;corelib;Corelib;;
+;5871;corelib;CoreLib;;
 ;5872;betterlight;BetterLight;;
-;5873;colorfulfabric;Colorful Fabric;;
+;5873;colorfulfabric,bismuthlib;BismuthLib / Colorful Fabric;;
 ;5874;betterleaves;Better Leaves;;
 ;5875;bushyleaves;Bushy Leaves;;
 robins-ruby-mod;5876;ruby_mod;Robins Ruby Mod;;
 ;5877;betaloader;BetaLoader;;
 ;5878;pouchofunknown;未知之袋：重置;Pouch of Unknown Reloaded;POU
 just-needed;5879;justneeded;Just Needed;;
-nodami-remake;5880;;伤害免疫机制移除重制版;NoDamIRemake;
+nodami-remake;5880;nodami_remake;伤害免疫机制移除重制版;NoDamIRemake;
 had-enough-items;5881;jei;HEI物品管理器;Had Enough Items;HEI
 worldinfo;5882;world_info;WorldInfo;;
 ;5883;bang;Benchworking Aesthetic Noise Generator;;BANG
@@ -5702,7 +5699,7 @@ gregicprobe;5887;gregicprobe;Gregic Probe;;GP
 travelers-index;5889;travelers_index;Traveler's Index;;
 ;5890;fd;未来装饰;FutureDecoration;FD
 dimension-data-fix;5891;dimension_data_fix;维度数据修复;Dimension Data Fix;
-gtce-bees;5892;gtcebees;GTCE Bees;;
+gtce-bees;5892;gtcebees;GTCE 蜜蜂;GTCE Bees;
 ;5893;IntermediaryMod;Intermediary;;
 ;5894;;Java 8 compatibility patch;;
 armory-expansion-bits-and-pieces;5895;armoryexpansion-bitsandpieces;Armory Expansion - Bits And Pieces;;
@@ -5717,7 +5714,7 @@ tinkers-golems-addon;5903;golems_tcon;Tinkers' Golems Addon;;
 tinkers-addons-fork;5904;TinkersAddons;Tinkers' Addons(Fork) with Mod Support;;
 reagenchant;5905;;Reagenchant;;
 ;5906;extraenchantments;额外附魔;Extra Enchantments;
-sim-u;5907;sim;模拟城市;Sim-U;Sim
+sim-u;5907;sim;模拟城市/模拟大都市;;Sim
 ;5908;copper_and_crystal;铜与晶;Copper And Crystal;CAC
 thorium;5909;thorium;钍;Thorium;Th
 creative-one-punch;5910;creativeonepunch;Creative One-Punch;;
@@ -5727,12 +5724,12 @@ game-stages-conditions;5913;gamestageconditions;Game Stages Conditions;;
 tinkers-construct-tool-leveling-with-random;5914;liketechnikstinkertweaks;Tool Leveling with Random Modifiers;;
 odd-water-mobs;5915;oddwatermobs;Odd Water Mobs;;
 glowsquids-begone;5916;glowsquids-begone;Glowsquids Begone!;;
-theundead;5917;undead,undead_revamp2;THE UNDEAD;;
+theundead;5917;undead,undead_revamp2;THE UNDEAD REVAMPED;;
 framedblocks;5918;framedblocks;框架方块;FramedBlocks;
 nekos-enchanted-books;5919;nebs;Neko's Enchanted Books;;
 istc;5920;istc;我说了算;I Said The Calculation;ISTC
 ;5921;;Fycraft;;
-dracovita-farm-life;5922;farmlife;Dracovita Farm Life;;
+dracovita-farm-life;5922;dracovita-farm-life;Dracovita Farm Life;;
 no-enchant-cap;5923;noenchantcap;No Enchant Cap;;
 ;5924;visions_block_mod;幻象;Visions Blocks;VB
 artisan-automation;5925;artisanautomation;工匠自动化;Artisan Automation;
@@ -5750,7 +5747,7 @@ bettertridentreturn;5936;bettertridentreturn;Better Trident Return;;
 multibeds;5937;multibeds;MultiBeds;;
 enhanced-armaments-reload;5938;enhancedarmaments;增强装备重制版;Enhanced Armaments Reload;
 entangled;5939;entangled;Entangled;;
-;5940;water_is_highly_toxic,wip;水是剧毒的！;;
+;5940;water_is_highly_toxic;水是剧毒的！;;
 createplus;5941;createplus;CreatePlus;;CP
 custom-fluid-mixin;5942;customfluidmixin;Custom Fluid Mixin;;
 slender-reimagined;5943;Slender;Slender – Reimagined;;
@@ -5828,7 +5825,7 @@ too-many-glyphs;6015;toomanyglyphs;Too Many Glyphs;;
 create-cafe;6016;createcafe;机械动力：咖啡馆;Create Cafe;
 ;6017;worldbordercolor;Recolorable World Border;;
 ic2-rpg;6018;ic2rpg;工业RPG;IC2 RPG;
-drop-the-meat;6019;dropthemeat;Drop the Meat;;
+drop-the-meat;6019;dropthemeat;肉多多;Drop the Meat;
 better-invisibility;6020;betterinvisibility;更好的隐身;Better Invisibility;
 tweakerplus;6021;tweakerplus;TweakerPlus;;
 autorun-fabric;6022;autorun;AutoRun(Fabric);;
@@ -5847,7 +5844,7 @@ brewevolution;6034;brewevolution;酿造进化🍺;Brewevolution 🍺;
 devil-fruits;6035;devilfruits;恶魔果实;Devil Fruits;
 ;6036;BetterFonts;BetterFonts Forked by Suzutsuki;;
 trail-mix;6037;trailmix;Trail Mix;;
-multiplayer-server-pause-fabric;6038;serverpause;多人服务器暂停;Multiplayer Server Pause;
+multiplayer-server-pause-forge;6038;serverpause;多人服务器暂停;Multiplayer Server Pause;
 noshelter-reborn;6039;noshelter;无庇护所：重生;NoShelter Reborn;
 initial-spawn-dimension;6040;isd;Initial Spawn Dimension;;ISD
 the-one-probe-fabric;6041;theoneprobe;The One Probe Fabric;;TOPF
@@ -5877,7 +5874,7 @@ croptosis;6064;croptosis;Croptosis;;
 weeping-angels-mod;6065;weeping_angels;Doctor Who - Weeping Angels;;
 hardcore-item-stages;6066;;Hardcore Item Stages;;
 game-stages-viewer;6067;gamestagesviewer;Game Stages Viewer;;
-mpm-lotr;6068;mpmLotr;MPM LOTR;;
+mpm-lotr;6068;mpmLotr;更多玩家模型：魔戒兼容;MPM LOTR;
 guard-villagers-fabric;6069;guardvillagers;警卫村民Fabric版;Guard Villagers (Fabric);
 ;6070;server_cmd;服务器指令;Server Cmd;
 item-highlighter;6071;highlighter;物品高亮;Item Highlighter;
@@ -5945,10 +5942,10 @@ just-the-binding-of-isaac-pills;6132;just_the_binding_of_isaac_pills;Just the bi
 pendant-of-life;6133;jmilpol;Pendant of Life;;
 the-binding-of-isaac-tears-mod;6134;thebindingofisaactears;The binding of Isaac Tears Mod;;
 humbling-bundle;6135;humblingbundle;慈善捆绑包;Humbling Bundle;
-grindstone-sharper-tools-fabric;6136;grindstonesharpertools;Grindstone Sharper Tools;;
+grindstone-sharper-tools;6136;grindstonesharpertools;Grindstone Sharper Tools;;
 nutritious-milk;6137;nutritiousmilk;Nutritious Milk;;
 extract-poison;6138;extractpoison;Extract Poison;;
-zombie-villagers-from-spawner-fabric;6139;zombievillagersfromspawner;Zombie Villagers from Spawner;;
+zombie-villagers-from-spawner;6139;zombievillagersfromspawner;Zombie Villagers from Spawner;;
 vine-climber;6140;vineclimber;Vine Climber;;
 healing-soup;6141;healingsoup;Healing Soup;;
 idas;6142;idas;地牢建筑统合;Integrated Dungeons and Structures;IDAS
@@ -5967,10 +5964,10 @@ alwayseat-reload;6154;;吃不停重制版;AlwaysEat Reload;AER
 ;6155;herobrinemod;The Herobrine Mod;;
 tps-hud-fabric;6156;tpshud;TPS Hud;;
 ;6157;thaumic_tinkerer_lite;神秘工匠精简版;Thaumic Tinkerer Lite;TTL
-orcz;6158;;Vanilla Expanded - Orcz;;
+orcz;6158;orcz;Vanilla Expanded - Orcz;;
 sandwichable;6159;sandwichable;Sandwichable;;
 ;6160;shelve;Shelve Refabricated;;
-mod-erate-loading-screen;6161;moderate-loading-screen;Mod erate Loading Screen;;
+mod-erate-loading-screen;6161;moderate-loading-screen;Mod-erate Loading Screen;;
 shrink_;6162;shrink;Shrink;;
 cable-tiers;6163;cabletiers;Cable Tiers;;
 jumbo-furnace;6164;jumbofurnace;Jumbo Furnace;;
@@ -5978,7 +5975,7 @@ no-villager-death-messages;6165;novillagerdm;No Villager Death Messages;;
 tank-null;6166;tanknull;/tank/null;;
 trajans-tanks-forge;6167;trajanstanks;Trajan's Tanks;;
 colds-easy-paxel-lite;6168;easypaxellite;Colds: Easy Paxel;;
-;6169;sei;SEI物品管理器;Surely Enough Items;SEI
+;6169;sei;SEI 物品管理器;Surely Enough Items;SEI
 smooth-chunk-save;6170;smoothchunk;平滑区块保存;Smooth Chunk Save;
 rigoranthus-emortis;6171;rigoranthusemortisreborn;Rigoranthus Emortis Reborn;;
 jei-utilities;6172;jeiutilities;JEI实用设备;JEI Utilities;JEIU
@@ -6029,7 +6026,7 @@ atm-additions;6216;atmadditions;ATM: Additions;;
 extra-tags;6217;extratags;额外标签;Extra Tags;
 advancedchatlog;6218;advancedchatlog;AdvancedChatLog;;
 crafting-station;6219;craftingstation;合成站;Crafting Station;
-sons-of-sins;6220;sons_of_sins;Sons Of Sins;;
+sons-of-sins;6220;sons_of_sins;七罪之子;Sons Of Sins;
 advancedchathud;6221;advancedchathud;AdvancedChatHUD;;
 fuzes-relics;6222;fuze_relics;Fuze's Relics;;
 chirpys-wildlife;6223;wildlife;Chirpy's Wildlife;;
@@ -6039,15 +6036,15 @@ village-box;6226;villagebox;村庄盒子;Village Box;VB
 waila-stages;6227;wailastages;Waila Stages;;
 steves-vanilla;6228;steves_vanilla;Steve's Vanilla;;
 duckling;6230;duckling;Duckling;;
-wandering-bag;6231;wandering_bag;Wandering Bag;;
+wandering-bag;6231;wandering_bag;Wandering Bags;;
 friends-and-foes-forge;6232;friendsandfoes;Friends & Foes;;
 dynamic-trees-the-betweenlands;6233;dynamictreestbl;动态的树：交错次元附属;Dynamic Trees - The Betweenlands;
 ;6234;gilded;装备镶金;Gilded;
 pyrologer-and-friends;6235;pyrologernfriends;Pyrologer And Friends;;
 tree-hollows;6236;treehollows,tree-hollows;树洞;Tree Hollows;
 solar-apocalypse-refabricated;6237;solar_apocalypse;Solar Apocalypse;;
-;6238;icommon;iCommon;;
-chunky-pregenerator-forge;6239;chunky;预生成区块;Chunky;
+icommonlib;6238;icommon;iCommon;;
+chunky-pregenerator;6239;chunky;预生成区块;Chunky;
 beast-slayer;6240;ancientbeasts;上古凶灵/远古野兽;Ancient Beasts/Beast Slayer;
 easyauth;6241;easyauth;EasyAuth;;
 depth;6242;depth;Depth : Hidden World;;
@@ -6064,12 +6061,12 @@ jumpy-boats;6252;jumpboat;Jumpy Boats;;
 ;6253;pasterdream_beta;帕斯特之梦 旧版;PasterDream beta;
 carpetclient;6254;carpetclient;CarpetClient;;
 ;6255;kamenridertime;假面骑士时刻;Kamen Rider Time;KRT
-dynamic-trees-vampirism;6256;;动态的树：吸血鬼附属;Dynamic Trees - Vampirism;
+dynamic-trees-vampirism;6256;dtvampirism;动态的树：吸血鬼附属;Dynamic Trees - Vampirism;
 transcend;6257;transcend;超越;Transcend;Tr
 ;6258;cleanwater;Clean up The Water;;CTW
 connectible-chains;6259;connectiblechains;Connectible Chains;;
 ;6260;shiny_netherite;原版下界合金修改;ShinyNetherite;
-birds-nests-fabric;6261;birdsnests;鸟巢Fabric版;Birds Nests (Fabric);
+birds-nests-fabric;6261;birdsnests;鸟巢 Fabric 版;Birds Nests (Fabric);
 hot-or-not-tfc;6262;hotornot;Hot or Not TFC;;
 eye-of-dragons;6263;eyeofdragons;Eye of Dragons;;
 paperdoll;6264;paperdoll;纸娃娃;PaperDoll;
@@ -6128,16 +6125,16 @@ itemchat;6315;itemchat;ItemChat;;
 resident-evil-8-mod;6317;re8joymod,rejoymod;生化危机8;Resident Evil 8;RE8
 solar-forge;6318;solarcraft,solarforge;Solar Craft;;
 colored-allays;6319;coloredallays;染色悦灵;Colored Allays;
-;6320;;白金之星 TheWorld招式还原;;
+;6320;;白金之星 TheWorld 招式还原;;
 phantasm;6321;phantasm;End's Phantasm;;
 emerald-craft-mod;6322;emeraldcraft;绿宝石工艺;Emerald Craft Mod;EC
 roughly-enough-professions-rep;6323;roughlyenoughprofessions;REI工作方块;Roughly Enough Professions;REP
 sophisticated-core;6324;sophisticatedcore;精妙核心;Sophisticated Core;
-edibles-fabric;6325;374240 / 530648;Edibles;;
+edibles;6325;374240 / 530648;Edibles;;
 reach-fix;6326;reachfix;ReachFix;;
 lootjs-forge;6327;lootjs;LootJS;;
 chat-sounds;6328;chatsounds;Chat Sounds;;
-advancement-screenshot-fabric;6329;advancementscreenshot;Advancement Screenshot;;
+advancement-screenshot;6329;advancementscreenshot;Advancement Screenshot;;
 all-loot-drops;6330;alllootdrops;All Loot Drops;;
 disc-jockey;6331;disc_jockey;Disc Jockey;;
 better-taskbar;6332;bettertaskbar;更好的任务栏;Better Taskbar;
@@ -6149,7 +6146,7 @@ gate-of-babylon;6337;gateofbabylon;王之财宝;Gate of Babylon;
 ;6338;;天境数据包;The Aether Datapack;
 evocation;6339;evocation;Evocation;;
 the-illusioners-cabin;6340;;The Illusioner's Cabin;;
-gw-pillager-outpost;6341;;GW Mods | Pillager Outpost;;
+gw-pillager-outpost;6341;pillageroutpost;GW Mods | Pillager Outpost;;
 mercs-and-menaces;6342;mercsandmenaces;Mercs And Menaces;;
 illage-and-spillage;6343;illageandspillage;Illage and Spillage;;
 more-illagers;6344;;more illagers!!!;;
@@ -6158,19 +6155,19 @@ illager-plushies;6346;illager_plushies;Illager Plushies;;
 pillageplunder;6347;pillageplunder;PillagePlunder;;
 extended-illagers-mod;6348;eim;Extended Illagers Mod;;
 midnightcontrols;6349;midnightcontrols;MidnightControls;;
-wonderful-enchantments;6350;;Majrusz's Enchantments;;
+wonderful-enchantments;6350;majruszsenchantments;Majrusz's Enchantments;;
 a-lot-of-useless-stuff;6351;a_lot_of_useless_stuff;A Lot Of Useless Stuff;;
 lankaster-origins;6352;lank;Lankaster's Origins;;
 ;6353;minc.hfn;隐藏展示框名称;HideFrameName;HFN
 ;6354;eldenmessage;谏言;Elden Message;
 priority-target;6355;prioritytarget;优先目标;Priority Target;PT
-advanced-botany;6356;;Advanced Botany;;AB
+advanced-botany;6356;;高级植物学;Advanced Botany;AB
 charred;6357;charred;Charred;;
 incorporeal-3;6358;;幻想多媒体3;Incorporeal 3;
 ;6359;minc;禁用原版进度与合成配方;Disable Vanilla;DV
 ;6360;oceanite;海洋合金;Oceanite;
 oxygen;6361;Oxygen,oxygen;氧;Oxygen;
-better-combat-revamped;6362;bettercombatmod;沉浸式战斗;Immersive Combat;
+immersive-combat;6362;bettercombatmod;沉浸式战斗;Immersive Combat;
 ;6363;essential-client;EssentialClient;;
 mystical-index;6364;mystical_index;Mystical Index;;
 combat-commons;6365;combat_commons;Combat-Commons;;
@@ -6200,9 +6197,9 @@ dense-ores-reborn;6388;dense;致密矿石：重生;Dense Ores Reborn;
 ;6389;inventoryring;纳戒;Inventory Ring;
 tfctreatedwood;6390;tfctreatedwood;群峦·防腐木;TFC Treated Wood;
 retro64;6391;retro64;Retro64;;
-double-hotbar;6392;;双重快捷栏;Double Hotbar;
+double-hotbar;6392;double_hotbar;双重快捷栏;Double Hotbar;
 lavatech;6393;lavaplus;熔岩科技;Lava Tech;
-;6394;paster_fix,pineapple_psychic;凤梨通灵术;Pineapple Psychic;PPc
+pineapple-psychic;6394;paster_fix,pineapple_psychic;凤梨通灵术;Pineapple Psychic;PPc
 fragile-torches;6395;fragiletorches;Fragile Torches;;
 ;6396;timechanger;Time Changer;;
 come-closer;6397;;Come Closer;;
@@ -6274,13 +6271,13 @@ with-craft;6462;with_fire;手工艺;With Crafts;
 fluidconverters;6463;fluidconverters;流体转化器;FluidConverters;
 multiblock-stages;6464;multiblockstages;MultiBlock Stages;;
 metallurgylegend;6466;metallurgy_legend;冶金传奇;Metallurgy Legend;
-waterskin;6467;;WaterSkin;;
+waterskin;6467;waterskin;WaterSkin;;
 realism-thirst;6468;Thirst;Realism Thirst;;
 dungeons-libraries;6469;dungeons_libraries;Dungeones Libraries;;
 ;6470;easy_gun;简易枪械;Easy Gun;EG
 ;6471;fabricated-forge;Fabricated Legacy Forge;;
-raknetify;6472;raknet-fabric;RaknetFabric;;
-vmp-fabric;6473;vmp-fabric;Very Many Players;;VMP
+raknetify;6472;raknet-fabric;Raknetify;;
+vmp-fabric;6473;vmp-fabric,vmp;Very Many Players;;VMP
 flotage;6474;flotage;漂浮物;Flotage;Flo
 dynamic-trees-for-hungteens-plants-vs-zombies-mod;6475;dtpvz;动态的树：HungTeen的植物大战僵尸附属;Dynamic Trees for PVZ;
 antidrop;6476;antidrop;防丢;AntiDrop;AD
@@ -6339,8 +6336,8 @@ human-companions;6528;humancompanions;Human Companions;;
 odysseyhud;6529;odysseyhud;OdysseyHUD;;
 colorblindness;6530;colorblindness;ColorBlindness;;
 aether-addon;6531;aether_legacy_addon;Aether Continuation;;
-;6532;moonstone,moonstonemod;月之石;MoonStone;
-server-redirect;6534;;ServerRedirect;;
+moonstone;6532;moonstone,moonstonemod;月之石;MoonStone;
+server-redirect;6534;serverredirect;ServerRedirect;;
 city-blocks;6535;cityblocks;City Blocks;;
 useful-hats;6536;usefulhats;Useful Hats;;
 ;6537;panorama_changer;全景图切换器;Panorama Changer;
@@ -6351,7 +6348,7 @@ kitchen-karrot;6541;kitchenkarrot;胡萝卜厨房;Kitchen Karrot;
 servercore;6542;servercore;ServerCore;;
 ivan-carpet-addition;6543;ivan-carpet-addition;Ivan Carpet Addition;;
 food-funk;6544;;Food Funk;;
-wumpleutil;6545;;Wumple Util Library;;
+wumpleutil;6545;wumpleutil;Wumple Util Library;;
 twilight-delight;6546;twilightdelight;暮色乐事;Twilight Delight;
 recruits;6547;recruits;Villager Recruits;;
 the-true-backrooms;6548;the_backrooms;The True Backrooms;;
@@ -6375,7 +6372,7 @@ ae2-fluid-crafting-rework;6565;ae2fc;AE2流体合成套件重置;AE2 Fluid Craft
 ;6566;swordcraft;剑工艺;SwordCraft;SC
 ;6567;;神秘时代4：重制版;Fabric Thaumcraft Rewrited;
 moreculling;6568;moreculling;More Culling;;
-better-village-forge;6569;bettervillage;更好的村庄;Better Village;
+better-village-forge;6569;bettervillage;更好的村庄;Better Villages;
 trinkets-curios-theme;6570;trinkets-curios-theme;Trinkets Curios Theme;;
 banilla-claws-forge;6571;vanilla_claws;Banilla Claws/Vanilla Claws;;
 ;6572;chinese_charactoers_survival;汉字生存;Chinese Characters Survival;CCS
@@ -6384,10 +6381,10 @@ more-geodes-reforged;6574;geodes;More Geodes;;
 right-click-get-crops;6575;right_click_get_crops;Right Click, Get Crops;;
 oh-my-gourd;6576;omgourd;Oh My Gourd;;
 better-block-sounds;6577;bbs;Better Block Sound;;BBS
-;6578;CiYuanAntiCheat;次元反作弊;CiyuanAntiCheat;CY
+;6578;DimensionAntiCheat;次元反作弊;DimensionAntiCheat;DAC
 v0ids-smart-backpacks;6579;v0idssmartbackpacks;V0id的智能背包;V0id's Smart Backpacks;
 ;6580;more_lens;更多魔力透镜;More Lens;
-winterly;6581;winterly;Winterly;;
+winterly;6581;winterly;银装素裹;Winterly;
 forgetmechunk;6582;forgetmechunk;ForgetMeChunk;;
 ;6583;moremusic;More Music;;
 ;6584;mobgrows;怪物成长;MobGrows;
@@ -6396,7 +6393,7 @@ removehudbutnothand;6586;removehudbutnothand;RemoveHUDbutNotHand;;
 tool-part-stages;6587;toolpartstage;Tool Part Stages;;
 ;6588;;简单的RPG属性加点;;ERPG
 iron-backpacks-redone;6589;ironbackpacksredone;特殊背包重做版;Iron Backpacks Redone;
-b0bgarys-biome-remover-v-1-0-0-1;6590;;B0bGary的生物群系禁用器;B0bGary's Biome Remover;
+b0bgarys-biome-remover-v-1-0-0-1;6590;BiomeRemove;B0bGary的生物群系禁用器;B0bGary's Biome Remover;
 dualwielding;6591;dualwielding;双持;DualWielding;
 malum-quilt;6592;malum;Malum (Quilt);;
 memoryleakfix;6593;memoryleakfix;内存泄漏修复;Memory Leak Fix;
@@ -6408,7 +6405,7 @@ language-reload;6596;languagereload;Language Reload;;
 ;6599;block-entity-extended-rendering;Block Entity Extended Rendering;;BEER
 sound-categories;6600;soundcategories;Sound Categories;;
 ;6601;unsuspicious-stew;Unsuspicious Stew (Reloaded);;
-;6602;preventer;Preventer;;
+preventer;6602;preventer;Preventer;;
 ;6603;wpit;Whose Pet Is That?;;WPIT
 starflight-innovation;6604;space;Starflight Innovation;;
 powah-rearchitected;6605;powah;Powah! Rearchitected;;
@@ -6434,7 +6431,7 @@ zoomify;6624;zoomify;Zoomify;;
 golemania;6625;golemania;Golemania;;
 vulkanmod;6626;vulkanmod;VulkanMod;;
 sledgehammer;6627;sledgehammer;Sledgehammer;;
-quilt-loading-screen;6628;quilt_loading_screen,quilt-loading-screen;Quilt加载画面;Quilt Loading Screen;
+quilt-loading-screen;6628;quilt_loading_screen,quilt-loading-screen;Quilt 加载画面;Quilt Loading Screen;
 amethyst-imbuement;6629;amethyst_imbuement;紫晶魔艺;Amethyst Imbuement;AI
 emi;6630;emi;EMI;;
 nuclear-contraptions;6631;nuclear_contraptions;Nuclear Contraptions;;
@@ -6444,7 +6441,7 @@ tooltiptweaks;6633;tooltiptweaks;Tooltip Tweaks;;
 more-babies;6635;more_babies;More Babies;;
 ;6636;save-my-bed;Save My Bed!;;
 ;6637;datareload;Data Reload;;
-winver;6638;winver;winver.jar;;
+winver;6638;winver;Winver;;
 armor-visibility;6639;armor_visibility,armour_visibility;Armor Visibility;;
 ;6640;;电摇嘲讽;GrooveBattle;GB
 the-chicken-came-first;6641;tccf;先有鸡;The Chicken Came First;
@@ -6460,7 +6457,7 @@ fishy-delight-a-farmers-delight-add-on;6651;fishy_delight;Bettas Delight;;
 simple-delights;6652;simpledelights;Simple Delights;;
 color-me-outlines;6653;colormeoutlines;为轮廓上色;Color Me Outlines;
 nbttooltips;6654;nbttooltips;NBTtooltips;;
-;6655;mi;无象接口;MirageInterface;MI
+;6655;mi;无相接口;MirageInterface;MI
 upstream;6656;upstream;Upstream;;
 astemirs-fireflies;6657;firefliesmod;Astemir's Fireflies;;
 ;6658;cabrically;Cabrically;;
@@ -6472,9 +6469,9 @@ attained-drops-2;6664;attained_drops;可种植掉落物2;Attained Drops 2;
 ;6665;;多世界优先加载优化;;
 auth-me;6666;authme;Auth Me;;
 refinedcreativeinventory;6667;refinedcreativeinventory;创造模式物品栏重制;RefinedCreativeInventory;RCI
-;6668;;XRay;;
-runesword;6669;;Runesword;;
-;6670;jsblock;Joban Client Mod;;JCM
+;6668;XRayTweaker;XRay;;
+runesword;6669;runesword;Runesword;;
+;6670;jsblock;常磐装饰;Joban Client Mod;JCM
 autopackager;6671;autopackager;AutoPackager;;
 dynamx;6672;dynamxmod;DynamX;;
 mob-cards;6673;mob_cards;Mob Cards;;
@@ -6484,7 +6481,7 @@ hidden-names;6676;hiddennames;隐藏名称;Hidden Names;
 doph;6677;doph;远程命中提示;Ding On Projectile Hit;Doph
 keybinds;6678;keybindsgalore;Keybinds Galore;;
 hat-list;6679;hatlist;Hat List;;
-;6680;nmuk;No More Useless Keys;;NMUK
+nmuk;6680;nmuk;No More Useless Keys;;NMUK
 raven-brews-core;6681;ravenbrewscore;Raven Brews Core;;
 raven-coffee;6682;ravencoffee;Raven咖啡;Raven Coffee;
 cqc;6683;;CQC;;
@@ -6505,7 +6502,7 @@ modularmovements;6697;modularmovements;模块化动作;ModularMovements;MWFT
 uncle-js;6698;;Uncle J's;;
 wither-bones;6699;wither_bones;凋灵之骨;Wither Bones;
 sleep-warp;6700;sleepwarp;SleepWarp;;
-diagonal-fences;6701;diagonalfences;Diagonal Fences;;
+diagonal-fences;6701;diagonalfences;Diagonal Fences;;DF
 jumpy-boats-fabric;6702;jumpyboat;跳跃的船（Fabric/Quilt）;Jumpy Boats(Fabric/Quilt);
 dyeable-redstone-signal;6703;dyeable_redstone_signal;染色红石信号;Dyeable Redstone Signal;DRS
 velocity-based-damage;6704;veldmg;Velocity Based Damage;;
@@ -6527,20 +6524,20 @@ luckytnt;6719;luckytntmod;Lucky TNT;;
 gamma-utils;6720;gammautils;伽玛工具;Gamma Utils;
 pickle-tweaks;6721;pickletweaks;Pickle Tweaks;;
 dps-chaoscraft;6722;;DP's Chaoscraft;;
-;6723;computercraft;CC: Restitched with Polymer;;
+;6723;cc-tweaked-polymer-patch;Polymer Patch for CC: Tweaked;;
 moyai;6724;moyai;Moyai;;
 mega-meteors-mod;6725;megameteors;Mega Meteors;;
 gravity-generator;6726;gravity_generator;重力发电机;GravityGenerator;GG
 ;6727;mcmouser;McMouser;;
 mixinbootstraplegacy;6728;;MixinBootstrapLegacy;;
-freecam;6729;freecam;FreeCam;;
+freecam;6729;freecam;FreeCam by kapiteon;;
 ;6730;atomess;基石-基础;Atom-Essentials;
 animationrecorder;6731;animt;动图记录;AnimationRecorder;AnR
 ingame-biome-map-exporter;6732;ingame_biome_map;群系地图一键导出;Ingame Biome Map;IBM
 fishing-overhaul;6733;fishingoverhaul;Fishing Overhaul;;
 kronhud;6734;kronhud;KronHUD;;
 shared-ender-chest;6735;sharedechest;共享末影箱;Shared Ender Chest;
-no-beacon-beams;6736;;无信标光柱;No Beacon Beams;
+no-beacon-beams;6736;nobeam;无信标光柱;No Beacon Beams;
 farmers-respite;6737;farmersrespite;农夫暇事;Farmer's Respite;
 ;6738;fabricaeexnihilo;Fabricae Ex Nihilo;;FEN
 crafting-mania;6739;crafting_mania;Crafting Mania;;
@@ -6548,17 +6545,17 @@ loot-goblins;6740;lootgoblins;Loot Goblins;;
 skylib;6741;skylorlib;SkyLib;;
 dt3;6742;dontstarve3;不要饿死3;DontStarve3;DT3
 tbscclick;6743;tbscclick;TbscClick;;
-modern-elevators-and-escalators;6744;;现代电梯与扶梯;Modern Elevators and Escalators;
+modern-elevators-and-escalators;6744;;现代电梯与扶梯;Modern Elevators and Escalators;MEAE
 ;6745;traveller_music;腊小粥的音乐;Traveller's music;LTM
 extra-inventory;6746;extrainv;Extra Inventory;;
-chroma-concrete;6747;;Chromatic Blocks;;
+chroma-concrete;6747;chromaconcrete;Chromatic Blocks;;
 dracovita-delight-a-farmers-delight-add-on;6748;dracovitadelight;Dracovita Delight;;
 gobber-delight-a-farmers-delight-add-on;6749;gobberdelight;戈伯乐事;Gobber Delight;
 ;6750;qiq2i,qiq2i_clga1;时间追逐生存挑战;;
 ;6751;bathappymod;🦇蝙蝠快乐 Fabric;🦇 Bat Happy Mod Fabric;
 extinguish-by-uss_shenzhou;6752;extinguish;灭;Extinguish;
 biome-makeover-forge;6753;biomemakeover;生物群系改造;Biome Makeover;
-throwable-blocks;6754;;Throwable Blocks;;
+throwable-blocks;6754;throwableblocks;Throwable Blocks;;
 ancient-warfare-3;6755;AncientWarfare;古代战争3;Ancient Warfare 3;
 no-chat-reports;6756;nochatreports;禁用聊天举报;No Chat Reports;NCR
 valleycraft;6757;valleycraft;ValleyCraft;;
@@ -6571,17 +6568,17 @@ more-useful-villagers;6762;more_useful_villagers;More Useful Villagers;;
 ;6764;symbol-chat;Symbol Chat;;
 ;6765;forcegl20;ForceGL20;;
 hyle;6766;hyle;Hyle;;
-;6767;;itemdash;;
+;6767;ItemDash;ItemDash;;
 advanced-solar-panels-patcher;6768;advsolarpatch;Advanced Solar Panels Patcher;;
 no-recipe-book-reborn;6769;norecipebookreborn;没有配方书重制版;No Recipe Book Reborn;
-;6770;;Paxels;;
+;6770;paxels_mr;Paxels;;
 ;6771;dreamland;梦幻幽境;Dreamland;DLAND
 shulker-tooltip;6772;shulkertooltip;Shulker Tooltip;;
-;6773;;DynamicMappings;;
-;6774;;Meddle;;
-;6775;;Meddle API;;
+;6773;dynamicmappings;DynamicMappings;;
+;6774;meddle,Meddle;Meddle;;
+;6775;meddleapi;Meddle API;;
 midnightlib;6776;midnightlib;MidnightLib;;
-;6777;AllTheItems;All The Items;;
+;6777;AllTheItems,alltheitems;All The Items;;
 just-backpacks;6778;fyberbackpack;Just Backpack;;
 doubledoors;6779;DoubleDoorsMod;DoubleDoors;;
 ;6780;mod-remapping-api;Mod Remapping API;;
@@ -6610,9 +6607,9 @@ ez-mod-lib;6802;ezmodlib;Ez Mod Lib;;
 armor-toughness-bar-updated;6803;;Armor Toughness Bar (Ported);;
 colorful-health-bar-updated;6804;;Colorful Health Bar (Updated);;
 ;6805;;Bone Sword BTA;;
-wizardry-necromancers-delight;6806;;Wizardry - Necromancer's Delight;;
+wizardry-necromancers-delight;6806;necromancersdelight;Wizardry - Necromancer's Delight;;
 wizardryutils;6807;wizardryutils;WizardryUtils;;
-xp-orb-clump;6808;;XP Orb Clump;;
+xp-orb-clump;6808;xporbclump;Fixeroo;;
 inventory-weight;6809;;Inventory Weight;;
 time-reverse;6810;;Time Reverse;;
 nether-tears;6811;ntrs;下界遗泪;NetherTears;Ntrs
@@ -6633,16 +6630,16 @@ arte-magicum;6825;arte_magicum;Arte Magicum;;
 ocean-blender;6827;oceanblender;海洋搅拌机;OceanBlender;OB
 buildcraft-fluxified;6828;buildcraftfluxified;Buildcraft Fluxified;;
 brewin-and-chewin;6829;brewinandchewin;饮酒作乐;Brewin' And Chewin';
-infinite-source-of-water;6830;;Infinite source of water;;
+infinite-source-of-water;6830;watersources;Infinite source of water;;
 dramatic-doors;6831;dramaticdoors;Dramatic Doors;;DD
-recipe-gui;6832;;Recipe GUI/CraftTweaker GUI;;
-;6833;;AutoTechno;;
+recipe-gui;6832;recipe_gui;Recipe GUI / CraftTweaker GUI;;
+;6833;autotechno;AutoTechno;;
 villager-hats-mod;6834;villager-hats;Villager Hats;;
 custom-damage-particles;6835;torohealthmod;自定义伤害粒子;Custom Damage Particles;
 ;6836;;AEI物品管理器;Always Enough Items;AEI
 cyan-warrior-swords-mod;6837;cwsr;Cyan Warrior Swords;;
 plant-in-a-jar;6838;plantinajar;Plant In A Jar;;
-solid-mobs;6839;;Solid Mobs;;
+solid-mobs;6839;solid_mobs;Solid Mobs;;
 naturalist;6840;naturalist;自然主义;Naturalist;
 c3h6n6o6;6841;c3h6n6o6;环三亚甲基三硝胺;Cyclotrimethylenetrinitramine;C3H6N6O6
 syncmatica;6842;syncmatica;共享原理图;Syncmatica;
@@ -6658,7 +6655,7 @@ short-stacks;6851;;Short Stacks;;
 smooth-boot-reloaded;6852;smoothboot;流畅加载重置版;Smooth Boot Reloaded;
 stone-crafting-table;6853;;Stone Crafting Table;;
 lodestonelib;6854;ortus;Lodestone Lib;;
-witherturnsskeletons;6855;;WitherTurnsSkeletons;;
+witherturnsskeletons;6855;witherturnsskeletons;WitherTurnsSkeletons;;
 twilight-forest-the-lost-blocks;6856;tflostblocks;Twilight Forest: The Lost Blocks;;
 the-nexus-deep-dark-dimension;6857;thenexus;The Nexus;;
 jepp;6858;jepp;JEI绘画预览;Just Enough Painting Previews;JEPP
@@ -6683,7 +6680,7 @@ create-chromaticreturn;6877;createsupercharged;Create Chromatic Return;;
 powertool;6878;powertool;电动工具;PowerTool;
 keymap;6879;keymap;键盘映射;Keymap;
 actually-useful-stonecutter;6880;mandatory;Actually Useful Stonecutter;;
-itemphysic-lite-fabric;6881;itemphysiclite;ItemPhysic Lite - Fabric;;
+itemphysic-lite-fabric;6881;itemphysiclite;物品物理掉落：轻量版 - Fabric;ItemPhysic Lite - Fabric;
 forgotten-treasures;6882;forgottentreasures,forgotten_treasures;Forgotten Treasures;;
 player-health-indicators;6883;healthindicators;Player Health Indicators;;
 displaycase;6884;display_case;陈列柜;Display Case;
@@ -6692,7 +6689,7 @@ grimoire-of-gaia;6886;grimoireofgaia;盖亚魔典4;Grimoire of Gaia 4;GOG4
 ftb-jar-mod-forge;6887;ftbjarmod;FTB Jar Mod;;
 dimensional-paintings;6888;dimpaintings;维度绘画;Dimensional Paintings;
 item-recycler;6889;itemcollectors;Item Recycler;;
-linsapi;6890;;LinsAPI;;
+linsapi;6890;linsapi;LinsAPI;;
 titlechanger;6891;;标题切换器;TitleChanger;
 adobe-blocks-2;6892;adobeblocks;Adob​​e Blocks 2;;
 menacing-monsters;6893;menacing_monsters;Menacing Monsters;;
@@ -6716,7 +6713,7 @@ aof-emotes;6910;aofemotes;AOF Emotes;;
 grasslessdirtbackport;6911;grasslessdirtbackport;GrasslessDirtBackport;;
 dazzle-2;6912;dazzle;Dazzle 2;;
 smaller-nether-portals;6913;smallernetherportals,smallernp,smallernetherportals-fabric;Smaller Nether Portals;;
-basic-aiots;6914;;Basic AIOTs;;
+basic-aiots;6914;basicaiots;Basic AIOTs;;
 pokeball;6915;pokeball;精灵球;PokeBall;
 ;6916;GoodGenerator;GoodGenerator;;
 gravitychanger;6917;gravitychanger;Gravity Changer;;
@@ -6726,9 +6723,9 @@ aiots-expanded-fabric;6920;aiotexpanded;AIOTs Expanded;;
 moremcmeta;6921;moremcmeta;MoreMcmeta;;
 starry-skies;6922;starry_sky;Starry Skies;;
 flesh2leather-forge;6923;flesh2leather;Flesh 2 Leather;;
-fall-damage-indicator;6924;;Fall Damage Indicator;;
+fall-damage-indicator;6924;fdi;Fall Damage Indicator;;
 aww-man-achievement-mod;6925;awwman;Aww Man Achievement Mod;;
-fire-extinguisher;6926;fire_extinguisher;Fire Extinguisher;;
+fire-extinguisher;6926;fire_extinguisher;灭火器;Fire Extinguisher;
 farmers-knives;6927;farmersknives;Farmer's Knives;;
 sullys-mod;6928;sullysmod;Sully's Mod;;
 magicaldecorations;6929;mdeco;MagicalDecorations;;
@@ -6760,12 +6757,12 @@ better-bad-omen;6954;better_bad_omen;Better Bad Omen;;
 can-you-trash-it;6955;cyti;Can You Trash It?;;cyti
 croptopias-chocolaterie-forge;6956;cacao;作物盛景：巧克力工坊;Croptopia's Chocolaterie;
 crawl;6957;crawl;Crawl;;
-fabric-chisel;6958;chisel;Chisel Refabricated / Chisel Reborn;;
+fabric-chisel;6958;chisel;Chisel Reborn;;
 roost-ultimate;6959;chicken_roost;Roost Ultimate;;
 cammies-wearable-backpacks;6960;camsbackpacks;Cammie's Wearable Backpacks;;
 ;6961;;Midas Hunger;;
 parrying;6962;parrying;Parry This!;;
-back-in-slime-slime-blocks-for-1-7;6963;;Back in Slime;;
+back-in-slime-slime-blocks-for-1-7;6963;bis;Back in Slime;;
 ;6964;;Modern Furniture;;
 create-alloyed;6965;alloyed;机械动力：合金;Create: Alloyed;
 verdure;6966;verdure;郁郁葱葱;Verdure;
@@ -6784,10 +6781,10 @@ be-quiet-please;6978;bequietpls;请安静;Be Quiet Please;BQP
 prehistoric-revival-a-prehistoric-fauna-add-on;6979;prehistoric_revival;史前复生;Prehistoric Revival;
 had-enough-characters;6980;hecharacters;Had Enough Characters;;HECh
 medieval-origins;6981;medievalorigins;Medieval Origins;;
-;6982;;Better Trades;;
-;6983;;Sonic Bug Fix;;
+better-trades-addon;6982;;Better Trades;;
+;6983;;Block-Geo Fixer / Sonic Bug Fix;;
 elytra-chestplate-swapper;6984;ecs;Elytra/Chestplate Swapper;;ECS
-;6985;ends_flora;The End's Flora🌻;;
+the-ends-flora;6985;ends_flora;The End's Flora🌻;;
 apollos-additional-structures;6986;apollo;Apollo's Additional Structures;;
 ;6987;test-utils;test-utils;;
 chimes;6988;chimes;Chimes;;
@@ -6861,20 +6858,20 @@ endlessids;7056;endlessids;EndlessIDs;;
 ;7058;compactmachines;压缩空间 Fabric;Compact Machines - Fabric;
 cycle-paintings;7059;cyclepaintings;Cycle Paintings;;
 ;7060;nbtreader;NBT 检视者;NBT Reader;NR
-fire-spread-tweaks;7061;;Fire Spread Tweaks;;
+fire-spread-tweaks;7061;firespreadtweaks;Fire Spread Tweaks;;
 anger-management;7062;angermanagement;Anger Management;;
-easy-elytra-takeoff;7063;;Easy Elytra Takeoff;;
-stack-refill;7064;collective,stackrefill;Stack Refill;;
+easy-elytra-takeoff;7063;easyelytratakeoff;Easy Elytra Takeoff;;
+stack-refill;7064;stackrefill;Stack Refill;;
 light-meals;7065;lightmeals;轻食物语;Light Meals;
 lost-and-fished;7066;lost_found;失而钓得;Lost and Fished;
 custom-backgrounds;7067;custombackgrounds;Custom Backgrounds;;CB
 ydms-allay;7068;;YDM的悦灵;YDM's Allay;
-starmaker;7069;;StarMaker;;
+starmaker;7069;starmaker;StarMaker;;
 ;7070;swdheftpywaed;对不起，我们没有充足的资金为您提供一只末影龙;Sorry We Don't Have Enough Funds To Provide You With An Ender Dragon;SWDHEFTPYWAED
 simply-snow;7071;simplysnow;Simply Snow;;
 areas;7072;areas;Areas;;
 emberroot-zoo;7073;emberroot;EmberRoot Zoo;;
-mctimeextendsfabric;7074;;MCTimeExtendsFabric;;
+mctimeextendsfabric;7074;mctimeex;MCTimeExtendsFabric;;
 l2library;7075;l2library;L2 Library;;
 unstructured;7076;unstructured;Unstructured;;
 colorful-cut;7077;colorfulcut;Colorful Cut;;
@@ -6892,7 +6889,7 @@ twigs;7088;twigs;Twigs;;
 ;7090;exp1182;魔城传说·火了;Majou Burns Red;
 ;7091;bobs_better_nausea;Bob氩的更好反胃;Bob's Better Nausea;BBN
 ;7092;Baubles;指环王;Baubles Rebuild;
-;7093;falsepatternlib;FalsePatternLib;;
+fplib;7093;falsepatternlib;FalsePatternLib;;
 spongemixins;7094;spongemixins;SpongeMixins;;
 nock-enough-arrows;7095;nock_enough_arrows;Nock Enough Arrows;;
 every-compat;7096;everycomp;泛用兼容：木材;Every Compat: Wood Good;EC
@@ -6912,14 +6909,14 @@ sketchbook-attributes;7109;sketchbookattributes;SketchBook Attributes;;
 better-combat-by-daedelus;7110;bettercombat;Better Combat;;
 custom-stars;7111;customstars;Custom Stars;;
 ;7112;;电梯;Lift;L
-ice-and-fire-tweaker;7113;;Ice And Fire Tweaker;;
+ice-and-fire-tweaker;7113;iceandfiretweaker;Ice And Fire Tweaker;;
 soaring-clouds;7114;soaring-clouds;Soaring Clouds;;
 lapis-stays-in-the-enchanting-table;7115;csb_ench_table;Lapis Stays in the Enchanting Table;;
 goodall;7116;goodall;Goodall;;
 freecam-by-zergatul;7117;freecam;FreeCam;;
 ;7118;pyrotechnicraft;烟火工艺;Pyrotechnicraft;
 macaws-bridges-oh-the-biomes-youll-go;7119;macawsbridgesbyg;Macaw的桥梁：你将去的生物群系附属;Macaw's Bridges - Oh The Biomes You'll Go;
-macaws-fences-oh-the-biomes-youll-go;7120;;Macaw的栅栏与墙：你将去的生物群系附属;Macaw's Fences - Oh The Biomes You'll Go;
+macaws-fences-oh-the-biomes-youll-go;7120;mcwfencesbyg;Macaw的栅栏与墙：你将去的生物群系附属;Macaw's Fences - Oh The Biomes You'll Go;
 alternate-current;7121;alternate_current;Alternate Current;;
 no-unused-chunks;7122;nounusedchunks;No Unused Chunks;;
 no-fade;7123;nofade;No Fade;;
@@ -6931,7 +6928,7 @@ l2-artifacts;7128;l2artifacts;莱特兰-古遗物;L2 Artifacts;
 critters-and-companions;7129;crittersandcompanions;Critters and Companions;;
 memorytester;7130;memorytester;MemoryTester;;
 colormatic;7131;colormatic;Colormatic;;
-;7132;reign;王权;reign;
+;7132;reign;王权;Reign;
 fogbox;7133;fogbox;Fogbox;;
 ;7134;hopper;Hopper;;
 lots-of-shields;7135;lots_of_shields;Lots of Shields;;
@@ -6961,14 +6958,14 @@ apex-guns;7157;apexguns;Apex 枪械工艺;Apex Guns;
 ;7159;rtorch;减速火把;RetardTorch;RT
 hwyla-addon-horse-info;7160;horseinfo;Hwyla Addon Horse Info;;
 postal-pigeons;7161;postalpigeons;PostalPigeons;;
-swagoween;7162;;Swagoween;;
+swagoween;7162;swagoween;Swagoween;;
 no-lag-tickratechanger;7163;trc-no-lag;No Lag Tick Rate Changer;;
 alcocraft-beer-and-stuff;7164;alcocraft;Alcocraft: Beer & Stuff;;
 simplevillagers;7165;simplevillagers;SimpleVillagers;;
-;7166;;另一款可视化合成表修改;Another Magic Recipe;
+;7166;anothermagicrecipe;另一款可视化合成表修改;Another Magic Recipe;
 autoreconnect;7167;autoreconnect;AutoReconnect;;
 ;7168;better_combat;更好的战斗;Better Combat;
-dusk;7169;;Dusk;;
+dusk;7169;dusk;Dusk;;
 copper-craft;7170;coppercraft;铜制工艺;Copper Craft;
 extrabotany2;7171;extrabotany;额外植物学重置版;ExtraBotany2;EXBOT
 terramine;7172;terramine;TerraMine;;
@@ -6979,7 +6976,7 @@ more-frogs-fabric;7175;morefrogs;更多青蛙;More Frogs;
 ;7177;the_blue_skies_delight,blue_skies_delight;蔚蓝乐事;Blue Skies Delight;
 create-big-cannons;7178;createbigcannons;机械动力：火炮;Create Big Cannons;CBC
 fastanim;7179;faster_entity_animations;FastAnim;;
-rubidium-extra;7180;sodiumextra,rubidium_extra;铷 · 扩展;Embeddium (Rubidium) Extra;
+rubidium-extra;7180;sodiumextra,rubidium_extra,embeddium_extra;铷 · 扩展;Embeddium (Rubidium) Extra;
 less-feature;7181;lessfeatures;更少的特性;Less Features;
 mores-forge;7182;mores;More Ore Stones;;
 tactical-fishing;7183;tactical_fishing;Tactical Fishing;;
@@ -6989,7 +6986,7 @@ igiexteneded;7185;igiextended;IGI 信息扩展;IGIExteneded;IGIE
 landofsignals;7187;landofsignals;LandOfSignals;;
 lootbeams;7188;lootbeams;lootbeams;;
 ;7189;protector;存档保护器;Protector;
-stepupnext;7190;stepup;StepUpNext;;
+stepupnext;7190;stepup;StepUpNext / StepUp;;
 simple-bbq;7191;simplebbq;简易烧烤;Simple BBQ;
 mythic-mounts-forge;7192;mythicmounts;Mythic Mounts;;
 spice-of-life-sweet-potato-edition;7193;solsweetpotato;生活调味料：红薯版;Spice of Life: Sweet Potato Edition;
@@ -7009,7 +7006,7 @@ ender-logistics;7206;ender_logistics;末影物流;Ender Logistics;EL
 ;7209;quick_fix_iron_golem;快速修复铁傀儡;Quick Fix Iron Golem;
 megaplanets;7210;;MegaPlanets;;
 cosmic-horizons-gc-addon;7211;;Cosmic Horizon;;
-ultris-boss-expansion;7212;splatus_ultris;Ultris: Boss Expansion;;
+ultris-boss-expansion;7212;splatus_ultris,ultris_mr;Ultris: Boss Expansion;;
 bedfix;7213;bedfix;BedFix;;
 mo-glass;7214;mo_glass;Mo Glass;;
 flans-mod-global-firestorm;7215;GFS;Global Firestorm;;GFS
@@ -7054,7 +7051,7 @@ configuration;7253;configuration;Configuration;;
 ;7255;homekit;居家套件;HomeKit furniture;
 natural-decoration;7256;natural_decoration;Natural Decoration;;
 spice-of-fabric;7257;spiceoffabric;Spice of Fabric;;
-better-climbing;7258;better_climbing;Better Climbing;;
+better-climbing;7258;better_climbing;更好的攀爬;Better Climbing;
 dog-yeeter;7259;;Dog Yeeter;;
 mc122477fix;7260;mc122477fix;Mc122477Fix;;
 armors-hud-revived-liteloader-only;7261;ArmorsHUDRevived;Armors HUD Revived;;
@@ -7070,14 +7067,14 @@ bancis-enchantments;7269;;Banci's Enchantments;;
 ;7271;potionofbadomen;不祥之兆药水;;POBO
 ;7272;vanilla_craft_enhanced;原版合成增强;Vanilla Craft Enhanced;VCE
 skylands-fabric;7273;skylands;Skylands;;
-jjthunder-overhauled-world-generation;7274;jjthunder;JJThunder King of the Hills/Terrathunder;;
+jjthunder-overhauled-world-generation;7274;jjthunder;JJThunder King of the Hills / Terrathunder;;
 betterblockoutline;7275;betterblockoutline;BetterBlockOutline;;
 ;7276;sodiumfix;Sodium 临时崩溃修复;Sodium Crash Fix;
 scift;7277;scift;Scift;;
 ;7278;pingme;Ping Me;;
 ;7279;tool_rods;Tool Rods;;
 the-squid-game-mod;7280;squid_game_mod;The Squid Game Mod;;
-datapack-portals;7281;datapackportals;Datapack Portals;;
+datapack-portals;7281;datapackportals;数据包传送门;Datapack Portals;
 more-beautiful-walls;7282;morewalls;More Beautiful Walls;;
 iris-flywheel-compat;7283;Iris Flywheel Compat,irisflw;Iris & Oculus Flywheel Compat;;
 prism-lib;7284;prism;Prism;;
@@ -7085,7 +7082,7 @@ prism-lib;7284;prism;Prism;;
 map-atlases-forge;7286;map_atlases;地图册;Map Atlases;
 ;7287;epr;额外玩家渲染Rift版;ExtraPlayerRenderer-Rift;EPRR
 ;7288;arkworld;方舟世界;Arkworld;AW
-;7289;;温蒂库;;
+;7289;weedylib;温蒂库;WeedyLib;
 smartbrainlib;7291;smartbrainlib;SmartBrainLib;;SBL
 twilight-tweaks;7292;twilighttweaks;Twilight Tweaks;;
 aureus-simple-slabs;7293;aureusslabs;Aureus' Simple Slabs;;
@@ -7106,7 +7103,7 @@ mrp-library;7307;mrplibrary;mrp Library;;
 bypass-anvil-restriction;7308;bypass_anvil_restriction;Bypass Anvil Restriction;;
 no-early-loading-progress;7309;;No Early loading progress;;
 ;7310;spaceplane;三体工业：空天科技;Space&SkyTechnology;
-block-runner-forge;7311;blockrunner;Block Runner;;
+block-runner-forge;7311;blockrunner;Block Runner;;BR
 quick-paths;7312;quickpaths;Quick Paths;;
 solar-energy;7313;solarenergy;Solar Energy;;
 restored-earth;7314;restored_earth;Restored Earth;;
@@ -7120,7 +7117,7 @@ exlines-snorkel-mod;7321;snorkelmod;Exline's Snorkel Mod;;
 two-players-one-horse;7322;twoplayersonehorse;Two Players One Horse;;
 headshot-forge;7323;headshot;Headshot;;
 left-hanging;7324;hangman;Left Hanging;;
-;7325;sc;星光的载具;;
+stars_carrier;7325;sc;星光的载具;;
 ;7326;mekanism_make_item;通用机械附属：合成用物品;MekanismMakeItem;
 aetherworks;7327;aetherworks;天华之作;AetherWorks;
 slice-and-dice;7328;sliceanddice;Create Slice & Dice;;
@@ -7130,7 +7127,7 @@ textrues-rubidium-options;7329;reeses_sodium_options;TexTrue的铷视频界面;T
 rubber-duck;7332;rubber_duck;橡皮鸭;Rubber Duck;
 unlimited-dragon-eggs-fabric;7333;unlimiteddragoneggs;Unlimited Dragon Eggs;;
 moreplayermodels-plus;7334;moreplayermodels;MorePlayerModels+;;MPM+
-;7335;actioninventory;ActionInventory;;
+;7335;actioninventory;Action Inventory Mod;;
 ;7336;beta_brewing_system;远古酿造系统;Beta Brewing System;
 custom-void;7337;customvoid;Custom Void;;
 create-jetpack;7338;create_jetpack;机械动力：喷气背包;Create Jetpack;
@@ -7144,7 +7141,7 @@ solar-flux;7345;SolarFlux;日光通量;Solar Flux;SF
 ;7346;vdmod2;夜视眼镜;Night Glasses;
 custom-background-color;7347;cbc;自定义背景颜色;Custom Background Color;CBC
 simple-shulker-preview;7348;simpleshulkerpreview;Simple Shulker Preview;;
-bygone-nether;7349;bygonenether;Bygone Nether;;
+bygone-nether;7349;bygonenether;逝去的下界;Bygone Nether;
 ;7350;clickopener;Click Opener Mod;;
 kokoalinux-backport;7351;kokoalinux;KokoaLinux-Retro;;
 mechanical-clothesline;7352;clothesline;机械晾衣绳;Mechanical Clothesline;
@@ -7157,15 +7154,15 @@ thaumic-computers;7358;thaumcomp;Thaumic Computers;;
 ;7359;clicksoundfix;Slider ClickSoundFix;;
 instant-massive-structures-ims;7360;imsm;Instant Massive Structures;;IMS
 hunger-remover;7361;hunger_remover;Hunger Remover;;
-rad-enchants;7362;;Rad Enchants;;
+rad-enchants;7362;radenchants;Rad Enchants;;
 plus-the-end;7363;plus_the_end;Plus The End;;
 runic;7364;runic;Runic;;
 broken-discs;7365;brokendiscs;Broken Discs;;
 forgedfabric;7366;forgedfabric;ForgedFabric API;;
 create-extended-flywheels;7367;extendedflywheels;机械动力：更多飞轮;Create: Extended Flywheels;
 piggy-bank;7368;piggybank;Colds: Piggy Bank;;
-deeperdarker;7369;deeperdarker;Deeper And Darker;;
-;7370;;钓鱼战争;Fishing War;FW
+deeperdarker;7369;deeperdarker;幽邃黑暗;Deeper And Darker;
+;7370;mr_fishing_war;钓鱼战争：重生;Fishing War;FsW
 remote-gui-opener-forge;7371;remoteguiopener;Remote GUI Opener;;
 ;7372;ridespide;Ride Spiders;;
 illagers-pillagers;7373;illagers__pillagers;Illagers & Pillagers;;
@@ -7253,7 +7250,7 @@ create-factory;7454;create_factory;Create: Factory;;
 horseinboat;7455;horseinboat;HorseInBoat;;
 upgraded-tools;7456;upgradedtools;下界合金增强：工具;Upgraded Tools;
 tools-for-caves-and-cliffs;7457;tools_for_caves_and_cliffs;Tools for Caves and Cliffs;;C&C
-;7458;better_end_sky;Better End Sky;;
+betterendsky;7458;better_end_sky;Better End Sky;;
 ;7459;momostories;MoMo故事会;MoMo's Stories;
 infinity-with-mending;7460;infwithmend;无限与经验修补;Infinity With Mending;
 infinity-craft;7461;infinity;Infinity Craft;;
@@ -7267,10 +7264,10 @@ skin-hotkey;7468;skin-hotkey;Skin Hotkey;;
 dyeable-fishing-lines-fabric;7469;dyeablefishinglines;Dyeable Fishing Lines;;
 reciperemover;7471;reciperemover;RecipeRemover;;
 roughly-enough-loot-tables;7472;roughly_enough_loot_tables;Roughly Enough Loot Tables;;
-fld;7473;fldf;Fast Leaf Decaying;;FLD
+fld;7473;fldf;Speedy Leaf Decay / Fast Leaf Decay;;FLD
 lostcities-tfc;7474;lostcities_tfc;LostCities-TFC;;
 snowed-fabric;7475;snowed;Snowed;;
-player-blink;7476;modid;Player Blink;;
+player-blink;7476;blink;Player Blink;;
 better-command-block-ui;7477;bettercommandblockui;Better Command Block UI;;
 create-experienced;7478;create_experienced;Create Experienced;;
 gotta-go-fast;7479;gottagofast;Gotta Go Fast;;
@@ -7285,7 +7282,7 @@ playeranimator;7487;player-animator,playeranimator;PlayerAnimator;;
 apathy-mod;7488;apathy;Apathy;;
 auudio-forge;7489;auudio;Auudio;;
 ;7490;beta_brewing_system;远古酿造系统重置版;Beta Brewing System Reloaded;BBSR
-easy-shulker-boxes;7491;easyshulkerboxes;Easy Shulker Boxes;;
+easy-shulker-boxes;7491;easyshulkerboxes;Easy Shulker Boxes;;ES
 ;7492;redefined_baking;重定义烘焙;Redefined Baking;
 qu-enchantments;7493;qu-enchantments;QU enchantments;;
 ironchests;7494;ironchests;Iron Chests: Restocked;;
@@ -7298,10 +7295,10 @@ noits-simple-sorting;7500;simplesorting;Noit's Simple Sorting;;
 colds-gauntlets;7501;coldsgauntlets;Colds Gauntlets;;
 level-one;7502;level_one;Level One;;
 wilder-wild;7503;wilderwild;Wilder Wild;;
-paintings-with-dragons;7504;blackaures_paintings;Paintings with Dragons;;
+paintings-with-dragons;7504;blackaures_paintings;Paintings with Dragons / Black Aures Paintings;;
 more-redstone-lamps;7505;moreredlamps;更多红石灯;More Redstone Lamps;
 placeable;7506;placeable;可放置植物;Placeable Plants;
-hot-or-not-tfc-with-sticks;7507;;Hot or Not - TFC (with sticks);;
+hot-or-not-tfc-with-sticks;7507;tfchotornot;Hot or Not - TFC (with sticks);;
 quick-elytra;7508;quick_elytra;Quick Elytra;;
 other-berries;7509;other_berries_mod;Other Berries;;
 itank;7510;itank;ITank;;
@@ -7316,7 +7313,7 @@ bedrockcraft;7518;bedrockcraft;BedrockCraft;;
 better-mobgriefing-gamerule;7519;bettermobgriefinggamerule;Better mobGriefing GameRule;;
 frozen-fiend;7520;iceologer;Frozen Fiend;;
 ;7521;titanfall;MineFall;;
-gateways-to-eterrnity;7522;gateways;永恒之门;Gateways to Eternity;
+gateways-to-eternity;7522;gateways;永恒之门;Gateways to Eternity;
 gate-of-babylon-additions;7523;gate_of_babylon_additions;王之财宝附加;Gate of Babylon Additions;
 hephaestus-fabric;7524;tconstruct;匠神;Hephaestus;
 crafting-bench;7525;craftingbench;Crafting Bench;;
@@ -7329,12 +7326,12 @@ create-infinidrill;7529;infinidrill;Create InfiniDrill;;
 ;7532;scrollable_tooltips;Scrollable Tooltips;;
 attribute-tooltip-fix;7533;attributetooltipfix;Attribute Tooltip Fix;;
 ;7534;tntdrop;空袭;TNT Drop;TD
-;7535;no_slow_down;不减速;No Slow Down;
+no-slow-down;7535;no_slow_down;不减速;No Slow Down;
 crumbs;7536;crumbs;Crumbs;;
 italian-delights-add-on-for-farmers-delight;7537;italian_delight;Italian's Delight;;
 immersivemc;7538;immersivemc;沉浸式MC;ImmersiveMC;
 mc-vr-api;7539;vrapi;MC VR API;;
-exordium;7540;fastergui;Exordium;;
+exordium;7540;fastergui,exordium;Exordium;;
 fabric-launchpads;7541;zihlaunchpads;Launchpads;;
 ;7542;whitelist;白名单修复;Whitelist Repair;
 thermal-innovation-cyclic-compat;7543;thermalinnovationcycliccompat;Thermal Innovation Cyclic Compat;;
@@ -7382,12 +7379,12 @@ serene-seasons-harvestcraft2-compat;7584;sereneseasonsphc2;Serene Seasons - Pam'
 goat;7585;ohmygoat;Oh My Goat;;
 ;7586;eattoomuch;吃太饱了！;Eat Too Much!;ETM
 simple-autofish;7587;autofish;Simple Autofish;;
-;7588;thinkbeforedrop;丢弃物品保护;Think Before Drop;
+think-before-drop;7588;thinkbeforedrop;丢弃物品保护;Think Before Drop;
 omo;7589;omo;OMO;Teleport Asker;
 mushroom-additions;7590;mushroom_additions;Mushroom Additions;;
 ;7591;long_summer;那年夏天;Long Summer;
 project-the-void;7592;project_void;项目 -虚空-;Project the Void;
-ice-and-fire-rotn-edition;7593;;Ice and Fire: RotN Edition;;
+ice-and-fire-rotn-edition;7593;iceandfire;Ice and Fire: RotN Edition;;
 minescript;7594;minescript;Minescript;;
 no-capes;7595;nocapes;禁用披风;No Capes;
 apocalypsecraft;7596;apocalypse_craft;ApocalypseCraft;;
@@ -7405,10 +7402,10 @@ stop-hiding;7606;stophiding;Stop Hiding;;
 simple-world-timer;7608;SimpleWorldTimer;Simple World Timer;;
 recursive-resources;7609;recursiveresources;Recursive Resources;;
 inventory-actions;7610;inventoryactions;Inventory Actions;;
-;7611;lavafishing;岩浆钓鱼;Lava Fishing;
+lavafishing;7611;lavafishing;岩浆钓鱼;Lava Fishing;
 haunted-harvest;7612;hauntedharvest;Haunted Harvest;;
 dungeonsenhanced;7613;dungeons_enhanced;Dungeons Enhanced;;
-create-crystal-clear;7614;create_crystal_clear;机械动力：晶莹剔透;Create: Crystal Clear;
+create-crystal-clear;7614;create_crystal_clear,crystal_clear;机械动力：晶莹剔透;Create: Crystal Clear;
 ;7615;create_crystal_clear;Create: Crystal Clear Refabricated;;
 fix-experience-bug;7616;experiencebugfix;Fix Experience Bug;;
 ;7617;m24;24点;Minecraft024;m24
@@ -7424,12 +7421,12 @@ beaming-drops;7627;beamingdrops;掉落物光束;Beaming drops;
 protocharset;7628;protocharset;ProtoCharset;;
 the-hordes;7629;hordes;The Hordes;;
 ;7630;;永冻之地;The Forever Frozen;FF
-;7631;inventorymanagement;Inventory Management;;
+inventory-management;7631;inventorymanagement;Inventory Management;;
 soul-fired;7632;soulfired;Soul fire'd;;
 faithfulbackrooms;7633;faithfulbackrooms;Faithful Backrooms;;
 ex-machinis;7634;exmachinis;Ex Machinis;;
 goety;7635;goety;诡厄巫法;Goety;
-torch-hit;7636;;Torch hit!;;
+torch-hit;7636;torch_hit,torch-hit;Torch hit!;;
 ;7637;nan_health_fix;假死修复 : 重生;Entity NaN Health Fix : Reborn;
 we-got-runners;7638;wegotrunnners;We Got Runners!;;
 ;7639;cabricality;Cabricality Utils;;CABFU
@@ -7459,14 +7456,14 @@ onlylooking;7662;onlylooking;OnlyLooking;;
 the-birdwatching-mod;7663;birdwmod;The Birdwatching Mod;;
 giant-ai;7664;;Giant AI;;
 unlit-campfire;7665;unlitcampfire;Unlit Campfire;;
-xl-packets-renewed;7666;;XL Packets Renewed;;
+xl-packets-renewed;7666;xl_packets_renewed;XL Packets Renewed;;
 nameplate;7667;nameplate;Nameplate;;
 rpgdifficulty;7668;rpgdifficulty;RpgDifficulty;;
 tooltiprareness;7669;tooltiprareness;TooltipRareness;;
 ;7670;minimotd_reforged;MiniMOTD Reforged;;
 combat-roll;7671;combatroll;战斗翻滚;Combat Roll;
 project-brazier;7672;projectbrazier;Project Brazier/Dark Roleplay Medieval;;
-over-enchanted;7673;;Over Enchanted;;
+over-enchanted;7673;overenchanted;Over Enchanted;;
 creeper-overhaul-firework;7674;creeper_overhual_fireowork;烟花苦力怕改革;Creeper Overhaul Firework;
 spartan-weaponry-bewitchment;7675;spartanbewitchment;斯巴达的武器：巫师之路;Spartan Weaponry - Bewitchment;
 no-water-spread;7676;nowaterspread;No Water Spread;;
@@ -7478,7 +7475,7 @@ dogwhistle;7681;dogwhistle;DogWhistle;;
 ;7682;;MineVocal;;
 ;7683;onlylooking;OnlyLooking Refabricated;;
 ;7684;yyyy;羊羊羊羊;YYYY;YYYY
-;7685;tt;Ore Creepers;;
+;7685;;Ore Creepers;;
 wilder-wilds;7686;wilder_wilds;Wilder Wilds;;
 ;7687;ae2_unpowered;AE2: Unpowered;;
 better-respawn;7688;better_respawn;更好的重生;Better Respawn;BR
@@ -7509,15 +7506,15 @@ odysseymod;7712;odysseymod;Odyssey: Overhauled Trades & World Expansion;;
 libipn;7713;libipn;libIPN;;
 hulsealib;7714;hulsealib;HulseaLib;;
 blues-dynamic-lights;7715;bdlmod;Blue's Dynamic Lights;;
-gtc-expansion;7716;gtc_expansion;GTC Expansion;;
-nether-depths-upgrade;7717;netherdepthsupgrade;Nether Depths Upgrade;;
+gtc-expansion;7716;gtc_expansion;VGT Expansion;;
+nether-depths-upgrade;7717;netherdepthsupgrade;炽海生机;Nether Depths Upgrade;
 cloud-factory;7718;cloud_factory;Cloud Factory;;
 disc-holders-dj;7719;discholder;Disc holder & DJ;;
 ;7720;econ;eCon;;
 keepmum;7721;keepmum;三缄其口;KeepMum;
 saturn;7722;saturn;Saturn;;
 stackable;7723;stackable;Stackable;;
-do-a-barrel-roll;7724;do-a-barrel-roll;Do a Barrel Roll;;
+do-a-barrel-roll;7724;do-a-barrel-roll,do_a_barrel_roll;Do a Barrel Roll;;
 fantasys-dice;7725;fantasydice;Fantasy的骰子;Fantasy's Dice;
 ;7726;ukulib;ukulib;;
 ;7727;betterhurtcam;BetterHurtCam;;
@@ -7533,7 +7530,7 @@ simply-swords;7736;simplyswords;简易刀剑;Simply Swords;
 kuayue;7737;kuayue;跨越;KuaYue;KY
 ;7738;Technical_Engineering_3_compatible;科能工程3兼容;Technical Engineering 3 compatible;TEN3C
 summoningrituals;7739;summoningrituals;召唤仪式;Summoning Rituals;
-no-sleep-forge;7740;nosleep;No Sleep;;
+no-rest;7740;nosleep;No Rest;;
 you-died;7741;you_died;你死了;You Died;
 hotbarcycle;7742;hotbarswap;HotbarCycle;;
 hungry-in-peaceful-mode;7743;hungry_in_peaceful_mode;无中生饥;Hungry In Peaceful Mode;HIP
@@ -7542,7 +7539,7 @@ cave-generator;7745;cavegenerator;洞穴生成器;Cave Generator;
 console-filter;7746;consolefilter;Console Filter;;
 customized-dungeon-loot;7747;customizeddungeonloot,cdl;Customized Dungeon Loot;;
 customquests;7748;customquests;Custom Quests;;
-portal-cubed;7749;thinkingwithportatos;Portal Cubed/Thinking With Portatos;;
+portal-cubed;7749;thinkingwithportatos;Portal Cubed / Thinking With Portatos;;
 pehkui-resizer;7750;pehkui_resizer;Pehkui Resizer;;
 ;7751;kaffees_dual_ride;Kaffee's Dual Ride;;
 ;7752;sfreeze;Sfreeze;;
@@ -7552,7 +7549,7 @@ logic-chips;7755;logicchips;Logic Chips;;
 quit;7756;quit;Quit;;
 ;7757;mob_firework;生物烟花;Mob Firework;
 nears;7758;nears;Nears;;
-obsidianui;7759;spruceui;ObsidianUI;;
+obsidianui;7759;spruceui,obsidianui;ObsidianUI;;
 ;7760;walk-jog-run;Walk, Jog, Run!;;
 conveyor-belts-fabric;7761;conveyor-belts;传送带;Conveyor Belts;
 create-sifting;7762;createsifter;机械动力：筛子;Create Sifting;
@@ -7579,11 +7576,11 @@ polaroid-camera;7782;polaroidcamera;宝丽来相机;Polaroid Camera;
 dig;7783;dig;Dig;;
 stargate-network;7784;sgcraft;Stargate Network;;SGCraft
 dimensional_ores;7785;dimensional_ores;Mrthomas20121's Dimensional Ores;;
-devices-mod;7786;devices;Devices Mod;;
+devices-mod;7786;devices;Ultreon Devices Mod;;
 dynamistics;7787;dynamistics;Dynamistics;;
 eguilib;7788;eguilib;Erdbeerbaer's GUI Library;;
 glacidus;7789;glacidus;Glacidus;;
-;7790;origins;起源：基岩版;OriginsPE;
+originspe-be-add-on-1-2;7790;;起源：基岩版;OriginsPE;
 worldedit-bedrock-edition;7791;wedit;创世神：基岩版;WorldEdit: Bedrock Edition;
 compat-makeover;7792;compat_makeover;Compat Makeover;;
 ;7793;deferred_registries;Deferred Registries;;
@@ -7596,7 +7593,7 @@ tip-the-gui;7799;screenscale;界面尺寸设置优化;GUI Scale;
 copper-overhaul;7800;copperoverhaul;Copper Overhaul;;
 epic-fight-nbt-integration;7801;fightnbtintegration;Epic Fight NBT Integration;;
 login-protection;7802;logprot;登录保护;Login Protection;
-swem;7803;swem;Star Worm Equestrian Mod;;SWEM
+swem;7803;swem;星虫马术;Star Worm Equestrian Mod;SWEM
 metal-barrels-legacy;7804;metalbarrels;金属储物桶：传承;Metal Barrels: Legacy;
 inventoryfullalert;7805;inventoryfullalert;InventoryFullAlert;;
 lead-beyond;7806;lead_beyond;引向超越;Lead Beyond;BYD
@@ -7617,7 +7614,7 @@ gtce-tj-edition;7820;gregtech;格雷科技社区版：TJ版;GregTech Community E
 upc;7821;upc;UPC;;
 gregicality-tjfork;7822;gtadditions;Gregicality TJ Fork;;
 ;7823;flagslib;FlagsLib;;
-create-mechanical-extruder;7824;createmechanicalextruder;Create Mechanical Extruder;;
+create-mechanical-extruder;7824;createmechanicalextruder,create_mechanical_extruder;Create Mechanical Extruder;;
 no-debug-5-you;7825;nd5u;No Debug 5 You;;
 packagedavaritia;7826;packagedavaritia;封包无尽贪婪;PackagedAvaritia;
 pillar;7827;pillar;Pillar;;
@@ -7659,7 +7656,7 @@ pluto;7862;pluto;Pluto;;
 ;7863;elephantfix;大象修复;Elephant Fix;
 youre-in-grave-danger;7864;yigd;You're in Grave Danger;;
 reds-better-biomes-fabric-forge;7865;vanillabetterbiomes;Red's Better Biomes;;
-reds-more-structures;7866;redmorestructure;Red's More Structures;;
+reds-more-structures;7866;redmorestructure,reds_morestructures_mr;Red's More Structures;;
 rotn-tweaker;7867;rotntweaker;RotN Tweaker;;
 cannot-build-over-lava-source-blocks;7868;nolavabuild;Cannot Build over Lava Source blocks;;
 quark-rotn-edition;7869;;Quark: RotN Edition;;
@@ -7667,7 +7664,7 @@ inmisaddon;7870;inmisaddon;InmisAddon;;
 pineapple-delight;7871;pineapple_delight;凤梨乐事;Pineapple Delight;
 woodworks;7872;woodworks;Woodworks;;
 informational-accessories;7873;infoaccessories;信息饰品;Informational Accessories;
-nyfs-spiders;7874;nyfsspiders;Nyf's Spiders;;
+nyfs-spiders;7874;nyfsspiders,spiderstpo;Nyf's Spiders;;
 illager-additions;7875;illager_additions;Illager Additions;;
 idolizing;7876;;Idolizing;;
 evocation-and-annihilation;7877;evocationandannihilation;Evocation🧙‍♂️ and Annihilation💣!!;;
@@ -7676,7 +7673,7 @@ kebabs-crowns;7879;;Kebab's Crowns;;
 rerereskillable;7880;rereskillable;rerereSkillable;;
 hedgehogs;7881;hedgehog;刺猬;Hedgehogs;
 ;7882;pendulum;Pendulum;;
-yacl;7883;yet-another-config-lib;YetAnotherConfigLib;;YACL
+yacl;7883;yet_another_config_lib_v3,yet-another-config-lib;YetAnotherConfigLib;;YACL
 keyboard-wizard-legacy;7884;keywizard;按键精灵旧版;Keyboard Wizard: Legacy;
 queen-cats-dogs;7885;queencats;Queen Cats & Dogs;;
 additional-lights;7886;additional_lights;更多光源;Additional Lights;
@@ -7689,14 +7686,14 @@ create-enchantment-industry;7892;create_enchantment_industry;机械动力：附�
 enchanted-witchcraft;7893;enchanted;Enchanted: Witchcraft;;
 wyml;7894;wyml;Why You Make Lag;;WYML
 ;7895;catalyst;Overgrown Overworld;;
-bunch-o-bugs;7896;;Bunch O' Bugs;;
+bunch-o-bugs;7896;bunchobugs;Bunch O' Bugs;;
 useless-reptile;7897;uselessreptile;Useless Reptile;;
 technomancy-2;7898;technom;量子魔法2;Technomancy2;
 quickstore;7899;quickstore;快速贮藏重制版;QuickStoreRemake;
 your-items-are-safe;7900;youritemsaresafe;Your Items Are Safe;;
 techemistry;7901;techemistry;Techemistry;;
 the-missing-villages;7902;themissingvillages;The Missing Villages;;
-continents;7903;;Continents;;
+continents;7903;continents;Continents;;
 yungs-better-ocean-monuments;7904;betteroceanmonuments;YUNG的海底神殿优化;YUNG's Better Ocean Monuments;
 echoing-depths;7905;echoingdepths;Echoing Depths;;
 ;7906;EUC;ER的传说之下挑战MOD;ER's Undertale Challenges Mod;EUC
@@ -7708,7 +7705,7 @@ xanders-sodium-options;7911;xanders-sodium-options;Xander's Sodium Options;;XSO
 entity-view-distance;7912;entity-view-distance;Entity View Distance;;
 creeper-ai-updated;7913;creeperaiupdated;Creeper AI Updated;;
 sihywtcamd;7914;sihywtcamd;So I heard you were talking crap about Minecraft's difficulty?;;SIHYWTCAMD
-sihywtcamc;7915;sihywtcamc;So I heard you were talking crap about Minecraft's combat?;;
+sihywtcamc;7915;sihywtcamc;So I heard you were talking crap about Minecraft's combat?;;SIHYWTCAMC
 why-stacks-of-16;7916;wso16;Why stacks of 16?;;WSO16
 jumpquilt;7917;jumpquilt;JumpQuilt;;
 oh-how-the-crafting-has-tabled;7918;morecraftingtables;Oh, How the Crafting Has Tabled!;;
@@ -7740,7 +7737,7 @@ chubby-stuff-fabric;7943;;Chubby Stuff!;;
 better-brightness-slider;7944;brightnessslider;Better Brightness Slider;;
 open-parties-and-claims;7945;openpartiesandclaims;Open Parties and Claims;;OPAC
 loading-screen-tips;7946;loadingscreentips;Loading Screen Tips;;
-better-tips;7947;bettertags;Better Tag Tips;;
+better-tips;7947;bettertags;Better Tag NBT Tips;;
 immediatelyfast;7948;immediatelyfast;ImmediatelyFast;;
 opac-fabric-create-support;7949;opaccreatesupport;Create Support for Open Parties and Claims;;
 steel-for-fabric;7950;steel;钢;Steel;
@@ -7788,11 +7785,11 @@ puzzle;7990;puzzle,Puzzle;Puzzle;;
 ;7992;more-create-recipes_datapack;更多机械动力配方-数据包;MoreCreateRecipes - DataPack;MCR-D
 ;7993;tdfp;暮色乐事：冰雪豪饮;Twilight Delight: Frozen Pride;TDFP
 ftb-pack-companion;7994;ftbpc;FTB Pack Companion;;
-teams-stages;7995;;Teams Stages;;
+teams-stages;7995;teamsstages;Teams Stages;;
 kiwi-boi;7996;kiwiboi;Kiwi Boi;;
 rubidium-toolkit;7997;rubidium_toolkit;铷 · 工具箱;Rubidium Toolkit;RT
 advanced-combat;7998;advancedcombat;高级战斗装备;Advanced Combat;
-advanced-combat-revitalized;7999;;高级战斗装备重置;Advanced Combat (Revitalized);
+advanced-combat-revitalized;7999;advancedcombat;高级战斗装备重置;Advanced Combat (Revitalized);
 totemic-overhaul;8000;totemicoverhaul;Totemic Overhaul;;
 ;8001;;便宜的修复;Cheap Repair;
 battlecorrection;8002;battlecorrection;战斗修正;BattleCorrection;BC
@@ -7832,7 +7829,7 @@ archon;8036;archon;Archon;;
 stackie;8037;stackie;Stackie;;
 ;8038;cullclouds;Cull Clouds;;
 ;8039;superfancyclouds;SuperFancyClouds;;
-stage-tabels;8040;stagetables;Stage Tabels;;
+stage-tabels;8040;stagetables;Stage Tables;;
 temporal-dynamics;8041;temporaldynamics;Temporal Dynamics;;
 villagertradingban;8042;vtb;VillagerTradingBan;;
 enchantment-machine;8043;enchantmentmachine;Enchantment Machine;;
@@ -7842,7 +7839,7 @@ onebar;8046;onebar;单条;OneBar;
 berdinskiybears-armor-hud;8047;armor_hud;BerdinskiyBear's Armor HUD;;
 ;8048;blockoverlay;Block Overlay;;
 ;8049;PingTag;Ping Tag;;
-tiered-tooltips;8050;;Tiered Tooltips;;
+tiered-tooltips;8050;tieredtooltips;Tiered Tooltips;;
 rgb-blocks-forge;8051;rgbblocks;调色方块;RGB Blocks;
 ;8052;deathinterface;独特的死亡界面;UniqueDeathInterface;UDI
 quicksand-fabric;8053;quicksand;流沙;Quicksand;
@@ -7854,7 +7851,7 @@ packet-size-doubler;8057;packet_size_doubler;Packet Size Doubler;;
 arachnophobia-mode-for-minecraft;8059;arachnophobiamode;Arachnophobia Mode For Minecraft;;
 villagerconfig;8060;villagerconfig;村民配置;VillagerConfig;
 jasm;8061;speedometer;Just Another Speedometer Mod;;JASM
-paginated-advancements;8062;paginatedadvancements;分页进度;Paginated Advancements;
+paginated-advancements;8062;paginatedadvancements;分页进度;Paginated Advancements & Custom Frames;
 ;8063;backportgamerules;Backport Gamerules;;
 structures-compass;8064;structures_compass;Structures' Compass;;
 swiss-cheese;8065;swisscheese;Swiss Cheese Caves;;
@@ -7870,14 +7867,14 @@ custom-shop;8074;custom_shop;自定义商店;CustomShop;CTS
 another-liquid-milk;8075;almm;Another Liquid Milk;;
 dark-mode-everywhere-fabric;8076;darkmodeeverywhere;夜间模式无处不在Fabric版;Dark Mode Everywhere - Fabric;
 ;8077;;不毛之地;Waste Land;
-bartering-station;8078;barteringstation;Bartering Station;;BS
+bartering-station;8078;barteringstation;易物站;Bartering Station;BS
 dark-paintings;8079;darkpaintings;Dark Paintings;;
 ;8080;kusl_recipe_fix;KuSL Recipe Fix;;
 filtpick;8081;filtpick;拾取筛;FiltPick;FP
 ;8082;pog;Better on Bedrock;;
 deepslatecutting;8083;deepslatecutting;DeepslateCutting;;
-easy-anvils;8084;easyanvils;简易铁砧;Easy Anvils;
-leaves-be-gone;8085;leavesbegone;Leaves Be Gone;;
+easy-anvils;8084;easyanvils;简易铁砧;Easy Anvils;EA
+leaves-be-gone;8085;leavesbegone;Leaves Be Gone;;LG
 recipe-cache;8086;recipecache;配方缓存;Recipe Cache;
 mob-catcher;8087;mobcatcher;Mob Catcher;;
 ;8088;quiltgoslightlyfasterlol;🗿QuiltGoSlightlyFasterLol🗿;;
@@ -7899,7 +7896,7 @@ toomanyorigins;8103;;TooManyOrigins;;
 evil-regeneration;8104;evilregeneration;Evil Regeneration;;
 food-treasure-box;8105;alien_food;食物宝盒;Food Treasure Box;
 revolution;8106;revolution;Revolution;;
-apugli;8107;;Apugli;;
+apugli;8107;apugli;Apugli;;
 harvest-season;8108;harvestseason;Harvest Season;;
 ;8109;ic2fix;IC2Fix;;
 ;8110;extendedbookshelves;Extended bookshelves;;
@@ -7914,7 +7911,7 @@ mystical-nature;8119;mysticalcrops;神秘自然;Mystical Nature;
 ;8120;formula_addition;配方追加;Formula addition;FA
 randomlib;8121;randomlib;RandomLib;;
 ;8122;kinventory;KInventory;;
-pullup;8123;pullup;飞行警报;;PLUP
+pullup;8123;pullup;飞行警报;Pullup;PLUP
 id-primeval;8124;primeval;Primeval;;
 colorfulazaleas;8125;colorfulazaleas;Colorful Azaleas;;
 pigeon-post;8126;pigeonpost;Pigeon Post;;
@@ -7956,9 +7953,9 @@ variant-barrels-fabric;8162;variantbarrels;Variant Barrels;;
 variant-crafting-tables-fabric;8163;variantcraftingtables;Variant Crafting Tables;;
 immersive-structures;8164;imst;Immersive Structures;;IMST
 avaritia-port-fabric;8165;avaritia;Greedy Grinding Mod - Avaritia (Fabric);;
-explorify;8166;explorify-fabric,explorify;Explorify;;
+explorify;8166;explorify-fabric,explorify;Explorify – Dungeons & Structures;;
 variant-bookshelves-fabric;8167;variant_bookshelves;Variant Bookshelves;;
-variant-tiered-shields-fabric;8168;variant_shields;Variant Shields;;
+variant-tiered-shields-fabric;8168;variant_shields,variantshields;Variant Shields;;
 libertys-villagers;8169;libertyvillagers;自由村民;Liberty's Villagers;
 server-translation-api;8170;server_translations;Server Translation API;;
 rough-mobs-2;8171;;粗暴的怪物2;Rough Mobs 2;
@@ -7994,7 +7991,7 @@ seed-finder-mod;8200;seedfindermod;Seed Finder;;
 potato-food;8201;potatofood;Potato Food;;
 ;8202;morerecipes;更多配方;More Recipes;MR
 compassplus;8203;compassplus;Compass Plus;;
-create-industry;8204;createindustry;机械动力：工业长路;Create: Industry/Create: The Factory Must Grow;TFMG
+create-industry;8204;createindustry,tfmg;机械动力：工业长路;Create: Industry/Create: The Factory Must Grow;TFMG
 simple-splash-screen;8205;simplesplashscreen;Simple Splash Screen;;
 unusual-prehistory-forge;8206;unusualprehistory;Unusual Prehistory;;
 biospheres;8207;biospheres;生物圈;Biosphere;
@@ -8015,12 +8012,12 @@ helicopters-madness;8221;helicopters_madness;Helicopters Madness;;
 fanon-mutant-entities;8222;fme;Fanon Mutant Entities;;
 technical-enchant;8223;teplus;更多附魔重置版;TechnicalEnchant+;TE+
 naturally-spawning-vex;8224;naturallyspawningvex;Naturally Spawning Vex;;
-better-game-menu;8225;bettergamemenu;BetterGameMenu;;
+better-game-menu;8225;bettergamemenu;Better Game Menu;;
 ;8226;;MQ的连锁采集;MQ's Chain;MQC
 seasonhud;8227;seasonhud;SeasonHUD;;
 stack-to-nearby-chests;8228;stack-to-nearby-chests;堆叠到附近的箱子;Stack to Nearby Chests;
 gmod-title-screen;8229;gmod-title-screen;GMod Title Screen;;
-create-steam-n-rails;8230;railways;机械动力：汽鸣铁道;Create: Steam 'n Rails;SnR
+create-steam-n-rails;8230;railways;机械动力：汽鸣铁道;Create: Steam 'n' Rails;SnR
 neutron;8231;neutron;Neutron;;
 applied-cooking;8232;appliedcooking;应用厨房;Applied Cooking;
 ;8233;litematica_printer;投影打印机;Litematica Printer;
@@ -8032,7 +8029,7 @@ qfapi-and-qsl-biomefix-1-18-2;8236;quilted_fabric_api;QFAPI and QSL - Biomefix;;
 honey-expansion-add-on-for-farmers-delight;8240;honeyexpansion;蜂蜜拓展;Honey Expansion;
 moguns;8241;moguns;Mo' Guns;;
 dayz-minecraft;8242;dayz;DayZ for Minecraft;;
-infusion-table;8243;infusion_table;Infusion Table;;
+infusion-table;8243;infusion_table;灌注祛魔台;Infusion Table;
 backroomtastic;8244;the_backrooms;Backrooms With 19 Levels;;
 xps-things;8245;exps_things;经验之谈;XP's Things;
 gravityapi;8246;gravity_api;GravityAPI;;
@@ -8055,11 +8052,11 @@ flatter-entities;8262;flatterentities;Flatter Entities;;
 daves-potioneering;8263;davespotioneering;Dave's Potioneering;;
 last-days-of-humanity-tweaks;8264;hundreddayz;LDoH Tweaks;;
 space-bosstools-giselle-addon;8265;beyond_earth_giselle_addon;Beyond Earth: Giselle Addon;;
-;8266;spawn_eggs_recipes,ser;刷怪蛋配方;Spawn Eggs Recipes;SER
+;8266;spawn_eggs_recipes,ser,ser_for_alex;刷怪蛋配方;Spawn Eggs Recipes;SER
 mined-rider-kuuga;8267;mined_rider_kuuga;Mined Rider KUUGA;;
 inventory-essentials;8268;inventoryessentials;Inventory Essentials;;
 astral-additions;8269;aam;星辉附加;Astral Additions;
-simple-copper-pipes;8270;copper_pipe,lunade;Simple Copper Pipes;;
+simple-copper-pipes;8270;copper_pipe,lunade,simple_copper_pipes;Simple Copper Pipes;;
 advanced-nbt-tooltips;8271;advanced-nbt-tooltips;高级NBT提示工具;Advanced NBT Tooltips;
 follow-me;8272;followme;Follow Me;;
 stabx-modern-guns;8273;stabxmodernguns;Stabx Modern Guns;;
@@ -8108,7 +8105,7 @@ decoration-delight;8317;decoration_delight;装饰乐事;Decoration Delight: Refu
 ;8318;hcookbook;Havio的烹饪书;Havio's Cookbook;
 formidablefarmland;8319;formidablefarmland;FormidableFarmland;;
 ;8320;;刀艺;KatanaCraft;
-;8321;survivality;Survivality;;
+survivality;8321;survivality;Survivality;;
 dynamic-crosshair-compat;8322;dynamiccrosshaircompat;动态准星兼容;Dynamic Crosshair Compat;
 litewolfcore;8323;litewolfcore;LiteWolfCore;;
 vineyard-mod;8324;vineyardmod;Vineyard;;
@@ -8117,9 +8114,9 @@ mo-colors;8326;mocolors;Mo' Colors;;
 peek;8327;peek;Peek;;
 fancy-dyes;8328;fancydyes;Fancy Dyes;;
 ;8329;;进度追加;Advancements addition;AA
-;8330;extra-mod-integrations;EMI Addon: Extra Mod Integrations;;
+extra-mod-integrations;8330;extra-mod-integrations;EMI Addon: Extra Mod Integrations;;
 mod-settings;8331;modsettings;Mod Settings for Fabric;;
-;8332;dontdisappear;Don't dissapear on me;;
+dont-disappear-on-me;8332;dontdisappear;Don't dissapear on me;;
 fastquit;8333;fastquit;FastQuit;;
 violeta-cannons;8334;violetacannons;Violeta Cannons;;
 war-of-valor;8335;shocked;War of Valor;;
@@ -8130,7 +8127,7 @@ epic-paladins;8339;arclight;Epic Paladins;;
 brazier;8340;brazier;生灵火盆;Brazier;
 stackcalc-revived;8341;stackcalc;StackCalc Revived;;
 with-thursday-delight;8342;thursday_delight;乐在星期四;With Thursday Delight;
-;8343;osmium;锇;Osmium;
+osmiummod;8343;osmium;锇;Osmium;
 ;8344;mgbuttons;Command GUI Buttons;;
 wagyourminimap;8345;wagyourminimap;WagYourMinimap;;WYM
 chunks-fade-in;8346;chunksfadein;区块淡入动画;Chunks fade in;
@@ -8144,7 +8141,7 @@ packages;8353;packages;自定义包裹;Packages;
 giant-spawn;8354;giantspawn,giantspawn-fabric;Giant Spawn;;
 ;8355;mtrsteamloco;纸板箱的交通扩展;Nemo's Transit Expansion;NTE
 serene-shrubbery;8356;serene_shrubbery;Serene Shrubbery;;
-gardens-of-the-dead;8357;gardens_of_the_dead;Gardens of the Dead;;
+gardens-of-the-dead;8357;gardens_of_the_dead;死亡花园;Gardens of the Dead;
 pirate-hats;8358;pirate_hat;Pirate Hats;;
 decor4fabric;8359;decor4fabric;Decor4Fabric;;
 mob-skills;8360;mobskills;Mob Skills;;
@@ -8165,7 +8162,7 @@ biomes-in-jars-forge;8373;biomesinjars;群系罐子;Biomes in Jars;
 craftable-potion-combinations;8375;craftablepotioncombinations;Craftable Potion Combinations;;
 polylib;8376;polylib;PolyLib;;
 ;8377;creeper-fire-charge-fix;Creeper火焰弹修复;Creeper Fire Charge Fix;
-;8378;tags_binder;Tags Binder;;
+tags-binder;8378;tags_binder;Tags Binder;;
 fastcaps;8379;fastcaps;FastCaps;;
 throwable-fluids;8380;throwablefluids;Throwable Fluids;;
 time-in-a-bottle;8381;timeinabottle;时间之瓶 Fabric 版;Time in a Bottle (Fabric);
@@ -8177,7 +8174,7 @@ atom-sweep;8386;atomsweep;基石-清理;Atom-Sweep;
 the-gold-rush;8387;the_gold_rush;The Gold Rush;;
 optifabric-origins;8388;optifabric;OptiFabric Origins;;
 lng-deco;8389;lngdeco;LnG Deco;;
-darkrpg-reborn;8390;darkrpg;黑暗RPG：重生;DarkRPG: REBORN;
+darkrpg-reborn;8390;darkrpg;黑暗 RPG：重生;DarkRPG: REBORN;
 modpack-manager;8391;packmger;模组管理器;Modpack Manager;
 rocket-connector;8392;rocketconnector;Rocket Connector;;
 hot-and-cold;8393;heat;HOT and COLD;;
@@ -8192,9 +8189,9 @@ minecraft-style-paintings;8401;minecraft_style_paintings;MC style paintings;;
 potato-cooking;8402;potato_cooking_mod_fabric;Potato Cooking;;
 ;8403;cftags;Conveniented Forge Tags;;CFT
 clienttime;8404;clienttime;ClientTime;;
-mcpitanlibarch;8405;mcpitanlibarch;MCPitanLibarch/MCPitanLib;;
+mcpitanlibarch;8405;mcpitanlibarch;MCPitanLib;;
 ;8406;bontany_ore_trees_reborn;植物盆栽矿物树拓展：重制;Botany Ore Trees:Reborn;BOT:R
-manure-fabric;8407;manure,manure-fabric;粪便;Manure;
+manure;8407;manure,manure-fabric;粪便;Manure;
 well;8408;well;Well well well...;;
 ;8409;mystructure;Sky Structures;;
 enderling-invaders;8410;enderlinginvaders;Enderling Invaders;;
@@ -8210,7 +8207,7 @@ mob-crossing;8419;mobcrossing;Mob Crossing;;
 just-enough-vehicles;8420;jev;Just Enough Vehicles;;JEV
 ;8421;gift_from_the_black_dragon;黑龙赠礼;Gift From The Black Dragon;
 max-health-fix;8422;maxhealthfix;Max Health Fix;;
-;8423;synlib;SynapseLib;;
+synlib;8423;synlib;SynapseLib;;
 tell-me-my-items;8424;tellmemyitems;Tell Me My Items;;TMMI
 pollen;8425;pollen;Pollen;;
 mavapi;8426;mavapi;More Axolotl Variants API;;MAVAPI
@@ -8219,7 +8216,7 @@ guaranteed-villager-conversion;8428;guaranteedvillagerconversion;Guaranteed Vill
 windchimes;8429;windchimes;风铃;Windchimes;
 ;8430;projecta;代号 A;ProjectA;
 diamond-ingots;8431;diamondingots;钻石锭;Diamond Ingots;
-;8432;mouse-danmu;鼠鼠弹幕;;
+;8432;mouse-danmu,mousedanmu;鼠鼠弹幕;;
 inventory-sorting;8433;inventorysorter;Inventory Sorting;;
 mine-piece;8434;minepiece;Mine Piece;;
 mine-piece-animation;8435;minepiece_animation;Mine Piece Animation;;
@@ -8228,7 +8225,7 @@ custom-skyboxes;8437;customskyboxes;Custom Skyboxes;;
 breedable-killer-rabbit;8438;breedablekillerrabbit,breedablekillerrabbit-fabric;可繁殖的杀手兔;Breedable Killer Rabbit;
 bqenergyexpansion;8439;bqenergyexpansion;BQEnergyExpansion;;
 magic-and-wand;8440;tlot_magic_wand;法术与法杖;Magic&Wand;MW
-re-ftbqkeys;8441;ftbqlocalkeys;FTB任务本地化键：重置;Re-FTBQLocalizationKeys;Re-FTBQKeys
+re-ftbqkeys;8441;ftbqlocalkeys,ftbqkeys;FTB任务本地化键：重置;Re-FTBQLocalizationKeys;Re-FTBQKeys
 enchantment-sort;8442;enchsort;附魔排序;Enchantment Sort;
 wrapfix;8443;wrapfix;换行修复;WrapFix;
 gem-crabs;8444;gem_crab;宝石蟹;Gem Crabs;
@@ -8335,7 +8332,7 @@ async-locator;8544;asynclocator;Async Locator;;
 minemention;8545;minemention;提及;MineMention;
 umapyoi;8546;umapyoi;马儿蹦跳;Umapyoi;
 origins-full-moon;8547;originsfullmoon;起源：满月;Origins: Full Moon;
-codechickenlib-unofficial;8548;codechickenlib;CodeChickenLib Unofficial;;CCLU
+codechickenlib-unofficial;8548;;CodeChickenLib Unofficial;;CCLU
 codechickencore-unofficial;8549;CodeChickenCore;鸡块核心非官方版;CodeChickenCore Unofficial;CCCU
 permafrost-biome;8550;permafrost_biome;permafrost biome;;
 ;8551;;苹果肉;AppleFlesh;AF
@@ -8354,7 +8351,7 @@ naturalized;8563;naturalized;Naturalized;;
 ;8564;disenchanter;祛魔;Disenchanter;
 rsls;8565;rsls;Raise Sound Limit Simplified;;
 emi-loot;8566;emi_loot;EMI Loot;;
-;8567;mfs;MC百科闪烁标语;MCmod Flashing Slogan;MFS
+;8567;mfs;MC百科闪烁标语;MCmod Splashes;MS
 backhand;8568;backhand;Backhand;;
 ;8569;stones_cookbook;Stone的烹饪书;Stone's Cookbook;SC
 farmers-delight-jei-plugin;8571;fdjei;Just Enough Farmer's Recipes;;
@@ -8363,7 +8360,7 @@ tales-of-villagers-the-infiltrators;8573;infiltrators;村民之书：渗透者;T
 ;8574;morecullingextra;More Culling Extra;;
 carpet-fixes;8575;carpet-fixes;Carpet-Fixes;;
 er-core;8576;ercore;ER 核心;ER Core;ERC
-rings-of-ascension;8577;ringsofascension;Rings of Ascension;;
+rings-of-ascension;8577;ringsofascension;提升戒指;Rings of Ascension;
 ;8578;;凡人修仙前置;;
 ;8579;yuanchuzhushou;修士小助手;;
 ;8580;minecraft-command-permissions;Minecraft Command Permissions Fabric;;
@@ -8392,7 +8389,7 @@ table-top-craft;8602;table_top_craft;Table Top Craft;;
 ddyc;8603;dont_drop_your_compass;Dont Drop Your Compass;;DDYC
 ;8604;stonecutter_damage_mr;Stonecutter Damage;;
 shipping;8605;shipping;Shipping;;
-structureutils;8606;;StructureUtils;;
+structureutils;8606;sutils;StructureUtils;;
 ;8607;cloudmusic;云音乐;CloudMusic;
 i-like-wood;8608;ilikewood;I Like Wood;;
 macaws-furnitures-biomes-o-plenty;8609;mcwfurnituresbop;Macaw的家具：超多生物群系附属;Macaw's Furnitures - Biomes O' Plenty;
@@ -8402,13 +8399,13 @@ news-pillagers;8612;illager_plus;News Pillagers;;
 rangers-haven;8613;rangers_haven;Ranger's Haven;;
 heyberryshutup;8614;heyberryshutup;Hey Berry! SHUT UP;;
 destroy-on-death;8615;destroyondeath;Destroy on Death;;
-yes-steve-model;8616;yes_steve_model;是，史蒂夫模型;Yes Steve Model;YSM
+;8616;yes_steve_model;是，史蒂夫模型;Yes Steve Model;YSM
 macaws-roofs-oh-the-biomes-youll-go;8617;macawsroofsbyg;Macaw的屋顶：你将去的生物群系附属;Macaw's Roofs - Oh The Biomes You'll Go;
 macaws-roofs-biomes-o-plenty;8618;macawsroofsbop;Macaw的屋顶：超多生物群系附属;Macaw's Roofs - Biomes O' Plenty;
 configured-feature-saplings;8619;configured_feature_saplings;Configured Feature Saplings;;
 coyote-time;8620;coyote_time;Coyote Time;;
 ;8621;LegacyJavaFixer;Legacy Java Fixer;;
-macaws-bridges-modding-legacy;8622;mcwbridgesmoddinglegacy;Macaw的桥梁：Modding Legacy 附属;Macaw's Bridges - Modding Legacy;
+macaws-bridges-modding-legacy;8622;mcwbridgesmoddinglegacy;Macaw 的桥梁：Modding Legacy 附属;Macaw's Bridges - Modding Legacy;
 macaws-bridges-aurora;8623;mcwbridgesaurora;Macaw的桥梁：Aurora 附属;Macaw's Bridges - Aurora;
 betterlands;8624;betterlands;Betterlands;;
 koremods;8625;koremods;Koremods;;
@@ -8429,8 +8426,8 @@ lunar-mana-generator;8639;lunar_mana;月光魔能制造器;Lunar Mana Generator;
 ost-overhaul;8640;ostoverhaul;Ost Overhaul;;
 chunk-by-chunk;8641;chunkbychunk;Chunk By Chunk;;
 beyond-planets-core;8642;;飞越群星：核心;Planeteer - Core;
-webdisplays;8643;webdisplays;内置网页浏览器;Webdisplays;
-mcef-forge;8644;;Minecraft Chromium嵌入式框架;MCEF [Forge];
+webdisplays;8643;webdisplays;内置网页浏览器;WebDisplays;WD
+mcef;8644;mcef;Minecraft Chromium 嵌入式框架;Minecraft Chromium Embedded Framework;MCEF
 ;8645;;Custom Throwable Weapons+;;
 ;8646;;神秘农业：基岩版;Mystical Agriculture: Bedrock Edition;
 ;8647;;Strat's Food Expansion;;
@@ -8512,7 +8509,7 @@ tech-reborn-patchouli;8723;tr-patchouli;Tech Reborn Patchouli;;
 biome-bundle;8724;biomebundle;Biome Bundle;;
 moon-phase-info;8725;moonphaseinfo;Moon Phase Info;;
 ;8726;fabwork;Fabwork;;
-projecte-max;8727;projecte.max;等价交换max;ProjectE Max;PEMAX
+;8727;projecte.max;等价交换max;ProjectE Max;PEMAX
 advanced-tweakery;8728;AdvancedTweakery;Advanced Tweakery;;
 creeper-hector;8729;creeper_hector;Creeper Hector;;
 tightened-village-security;8730;villagesecurity;Tightened Village Security;;
@@ -8537,9 +8534,9 @@ thaumic-travelers-dream;8747;thaumictravelersdream;Thaumic Traveler's Dream;;TTD
 ;8749;flashlight;Flashlight mod;;
 aetherium-ashen-armor;8750;aetheriumashenarmor;Aetherium Ashen Armor;;
 smoothmenu;8751;smoothmenu;平滑菜单;Smooth Menu;
-;8752;cabricality;Cabricality;;
-unusual-fish;8753;unusualfish;独特鱼类;Unusual Fish;
-obscure-tooltips;8754;;Obscure Tooltips;;
+cabricality;8752;cabricality;Cabricality;;
+unusual-fish;8753;unusualfish,unusualfishmod;独特鱼类;Unusual Fish Mod;
+obscure-tooltips;8754;obscure_tooltips;Obscure Tooltips;;
 ;8755;xibao;喜报-低版本移植版;XiBao;
 ;8756;transformersg1;变形金刚G1;Transformers Mod: G1 Edition;
 otg-tutorial-world;8757;otgtutorialworld;OTG: Tutorial World;;
@@ -8589,7 +8586,7 @@ zenscroll;8800;zenscroll;ZenScroll;;
 zentraits;8801;zentraits;ZenTraits;;
 l2-archery;8802;l2archery;莱特兰-弓艺;L2 Archery;
 vanity-metallurgical;8803;vanity_metallurgical;Vanity: Metallurgical;;
-minespaceex;8804;;MineSpaceEX;;MSEX
+minespaceex;8804;minespaceex;MineSpaceEX;;MSEX
 gregious-maximus;8805;gregiousmaximus;Gregious Maximus;;
 shut-up-model-loader;8806;shutupmodelloader;Shut Up, Model Loader!;;SUML
 cultural-delights-fabric;8807;culturaldelights;多元乐事（Fabric版）;Cultural Delights [Fabric];
@@ -8598,22 +8595,22 @@ bones-and-swords;8809;bonesandswords;Bones And Swords;;
 vanity-shedds-mystical-toolsets-pack;8810;sheddmersopal;Vanity: Shedd's Mystical Toolsets Pack;;
 emc-builders-wand;8811;emcbuilderswand;EMC Builders Wand;;
 vanity-charcutier;8813;vanity_charcutier;Vanity: Charcutier;;
-hunger-in-peace;8814;HungerInPeace;Hunger In Peace;;
+hunger-in-peace;8814;HungerInPeace,hungerinpeace;Hunger In Peace;;
 ;8815;;复杂枪械;complex guns;CG
 lexicon;8816;lexicon;Lexicon;;
 scaffolding-drops-nearby;8817;scaffoldingdropsnearby,scaffoldingdropsnearby-fabric;Scaffolding Drops Nearby;;
-;8818;fuelinfo;FuelInfo;;
+fuel-info;8818;fuelinfo;FuelInfo;;
 glacier-ice;8819;GlacierIce;Glacier Ice;;
 gtnhmixins;8820;gtnhmixins;GTNH Mixins;;
 dawn-to-dusk;8821;projectdown;Project Dawn;;
 open-tower-defence;8822;opentd;开放式塔防;Open Tower Defence;OpenTD
-mtr-station-decoration;8823;msd;MTR Station Decoration;;MSD
+mtr-station-decoration;8823;msd;MTR车站装饰;Station Decoration;MSD
 perviaminvenire;8824;per_viam_invenire;PerViamInvenire;;PVI
 silverbirch;8826;silverbirch;Silver Birch;;
 ;8827;mublueprint;蓝图;Mublueprint;
 ;8828;flamesweeping;烈焰横扫;Flame Sweeping;
 creepypastas-mod;8829;creepypastas_mod;CreepyFights;;
-more-slab;8830;;More slab;;
+more-slab;8830;more_slab;More slab;;
 landk-brick;8831;landk_block_brick;LandK brick;;
 kubejs-offline;8832;kubejsoffline;KubeJS离线文档;KubeJS Offline Documentation;
 ;8833;bannerpp;Banner++;;
@@ -8634,7 +8631,7 @@ fabric-furnaces;8848;fabric-furnaces;Fabric Furnaces;;
 ;8849;;UIN;;
 mixinbooterlegacy;8850;mixinbooter;MixinBooterLegacy;;
 basalt-walker-reborn;8851;bswk;玄武岩行者：重生;Basalt Walker : Reborn;
-create-industrial-chemistry;8852;createindustrialchemsitry;机械动力：工业化学;Create: Industrial Chemistry;CIC
+create-industrial-chemistry;8852;createindustrialchemistry;机械动力：工业化学;Create: Industrial Chemistry;CIC
 ;8853;oct;万能工作台;Omnipotent Crafting Table;OCT
 ;8854;fl_flaming_fabric,fl_flaming_forge;火焰熊熊;Flaming;FL
 cruelars-triforcemod;8855;cruelars_triforcemod;Cruelars Triforcemod;;
@@ -8648,7 +8645,7 @@ goldfish-myth;8862;;Goldfish Myth;;
 rezombies;8863;;ReZombies;;
 wound;8864;wound;外伤;Wound;
 survival-campfire;8865;survival_campfire;Survival Campfire;;
-eyes-mod;8866;;Eye Blocks;;
+eyes-mod;8866;eyes;Eye Blocks;;
 ;8867;lnrepair_2317;提示栏换行;\n Repair;
 colorful-rods;8868;colorful_rods;缤纷彩烛;Colorful Rods;
 xp-plus;8869;xpplus;XP-Plus;;
@@ -8669,7 +8666,7 @@ botanical-addons;8882;shadowfox_botany;Botanical Addons;;
 hodgepodge;8884;hodgepodge;Hodgepodge;;
 fast-projectile-fix;8885;fast_projectile_fix;Fast Projectile Fix;;
 edivadlib;8886;edivadlib;EdivadLib;;
-systeams;8887;systeams;Thermal Systeams;;
+systeams;8887;systeams;热力系列：蒸汽锅炉;Thermal Systeams;
 waymaker;8888;waymaker;Waystone Waypoint Maker;;
 ;8889;mixingasm;Mixingasm;;
 dmod;8890;dmod;D-Mod;;
@@ -8680,7 +8677,7 @@ basketcase;8894;basketcase;Basketcase;;
 primal-lib;8895;primallib;Primal Lib;;
 biomes-youll-go-1-12-2-fixed;8896;byg;你将去的生物群系修复版;Biomes You'll Go Fixed;
 rune-crafting;8897;runes;符文;Runes;
-controlled-random;8898;;Controlled Random;;
+controlled-random;8898;controlled_random;Controlled Random;;
 leos-bosses;8899;;Leo的Boss;Leo's Bosses;LB
 leos-illagers;8900;;Leo's Illagers;;LI
 ;8901;moving_piston_mod;移动的活塞;Block 36 Mods;
@@ -8713,15 +8710,15 @@ minegooseduck;8927;joyggd;Mine Goose Duck;;GGD
 floating-islands;8928;;Terrarian Floating Islands;;
 ;8929;mineshell;MineShell;;MSH
 ;8930;qwq;QωQ Library;;
-scorched-guns;8931;scorchedguns;~SCORCHED GUNS~;;
+scorched-guns;8931;scorchedguns,scguns;~SCORCHED GUNS 2~;;
 ;8932;createplus;CreatePlus1.19分支;;CP
 fred-qol;8933;fred;Fred;;
 mekanism-ce-unofficial;8934;mekanism;通用机械社区版：非官方;Mekanism CE Unofficial;MekCEu
 guntopia-legend-of-the-guns;8935;tylerdirden_guntopia;Guntopia Legend of the Guns;;
 ;8936;slots-checker;Slots Checker;;
-;8937;carpet-ams-addition;Carpet AMS Addition;;
+carpet-ams-addition;8937;carpet-ams-addition;Carpet AMS Addition;;
 pixelmon-gameshark;8938;gameshark;Gameshark;;
-hidden-creepers-creepers-pretend-to-be-other-mobs;8939;;Hidden Creepers;;
+hidden-creepers-creepers-pretend-to-be-other-mobs;8939;fakemob;Hidden Creepers;;
 ob-core;8940;ob_core;Obscuria's Essentials;;
 ob-pandorica;8941;pandorica;Pandoricа;;
 no-weather-effects;8942;noweathereffects;No Weather Effects;;
@@ -8729,7 +8726,7 @@ ob-tooltips;8943;ob_tooltips;Obscuria's Tooltips;;
 hekate-lib;8944;hekate_lib;Hekate Lib;;
 loot-journal;8945;loot_journal;Loot Journal;;
 ;8946;flansmod;Flan's Mod Ultimate 1.1 Modified;;FMUM
-repurposed-structures-better-ocean-monuments;8947;;结构变体：YUNG的海底神殿优化兼容数据包;Repurposed Structures - Better Ocean Monuments Compat Datapack;
+repurposed-structures-better-ocean-monuments;8947;repurposed_structures_yungs_better_ocean_monuments_compat;结构变体：YUNG 的海底神殿优化兼容数据包;Repurposed Structures - Better Ocean Monuments Compat Datapack;
 repurposed-structures-better-desert-temples-compat;8948;;结构变体：YUNG的沙漠神殿优化兼容数据包;Repurposed Structures - Better Desert Temples Compat Datapack;
 repurposed-structures-savage-ravage-datapack;8949;;结构变体：残暴与掠夺兼容数据包;Repurposed Structures - Savage & Ravage Compat Datapack;
 repurposed-structures-oh-the-biomes-youll-go;8950;;结构变体：你将去的生物群系兼容数据包;Repurposed Structures - Oh The Biomes You'll Go Compat Datapack;
@@ -8739,11 +8736,11 @@ repurposed-structures-friends-and-foes-datapack;8953;;结构变体：Friends & F
 repurposed-structures-farmers-delight-datapack;8954;;结构变体：农夫乐事兼容数据包;Repurposed Structures - Farmer's Delight Compat Datapack;
 repurposed-structures-better-witch-huts-compat;8955;;结构变体：YUNG的沼泽小屋优化兼容数据包;Repurposed Structures - Better Witch Huts Compat Datapack;
 repurposed-structures-better-strongholds-datapack;8956;;结构变体：YUNG的要塞重制兼容数据包;Repurposed Structures - Better Strongholds Compat Datapack;
-repurposed-structures-better-dungeons-datapack;8957;;结构变体：YUNG的地牢优化兼容数据包;Repurposed Structures - Better Dungeons Compat Datapack;
+repurposed-structures-better-dungeons-datapack;8957;;结构变体：YUNG 的地牢优化兼容数据包;Repurposed Structures - Better Dungeons Compat Datapack;
 repurposed-structures-hexerei-datapack-compat;8958;;结构变体：Hexerei 兼容数据包;Repurposed Structures - Hexerei Compat Datapack;
 repurposed-structures-ice-and-fire-datapack-compat;8959;;结构变体：冰火传说兼容数据包;Repurposed Structures - Ice and Fire Compat Datapack;
 repurposed-structures-advanced-peripherals-compat;8960;;结构变体：Advanced Peripherals 兼容数据包;Repurposed Structures - Advanced Peripherals Compat Datapack;
-repurposed-structures-pneumaticcraft-repressurized;8961;;结构变体：气动工艺兼容数据包;Repurposed Structures - PneumaticCraft: Repressurized Compat Datapack;
+repurposed-structures-pneumaticcraft-repressurized;8961;repurposed_structures_pneumaticcraft_repressurized_compat;结构变体：气动工艺兼容数据包;Repurposed Structures - PneumaticCraft: Repressurized Compat Datapack;
 repurposed-structures-bountiful-datapack-compat;8962;;结构变体：赏金兼容数据包;Repurposed Structures - Bountiful Compat Datapack;
 structure-floater-fabric;8963;structure_floaters;Structure Floater;;
 applecore-unofficial;8964;AppleCore;苹果核非官方版;Applecore Unofficial;
@@ -8762,7 +8759,7 @@ monoblocks;8977;Monoblocks;Monoblocks;;
 tinkers-things-json;8978;tinkers_things;匠魂杂物;Tinkers' Things;
 free-cam;8979;freecam;Freecam;;
 workings;8980;workings;Workings;;
-;8981;mod-loading-screen;Mod Loading Screen;;
+;8981;mod-loading-screen;模组加载屏幕;Mod Loading Screen;
 lucky-cases;8982;lucky_cases;Lucky Cases;;
 atmosfera;8983;atmosfera;Atmosfera;;
 feruchemy-allomancy;8984;feruchemy;藏金术;Feruchemy;
@@ -8838,7 +8835,7 @@ superfancyclouds-refabricated;9053;sfcr;超级华丽云：重筑版;SuperFancyCl
 ;9054;;浮空岛数据包;FloatingIslands;
 pet-tracker;9055;pettracker;Pet Tracker;;
 ;9056;splashfox;狐狸加载界面;SplashFox;
-;9057;taptab;Tap Tab;;
+tap-tab;9057;taptab;Tap Tab;;
 mekanism-ce-tools;9058;MekanismTools;通用机械工具：社区版;Mekanism Community Edition: TOOLS;MEKCET
 mekanism-ce-generators;9059;MekanismGenerators;通用机械发电机：社区版;Mekanism Community Edition: GENERATORS;MEKCEG
 ;9060;ten3;Technical Engineering 3 Quilted;;TEN3Q
@@ -8860,15 +8857,15 @@ golden-delicacies;9075;golden_delicacies;Golden Delicacies;;
 hightiercrops;9076;ic2HighTierCrops;HighTierCrops;;
 commandspy;9077;cmdspy;CommandSpy;;
 slimyfloor;9078;slimyfloor;SlimyFloor;;
-daily-dad;9079;dailydad;每日冷笑话;Daily Dad;
+daily-dad;9079;dailydad,dailydad_server;每日冷笑话;Daily Dad;
 good-ending;9080;goodending;Good Ending;;
 creeper-nuggets;9082;creepernuggets;Creeper Nugget;;
-coherent-villages;9083;;Coherent Village;;
+coherent-villages;9083;coherentvillages;Coherent Village;;
 ;9084;;Unicode扩展字符支持;UnicodeFontExtend;
 ;9085;;发包崩服修复;PacketCrashFix;
 terrains;9086;terrains;Terrains;;
 ;9087;bugtorch;BugTorch;;
-better-tridents;9088;bettertridents;更好的三叉戟;Better Tridents;
+better-tridents;9088;bettertridents;更好的三叉戟;Better Tridents;BT
 undead-unleashed;9089;undead_unleashed;Undead Unleashed;;
 missing-wilds;9090;missingwilds;遗落荒野;Missing Wilds;
 ;9091;objparticle;obj particle;;op
@@ -8883,9 +8880,9 @@ welcome-to-the-jungle;9097;thejungle;丛林传说;Welcome to the Jungle;
 transparent;9100;transparent;Transparent;;
 hopperplus-instant-hoppers;9101;hopr;HopperPlus;;
 sbm-merpig;9102;merpig;Merpig;;
-;9103;lwjgl3ify;LWJGL3ify;;
+lwjgl3ify;9103;lwjgl3ify;LWJGL3ify;;
 ;9104;mcopper;原版主义;Mcopper;
-;9105;mine_treasure_mr;Mine Treasure;;
+;9105;mine_treasure_mr,mr_mine_treasure;Mine Treasure;;
 creates-delight;9106;createsdelight;机械动力乐事;Create's Delight;
 mo-villager;9107;redstonevillager;更多村民;Mo' Villager;
 ;9108;chinacraft;华夏文明2Fabric版;ChinaCraft for Fabric;CC2F
@@ -8917,13 +8914,13 @@ betweencards;9131;betweencards;Betweencards;;
 ;9134;;物品展示台;Item Displayer;
 ;9135;fire_track;烈焰轨迹;FireTrack;
 ;9136;create_dragon_lib;机械龙库;Create Dragon Lib;
-;9137;google-chat;GoogleChat;;
+google-chat;9137;google-chat;GoogleChat;;
 ;9138;resclone;Resclone;;
-tame-them-all;9139;;Tame Them All!;;
+tame-them-all;9139;tame_them_all;Tame Them All!;;
 ;9140;djyy;建筑楼层批量复制;Bulk copy of building floor;BCBF
 little-contraptions;9141;littlecontraptions;Little Contraptions;;
 choicetheorems-overhauled-village-farmer-delight;9142;mr_ctov_farmersdelightcompat;CTOV：农夫乐事兼容数据包;CTOV - Farmer Delight Compat;
-convenient-decor;9143;;精简锦饰;Convenient Decor;
+convenient-decor;9143;convenientdecor;精简锦饰;Convenient Decor;
 mixin-conflict-helper;9144;mixin-conflict-helper;Mixin Conflict Helper;;
 create-decoration-casing;9145;create_deco_casing;Create Decoration Casing;;
 create-brass-coated;9146;create_brass_coated;机械动力：黄铜覆壳;Create: Brass Coated;
@@ -8937,7 +8934,7 @@ ninezeros-gun-mod-addon;9153;nzgmaddon;NineZero's Gun Expansion;;
 donthurtthatboat;9154;donthurtthatboat;DontHurtThatBoat;;
 ;9155;horsebuff;Horse Buff;;
 enchanting-table-descriptions;9156;enchanting-table-descriptions;附魔台描述;Enchanting Table Descriptions;ETD
-harvest-with-ease;9157;harvestwithease;Harvest with ease;;
+harvest-with-ease;9157;harvestwithease,harvest_with_ease;Harvest with ease;;
 trade-refresh;9158;traderefresh;交易刷新;Trade Refresh;TR
 create-molten-geodes;9159;molten_geodes;Create: Molten Geodes;;
 thats-a-lot-of-items;9160;taloi;That's A Lot Of Items;;TALOI
@@ -8953,13 +8950,12 @@ why-does-my-food-taste-like-that;9169;whydoesmyfoodtastelikethat;Why Does My Foo
 iron-generators;9170;irongenerators;Iron Generators;;
 elytra-swapper-forge;9171;elytraswapperforge;鞘翅切换;Elytra Swapper;
 ftb-team-islands-forge;9172;ftbteamislands;FTB Team Islands;;
-nightmare-craft-memeshrooms;9173;nmcshrooms;梦魇工艺：蘑菇;Nightmare Craft: MEMESHROOMS;
 market-crates;9174;marketcrates;集市板条箱;Market Crates;
 industrial-renewal-port;9175;industrialrenewal;工业复兴移植版;Industrial Renewal Port;
 tfcm;9176;tfc_metallum;群峦合金非官方版;TFC Metallum U;
 tnt-time-mod;9177;samhoque.forge.tnttime;TNT Time Mod;;
 drunken-mug;9178;drunken_mug;Drunken Mug;;
-cartoonish-horde-library;9179;cartoonishhorde;Cartoonish Horde Library;;
+cartoonish-horde-library;9179;cartoonishhorde,villainoushordemanager;Villainous Horde Manager;;
 limited-lives;9180;limitedlives;有限生命;Limited Lives;
 universe-box;9181;universebox;Universe Box;;
 invtweaks-emu-for-ipn;9182;invtweaksemuforipn;InvTweaks Emu for IPN;;
@@ -8978,8 +8974,8 @@ cold-snap-horde;9195;coldsnaphorde;Cold Snap Horde;;
 tis-the-season;9196;tistheseason;Tis The Season;;
 ;9197;;更多镶嵌材质;;
 ;9198;baubles,baublesexpanded;Baubles Expanded;;
-cobblehaters;9199;;CobbleHaters;;
-;9200;mob_captains_mr;怪物队长;Mob Captains;
+cobblehaters;9199;CblH8Rs;CobbleHaters;;
+mob-captains;9200;mob_captains_mr,mobcaptains;怪物队长;Mob Captains;
 ;9201;thewandofrunning;跑搭之杖;The Wand Of Running;TWOR
 ;9202;sound_track;Sound-Track;;
 snowballing;9203;snowballing;Snowballing;;
@@ -8998,7 +8994,6 @@ spruce-willis-the-xmas-tree;9215;sprucewillisthexmastree;Spruce Willis the Xmas 
 sweet-potato-core-spc;9216;;地瓜核心;Sweet Potato Core;SPC
 merge-enchantments;9217;merenc;Merge Enchantments;;
 turkey;9218;turkey;火鸡;Turkey;
-nightmare-craft-legendary-gear;9219;nmcgear;梦魇工艺：传奇装备;Nightmare Craft: Legendary Gear;
 snowy-weaponry;9220;snowyweaponry;Snowy Weaponry;;
 dungeon-mobs-reborn;9221;dungeonmobs;Dungeon Mobs Reborn;;
 quickteleports;9222;quickteleports;Quick Teleports;;
@@ -9013,7 +9008,6 @@ fat-chicken;9230;fatchicken;Fat Chickens;;
 ;9231;;强化生物;;
 snowmancy;9232;snowmancy;Snowmancy;;
 ;9233;roadchina;道路中国;Road China;RCN
-nightmare-craft-decorations;9234;nmcdecorations;梦魇工艺：装饰品;Nightmare Craft: Decorations;
 ;9235;immersivesnow;Immersive Snow;;
 ;9236;note;备注;note;
 functional_tfc;9237;functional_tfc;Functional TFC;;
@@ -9033,11 +9027,10 @@ doespotatotick;9249;does_potato_tick,doespotatotick;远物停载：土豆版;Doe
 welcome-to-meadow;9251;meadow;青青草甸;Let's do Cheese! / Meadow;
 universal-enchants-forge;9252;universalenchants;通用附魔;Universal Enchants;
 aa-farmer-compat;9253;farmeradditions;AA Farmer Compat;;
-;9254;sctz_ywsj;生存挑战之意外事件;;ywsj
+;9254;sctz_ywsj;只要听话就不会死！;;
 ;9255;configurable-firework-explosion;可配置的烟花爆炸;Configurable Firework Explosion;CFE
 ;9256;;内修炼体（属性加点）;;
 better-crates;9257;bettercrates;Better Crates;;
-nightmare-craft-auto-factory;9258;nmcfactory;Nightmare Craft: Auto Factory;;
 vanillaicecreamfix;9259;vanillaicecreamfix;VanillaIcecreamFix;;
 actually-unbreaking-forge;9260;actuallyunbreaking;Actually Unbreaking;;
 handcrafted;9261;handcrafted;精巧手艺;Handcrafted;
@@ -9048,32 +9041,30 @@ easywhitelist;9265;easywhitelist;EasyWhitelist;;
 clayworks;9266;clayworks;Clayworks;;
 miniscaled;9267;miniscaled;MiniScaled;;
 lost-cities-potato-edition;9268;lostcities;失落的城市：土豆版;Lost Cities: Potato Edition;
-endless-noend;9269;;Endless / NoEnd;;
+endless-noend;9269;endless;Endless / NoEnd;;
 matmos-2;9270;matmos;MAtmos 2 sound effect;;
 tfc-item-barrels;9271;tfcbarrels;TFC Item Barrels;;
-nightmare-craft-super-foods;9272;nmcfoods;Nightmare Craft: Super Foods;;
 villagersplus-forge;9273;villagersplus;VillagersPlus;;
-data-criteria;9274;;Data Criteria;;
+data-criteria;9274;datacriteria;Data Criteria;;
 japanese-emoji-commands;9275;japaneseemojicommands;Japanese Emoji Commands;;
 attack-on-christmas;9276;aoc;Attack On Christmas;;
 voxel-latest;9278;voxellatest-remapper,voxellatest;Voxel Latest;;
 the-printer;9279;theprinter;The Printer;;
 ;9280;ecohelper;经济小助手;EcoHelper;EH
 flying-cullers;9281;flyingcullers;Flying Culler;;
-timeless-power;9282;;Timeless Power;;
+timeless-power;9282;timelesspower;Timeless Power;;
 create-deco-fabric-fixed;9283;;Create Deco Fabric Fixed;;
 calibrated;9284;calibrated;Calibrated Access;;
 frozen-memories;9285;frozenmemories;Frozen Memories;;
 atlantis-api;9286;atlantis;Atlantis API;;
 nutritional-balance;9287;nutritionalbalance;Nutritional Balance;;
 profession-lock;9288;proflock;Profession Lock;;
-nightmare-craft-mobs;9289;nmcmobs;Nightmare Craft: Mobs;;
 spectrum-jetpacks;9290;spectrumjetpacks;Spectrum Jetpacks;;
 difficult-caves;9291;;Difficult Caves;;
 ;9292;experience_shards_mr;Experience Shards;;
 spartanlands-rereforged;9293;;Spartanlands Rereforged;;
 red-pandas;9294;redpandas;Red Pandas;;
-;9295;opj;收纳袋;;
+;9295;bundle;收纳袋;;
 simple-cobblestone-generator-forge;9296;simple_cobblestone_generator;Simple Cobblestone Generator;;
 floral-flair-fabric;9297;floral_flair;🌷Floral Flair🌷;;
 vertical-slabs-compat;9298;v_slab_compat;Vertical Slabs Compat;;VSC
@@ -9084,20 +9075,18 @@ spawn-animations;9302;spawn_animations_mr;Spawn Animations;;
 head-in-the-clouds;9303;head_in_the_clouds;Head in the Clouds;;
 fdmc;9304;fdmc;HyperWorld;;
 rpg-style-more-weapons;9305;rpgsmw;⚔️ RPG style More Weapons!;;
-nightmare-craft-guns-explosives;9306;nmcguns;Nightmare Craft: Guns & Explosives;;
 siriuss-origins-origins-datapack;9307;;Sirius's Origins - Origins Datapack;;
-easy-experience;9308;;Easy Experience;;
+easy-experience;9308;easyexperience;Easy Experience;;
 ;9309;originiumtech;源石科技;OriginiumTech;OT
 full-turtle-armor;9310;fullturtlearmor;Full Turtle Armor;;
 choicetheorems-overhauled-village-waystone;9311;ctov_waystonecompat_mr;CTOV：传送石碑/指路石兼容数据包;CTOV - Waystone Compat;
 choicetheorems-overhauled-village-more-villagers;9312;mr_ctov_morevillagerscompat;CTOV：更多村民兼容数据包;CTOV - More villagers compat;
-tokusatsu-hero-completion-plan;9313;tokusatsu_hero_completion_plan;特摄英雄补完计划;Tokusatsu Hero Completion Plan;THCP
+tokusatsu-hero-completion-plan;9313;tokusatsu_hero_completion_plan;特摄英雄补完计划;Tokusatsu Hero Instrumentality Project;THIP
 ;9314;djyy;对江的现代生存模组;Djyy's morden survival mod;DMSM
 ;9315;hardcodepatcher;硬编码文本补丁;HardcodePatcher/HardcodeTextPatcher;HP/HTP
 spyglass-astronomy;9316;spyglass_astronomy;Spyglass Astronomy;;
 mchalo;9317;mchalo;MCHalo;;
 darkmenu-darkrpg-legacy-menu;9318;darkmenu;DarkMenu - DarkRPG Menu (RPG Theme);;
-nightmare-craft-game-engine;9319;;Nightmare Craft: Game Engine;;
 rl-artifacts;9320;artifacts;奇异饰品-RLCraft版;RLArtifacts;
 azurelib;9321;azurelib;AzureLib;;
 harder-monster-boats-finer-boat-control;9322;hardermonsterboats;Harder Monster Boats;;
@@ -9105,8 +9094,8 @@ spyglass-improvements;9323;spyglass-improvements,spyglass_improvements;望远镜
 vanilla-zoom;9324;vanillazoom;Vanilla Zoom;;
 time-in-a-bottled;9325;timeinabottled;Time in a Bottled;;
 improved-end;9326;improved_end;Improved End;;
-raw-block-smelting;9327;;Raw Block Smelting;;
-nocubes-better-blast-furnace;9328;;NoCube's Better Blast Furnace;;
+raw-block-smelting;9327;raw_block_smelting;Raw Block Smelting;;
+nocubes-better-blast-furnace;9328;ncbetterblastfurnace;NoCube's Better Blast Furnace;;
 bugjump;9329;bugjump;BugJump;;
 cluttered;9330;luphieclutteredmod;Cluttered;;
 digitality;9331;digitality;DigitalityAPI;;
@@ -9119,7 +9108,7 @@ female-villagers;9336;femalevillagers;女性村民;Female Villagers;
 subaquatic;9338;subaquatic;Subaquatic;;
 leos-sans;9339;sansmod;Leo's Sans;;LS
 ;9340;damagevignette;DamageVignette;;
-no-irom-farm;9341;;No Iron Farm;;
+no-irom-farm;9341;no_iron_farm;No Iron Farm;;
 amethyst-tools-mod;9342;amethysttoolsmod;Amethyst Tools Mod;;
 ;9343;grateblocks;Grate Blocks;;
 lush-forests;9344;lushforest;Lush Forests;;
@@ -9151,7 +9140,7 @@ beneath-the-wetlands;9369;wetlands;Beneath the Wetlands;;
 ;9370;go_shopping;购物同乐;With Shopping！;
 add-on-the-abyss-beginning;9371;thebeginning;The Abyss: Beginning;;
 reusable-rockets;9372;reusable_rockets;Reusable Rockets;;
-item-info;9373;;Item Info;;
+item-info;9373;minecraftenchant;Item Info;;
 florist;9374;florist;Florist;;
 omni;9375;omni;Omni;;
 frostrealm;9376;frostrealm;FrostRealm;;
@@ -9164,7 +9153,7 @@ nan-health-fixer;9381;nanhealthfixer;假死修复：土豆版;Potato NaN Health 
 blood-and-stuff;9383;blood_and_stuff;Blood and Stuff;;
 yungs-better-nether-fortresses;9384;betterfortresses;YUNG的下界要塞优化;YUNG's Better Nether Fortresses;
 squidless;9385;Squidless;Squidless;;
-;9386;modmenu;Mod Menu Legacy;;
+;9386;;Mod Menu Legacy;;
 enders-delight;9387;endersdelight;末影乐事;Ender's Delight;
 decostorage;9388;deco_storage;Decorative Storage;;
 mahogany;9389;mahogany;Mahogany;;
@@ -9178,7 +9167,7 @@ valkyrien-computers;9396;vc;Valkyrien Computers;;VC
 blazeandcaves-advancements-pack;9397;blazeandcave;BlazeandCave's Advancements Pack;;BACAP
 gems-jewels;9398;gemsnjewels;Gems & Jewels;;
 ;9399;angling;Angling;;
-dimensional-sync-fixes;9400;dimensionalsycnfixes;维度同步修复;;
+dimensional-sync-fixes;9400;dimensionalsyncfixes;维度同步修复;Dimensional Sync Fixes;
 exhaustion-fatigue;9401;exhaustion_fatigue;Exhaustion Fatigue;;
 chainmail-bucket;9402;chainmail_bucket;Chainmail Bucket;;
 preciseblockplacing;9403;;Precise Block Placing;;
@@ -9195,7 +9184,7 @@ combat-enchantments;9413;cenchants;Combat Enchantments;;
 fastentitytransfer;9414;fastentitytransfer;Fast Entity Transfer;;
 chalice;9415;;Chalice;;
 ;9416;dtbe;不要饿死基岩版;Don't Starve Bedrock Edition;DTBE
-one-twenty-update;9417;;Minecraft 1.20 One Twenty Update;;
+one-twenty-update;9417;one_twenty;Minecraft 1.20 One Twenty Update;;
 minecraft-middle-ages;9418;mma;Days in the Middle Ages;;
 gibmemojangstudio;9419;;GibMeMojangStudio;;
 redwolf-music-expansion;9420;redwolf_music_mod;RedWolf's Music Expansion;;
@@ -9209,15 +9198,15 @@ propertyerizer;9427;propertyerizer;Propertyerizer;;
 waxable-coral;9428;waxablecoral;涂蜡珊瑚;Waxable Coral;
 ;9429;fireframe;火焰框架;FireFrame;FF
 goated;9430;goated;You've Goat to be Kidding Me!;;
-morebread;9431;;MoreBread;;
+morebread;9431;more-bread;MoreBread;;
 ;9432;DayZ;DayZ for Minecraft：重铸;DayZ for Minecraft：Reforge;
 repurposed-structures-villagerplus-compat-datapack;9433;;结构变体：VillagerPlus 兼容数据包;Repurposed Structures - VillagerPlus Compat Datapack;
-repurposed-structures-chefs-delight-compat;9434;;结构变体：Chef's Delight兼容数据包;Repurposed Structures - Chef's Delight Compat Datapack;
+repurposed-structures-chefs-delight-compat;9434;repurposed_structures_chefs_delight_compat;结构变体：Chef's Delight 兼容数据包;Repurposed Structures - Chef's Delight Compat Datapack;
 ice-prevents-crop-growth;9435;icepreventscropgrowth-fabric;Ice Prevents Crop Growth;;
 ;9436;coins;Coins Mod;;
 glowing-ores;9437;glowingores;矿石发光;Glowing Ores;
 ;9438;NpcBoundBoxFix;NPC碰撞箱修复;NpcBoundBoxFix;
-falsetweaks;9439;falsetweaks;FalseTweaks;;
+falsetweaks;9439;falsetweaks;FalseTweaks;;FT
 metaworlds-unofficial;9440;mwtestmod;元世界：非官方版;Metaworlds Unofficial;
 tslateffectslib;9441;tslateffectslib;TslatEffectsLib;;TEL
 tslatentitystatus-tes;9442;tslatentitystatus;TslatEntityStatus;;TES
@@ -9227,7 +9216,7 @@ config-swapper;9445;configswapper;Config Swapper;;
 viafabricplus;9446;viafabricplus;ViaFabricPlus;;
 menu-companions;9447;menucompanions;Menu Companions;;
 entity-render-distance-extender;9448;erde;Entity Render Distance Extender;;
-rpg-stamina;9449;rpgstamina;RPG Stamina;;
+rpg-stamina;9449;rpgstamina;RPG 耐力;RPG Stamina;
 mjs-animations;9450;mjs_animations;MJ`s Animations;;
 deepslate-generator;9451;deepslategenerator;Deepslate Generator;;
 hairy-zombies;9452;;Hairy Zombies;;
@@ -9235,14 +9224,14 @@ hairy-zombies;9452;;Hairy Zombies;;
 footprintparticle;9454;footprintparticle;脚印粒子;FootprintParticle;
 tabbychat;9455;tabbychat;TabbyChat;;
 ;9456;leafculling;Leaf Culling;;
-unimixins;9457;unimixins,unimixins-mixin,unimixins-compat,mixingasm,spongemixins,mixinbooterlegacy,gasstation,gtnhmixins,mixinextras,unimixins-devcompat;UniMixins;;
-nei-lotr-fa;9458;;魔戒：第一纪元NEI插件;NEI LOTR FA;
+unimixins;9457;unimixins,unimixins-mixin,unimixins-compat,unimixins-devcompat;UniMixins;;
+nei-lotr-fa;9458;;魔戒：第一纪元 NEI 插件;NEI LOTR FA;
 nogravity-mod;9459;nogravity;零重力;NoGravity;
 milk-of-magnesium;9460;milk_of_magnesium;Milk Of Magnesium;;
 ;9461;slumber;Slumber;;
-nei-recipe-handlers;9462;neirecipehandlers;NEI Recipe Handlers;;
+nei-recipe-handlers;9462;neirecipehandlers;NEI Recipe Handlers;;NEIRH
 nox-a-mob-and-difficulty-overhaul;9463;nox;Nox;;
-christmas-festivity;9464;;Christmas Festivity;;
+christmas-festivity;9464;christmasfestivity;Christmas Festivity;;
 tameable-beasts;9465;tameablebeasts;Tameable Beasts;;
 cute-hermit-crabs;9466;cutehermitcrabs;Cute Hermit Crabs;;
 ;9467;ulib;uLib;;
@@ -9256,7 +9245,7 @@ mob-compack;9474;;Mob Compack;;
 kore-sample;9475;koresample;Kore Sample;;
 multiworld;9476;MultiWorld;MultiWorld;;
 ;9477;createenchant;机械动力：附魔附加;Create Enchant Additions;
-peat-zombie;9478;;Peat Zombie;;
+peat-zombie;9478;peat_mummy;Peat Zombie;;
 ragna-goblin-updated;9479;ragnagoblin;Ragna Goblin;;
 demogorgon;9480;;The Demogorgon Mod;;
 haunted-fields;9481;hauntedfields;Haunted Fields;;
@@ -9269,7 +9258,7 @@ villager-brute;9487;villagerbrute;Villager Brute;;
 exspiravit-magicae;9488;;Exspiravit Magicae;;
 equiped;9489;;Equiped;;
 limited-chunkloading;9490;limitedchunk;Limited Chunkloading;;
-custom-villager-trades-forge;9491;;自定义村民交易;Custom Villager Trades;CVT
+custom-villager-trades-forge;9491;customvillagertrades;自定义村民交易;Custom Villager Trades;CVT
 dungeons-more-mod;9492;;Dungeons & More Mod;;
 ancient-trees;9493;dendrology;Ancient Trees;;
 extraskills;9494;extraskills;ExtraSkills;;
@@ -9285,7 +9274,7 @@ clay-soldiers-reborn;9503;clay;Clay Soldiers Reborn;;
 geore;9504;geore;GeOre;;
 mt-claysoldiers2-forge;9505;claysoldiers2;MT: ClaySoldiers2;;
 safekeystring;9506;safekeystring;安全键位名;SafeKeyString;
-loadingtips;9507;;LoadingTips;;
+loadingtips;9507;loadingtips;LoadingTips;;
 gear-o-plenty;9508;gearoplenty;Gear O' Plenty;;
 regional-water;9509;regionalwater;Regional Water;;
 battle-text;9510;BattleText;Battle Text;;
@@ -9297,7 +9286,7 @@ dont-pick-up;9515;DPU;Don't Pick Up;;
 easy-breeding;9516;easybreeding;简单繁殖;Easy Breeding;
 ;9517;betterrain;更好的降雨;Better Rain;
 chemcraft-core;9518;redgear_core;Red Gear Core;;
-;9519;;时间陷阱;TimeTrap;
+;9519;mr_time_trap;时间陷阱;TimeTrap;
 bonsai-man-mod;9520;bonsaimanmod;盆栽人;Bonsai Man Mod;
 ;9521;chatcopier;聊天复制;Chat Copier;
 pet-cemetery;9522;pet_cemetery;Pet Cemetery;;
@@ -9320,10 +9309,10 @@ vending-block-revived;9538;Vending;自动售货机：重生;Vending Block Revive
 assortment;9539;assortment;Assortment;;
 ;9540;ifmodloadboom,howdareyouload;如果你在加载我就梆梆梆 / 你怎么敢加载的啊;IFMODLOADBOOM / HowDareYouLoad;IMLB
 opotato;9541;opotato;哦，土豆！;Opotato;
-contingameime;9542;ingameime;游戏内输入法续更版/游戏内输入法Forge重置版;ContingameIME/IngameIME-Forge/IngameIME-Forged;CIGIME/IGIME
+contingameime;9542;ingameime;游戏内输入法续更版 / 游戏内输入法 Forge 重置版;ContingameIME / IngameIME-Forge / IngameIME-Forged;CIGIME/IGIME
 ccastroadds;9543;ccastroadds;Astro Adds to Chest Cavity;;
 aerial-hell;9544;aerialhell;Aerial Hell;;
-swashbucklers;9545;swashbucklers;Swashbucklers!;;
+swashbucklers;9545;swashbucklers;Swashbucklers;;
 style;9546;doggystyle;Doggy Style;;
 eatable-livestock;9547;eatable_sheep;Eatable Livestock;;
 hunger-strike;9548;hungerstrike;绝食;Hunger Strike;
@@ -9336,7 +9325,7 @@ luppiis-ladders;9553;LLadders;Luppii's Ladders;;
 anthropophagy;9555;anthropophagy;Anthropophagy;;
 ambient-structures;9556;ambient_structures;Ambient Structures;;
 minegicka-iii;9557;minegicka3;魔能3;Minegicka III;
-hopo-better-underwater-ruins;9558;hopobetterunderwaterruins;Hopo Better Underwater Ruins;;
+hopo-better-underwater-ruins;9558;hopobetterunderwaterruins,hopour;Hopo Better Underwater Ruins;;
 ;9559;nighttears;夜影;NightShadow;
 just-another-crafting-bench;9560;JACB;Just Another Crafting Bench;;JACB
 tiny-ents;9561;tiny_ents;Tiny Ents;;
@@ -9353,7 +9342,7 @@ small-boats-mod;9571;smallboats;Small Boats;;
 reimplemented;9572;redev;ReDev / Reimplemented;;
 wands-and-wizardry;9573;;Wands and wizardry;;
 geore-nouveau;9574;;GeOre Nouveau;;
-crimsonsteves-more-mobs;9575;;CrimsonSteve's more mobs;;
+crimsonsteves-more-mobs;9575;crimson_steves_mobs;CrimsonSteve's more mobs;;
 the-ulterlands;9576;ulterlands;Ulterlands: Worlds Apart;;
 mt-lotr;9577;mt-lotr;MT LOTR;;
 asjcore;9578;asjlib,hooklib,worldengine;ASJCore;;
@@ -9369,7 +9358,7 @@ lightspeedmod;9587;lightspeed;Lightspeed;;
 coffee-delight;9588;coffee_delight;咖啡乐事;Coffee Delight;
 simple-sculk-dimension-deeper-dark;9589;;Simple Sculk Dimension;;
 no-more-inifinite-water;9590;finitewater;No more Infinite Water;;
-choo-choo-craft;9591;;Choo-Choo Craft;;
+choo-choo-craft;9591;choochoocharlescraft;Choo-Choo Craft;;
 eco-mobs;9592;;Eco Mobs;;
 classic-hostiles;9593;;Classic Hostiles;;
 chalk-fabric-colorful-addon;9594;chalk-colorful-addon;Chalk (Fabric): Colorful Addon;;
@@ -9377,8 +9366,8 @@ chalk-fabric-colorful-addon;9594;chalk-colorful-addon;Chalk (Fabric): Colorful A
 food-bosses-reheated;9596;;food bosses: reheated!;;
 dreamland-biomes;9597;dreamland;Dreamland Biomes;;
 ;9598;bedrockjukebox;基岩版唱片机;BedrockJukebox;
-environmental-expansion;9599;;Environmental Expansion;;EE
-neutrality;9600;;Neutrality;;
+environmental-expansion;9599;environmentalexpansion;Environmental Expansion;;EE
+neutrality;9600;neutrality;Neutrality;;
 bygone-land;9601;;Bygone Land;;
 the-amazing-world-of-mobs;9602;the_amazing_world_of_mobs;The Amazing World Of Mobs!;;
 falloutcraft;9603;falloutcraft;Falloutcraft;;
@@ -9395,7 +9384,7 @@ improved-hoes;9613;improvedhoes;Improved Hoes;;
 orehider;9614;orehider;OreHider;;
 full-grown-crop-marker;9615;crop_marker;FullGrownCropMarker;;
 ;9616;;Minecraft Seasons Datapack;;
-;9617;realistic_itemdrops_mr;真实物品掉落;Realistic Item Drops;
+;9617;mr_realistic_itemdrops;真实物品掉落;Realistic Item Drops;
 luggage;9618;luggage;行李箱;Luggage;
 ;9619;scorched_mr;Scorched;;
 slime-breeder-advanced;9620;;Slime Breeder Advanced;;
@@ -9406,7 +9395,7 @@ delightful-mining;9622;delightfulmining;Delightful Mining;;
 ;9625;controlling;ModernControlling;;
 trimmable-tools;9626;trimmable_tools_mr;Trimmable Tools;;
 ;9627;tablesaw;锯木台;Tablesaw;
-;9628;glowglass;Glowglass;;
+glowglass;9628;glowglass;Glowglass;;
 all-the-fan-made-discs;9629;all_the_fan_made_discs;All The Fan Made Discs;;ATFMD
 from-the-fog;9630;watching;From The Fog;;
 more-ladders;9631;more_ladders;More+ Ladders;;
@@ -9467,19 +9456,19 @@ tfc_metalwork;9683;tfc_metalwork;群峦金属加工;TFC Metalwork;
 ;9686;natura_repair;自然修补;Natural Repair;NR
 furniture-compatibility-for-macaw-tfc;9687;mcw_tfc_furn;Macaw的家具：群峦传说附属;Furniture Compatibility for Macaw/TFC;
 roof-compatibility-for-tfc-macaw;9688;mcw_tfc_roof;Macaw的屋顶：群峦传说附属;Roof Compatibility for TFC/Macaw;
-;9689;;Cleanroom;;
+;9689;cleanroom;Cleanroom;;
 tfc-supplementaries;9690;tfcsupplementaries;群峦锦致装饰;TFC Supplementaries;
 tfc-ie-crossover;9691;tfc_ie_addon;群峦传说：沉浸工程兼容附属;TFC + IE Crossover;
-bridging-mod;9692;placementpog;Bridging Mod;;
+bridging-mod;9692;placementpog,bridgingmod;Bridging Mod;;
 geode-plus;9693;geode;晶洞+;Geode+;
 cursed-difficulty;9694;curse;Cursed Difficulty;;
-repurposed-structures-yungs-better-nether-fortress;9695;;结构变体：YUNG的下界要塞优化兼容数据包;Repurposed Structures - Yung's Better Nether Fortress Compat Datapack;
+repurposed-structures-yungs-better-nether-fortress;9695;repurposed_structures_yungs_better_nether_fortresses_compat;结构变体：YUNG 的下界要塞优化兼容数据包;Repurposed Structures - Yung's Better Nether Fortress Compat Datapack;
 repurposed-structures-apocalyptic-fortress-compat;9696;;结构变体：Apocalyptic Fortress 兼容数据包;Repurposed Structures - Apocalyptic Fortress Compat Datapack;
 algane;9697;algane;Algane;;
 dawn-of-time;9698;dawnoftimebuilder;Dawn Of Time - Builder Edition;;
 kubejs-projecte;9699;kubejsprojecte;KubeJS ProjectE;;
 biome-backport;9700;biomebackport;Biome Backport;;
-infernal-geode;9701;;Infernal Geode;;
+infernal-geode;9701;infernal_geode;Infernal Geode;;
 geode-o-plenty;9702;;Geode O' Plenty;;
 the-banished;9703;the_banished;The Banished;;
 pufflos;9704;pufflos;Pufflos!;;
@@ -9488,7 +9477,7 @@ wizardry-the-next-generation;9705;wizardrynextgeneration;Wizardry Next Generatio
 lagbgon;9707;LagBGon;Lag'B'Gon;;
 doodads-fabric;9708;doodads;Doodads;;
 subject-three-sweet-dreams;9709;subject3;科目三：甜蜜的梦;Subject Three: Sweet Dreams;ST
-ocd-shaders-mod;9710;oculus;OCD Shaders;;OCD
+ocd-shaders-mod;9710;;OCD Shaders;;OCD
 create-shrunk;9711;;Create Shrunk;;
 cherish;9712;cherish;Cherish;;
 the-lost-castle;9713;tlc;失落城堡;The Lost Castle;TLC
@@ -9498,7 +9487,7 @@ itemupgrader-core;9716;;Item Upgrader Core;;
 itemupgrader;9717;itemupgrader;Item Upgrader;;
 screenfx;9718;screenfx;ScreenFX;;
 dense-ores-abundant;9719;denseores;Dense Ores - Abundant!;;
-tinkers-thinking;9720;tinkers_thinking;匠心独运;Tinkers' Thinking;
+tinkers-thinking;9720;tinkers_thinking;工匠巧思;Tinkers' Thinking;
 simple-musket;9721;simplemusket;Simple Musket;;
 cash-ores;9722;cashore;Cash Ores;;
 stacked-dimensions;9723;stackeddimensions;Kelvin's Stacked Dimensions;;
@@ -9526,7 +9515,7 @@ rebind-narrator;9744;rebind_narrator;Rebind Narrator;;
 earth2java;9745;earthtojavamobs;Earth2Java;;
 fairy-dragons;9746;dragonmod;Fairy Dragons!;;
 turned-changed-extension;9747;turned;Turned: Changed Extension;;
-immediatelyfast-reforged;9748;immediatelyfast;ImmediatelyFast Reforged;;
+immediatelyfast-reforged;9748;;ImmediatelyFast Reforged;;
 magic-mirror;9749;magicmirror;Magic Mirror;;
 magic-mirror-fabric;9750;magic_mirror;Magic Mirror;;
 chassis;9751;chassis;Chassis;;
@@ -9578,12 +9567,12 @@ compressor;9796;compressor;Compressor;;
 ;9797;patcher;Patcher;;
 hexal;9798;Hexal;咒法拓展;Hexal;
 ;9799;;实用盔甲纹饰;Useful Armor Trim;UAT
-create-encased;9800;createcasing,createsasing-extendedgears;Create Encased;;
+create-encased;9800;createcasing,createsasing-extendedgears;机械动力：封装工艺;Create Encased;
 ;9801;treeplacer;Treeplacer;;
 death-knell;9802;deathknell;Death Knell;;
 moreiotas;9803;MoreIotas;MoreIotas;;
 numismatic-overhaul;9804;numismatic-overhaul;Numismatic Overhaul;;
-;9805;Hexbound;咒法组构学;Hexbound;
+hexbound-fork;9805;Hexbound;咒法组构学;Hexbound;
 vanity-druid-pack;9806;vanity_druid;Vanity: Druid Pack;;
 vanity-farcrs-colossal-weapons;9807;vanity_colossal_weapons;Vanity: Farcr's Colossal Weapons;;
 debris-chunk-raw-netherite-scrap;9808;raw_netherite;残骸碎块;Debris Chunk;
@@ -9593,17 +9582,17 @@ biome-music;9811;biomemusic;生物群系音乐;Biome Music;
 agers-earthquake-generator;9812;agers_earthquake_mod;Ager's Earthquake Generator;;
 vanity-black-gold;9813;vanity_black_gold;Vanity: Black Gold Pack;;
 vanity-bone-pack;9814;vanity_bone;Vanity: Bone Pack;;
-;9815;wolfhouse;那是什么？仓库管理员！;What That？ Wolfhouse！;WW
+what-that-wolfhouse;9815;wolfhouse;那是什么？仓库管理员！;What That？ Wolfhouse！;WW
 click-for-hot-chicks;9816;hotchicks;Click for Hot Chicks;;
 vanity-molten-pack;9817;vanity_molten;Vanity: Molten Pack;;
 vanity-spartan-pack;9818;vanity_spartan;Vanity: Spartan Pack;;
 woods-and-mires;9819;woods_and_mires;Woods and Mires;;
-;9820;suggestion_tweaker;Suggestion Tweaker;;
+suggestion-tweaker;9820;suggestion_tweaker;Suggestion Tweaker;;
 Additional-Redstone;9821;additionalredstone;Additional Redstone;;
 heartstone;9822;heartstone;Heartstone;;
 dyed;9823;dyed;Dyed;;
-wireless-redstone-re;9824;wirelessredstone;Wireless Redstone RE;;
-;9825;;史莱姆工艺&火枪;Slime's Craft&Musket;SCM
+wireless-redstone;9824;wirelessredstone;Wireless Redstone;;
+;9825;scm;史莱姆工艺&火枪;Slime's Craft&Musket;SCM
 vanity-steel-pack;9826;vanity_steel;Vanity: Steel Pack;;
 vanity-viking;9827;vanity_viking;Vanity: Viking Pack;;
 horse-expert;9828;horseexpert;Horse Expert;;
@@ -9625,11 +9614,11 @@ chatimg;9843;chatImg;图片聊天;chatImg;CI
 throwable-explosives;9844;throwableexplosives;Throwable Explosives;;
 ;9845;skillmmo;SkillMMO;;
 archeon;9846;archeon;Archeon;;
-chat-toggle;9847;;Chat Toggle;;
+chattoggle;9847;chattoggle;Chat Toggle;;
 enchancement;9848;enchancement;Enchancement;;
 ;9849;mtp;M传送;;mtp
 useful-spyglass;9850;usefulspyglass;Useful Spyglass;;
-befriendmobs-days-with-monster-girls;9853;dwmg,befriendmobs;友好化生物：与怪物娘的日常;BefriendMobs: Days with Monster Girls;DWMG
+nff-girls;9853;nffgirls;NFF: Girls;;
 launchgui;9854;launchgui;LaunchGUI;;
 villager-armor-layer;9855;villagerarmor;村民盔甲显示;Villager Armor Layer;VAL
 wasabi;9856;wasabi;Wasabi;;
@@ -9650,11 +9639,11 @@ mod-menu-no-more;9869;test-1;Mod Menu No More;;
 way2wayfabric;9871;way2wayfabric;way2wayfabric;;
 cloche-profit-peripheral;9872;clochepp;Cloche Profit Peripheral;;
 l2weaponry;9873;l2weaponry;莱特兰-武器;L2 Weaponry;
-;9875;lazydfu;铑;Rhodium;
+;9875;;铑;Rhodium;
 zoom-o-matic;9876;zoom-o-matic;Zoom-o-Matic;;
 ;9877;brokentoolmod;Broken Tool;;
 ;9878;fishing_ruler;Fishing Ruler;;
-;9879;commandrelay;Command Relay;;
+command-relay;9879;commandrelay;Command Relay;;
 beasts-bosses;9880;beastsnbosses;Beasts & Bosses;;
 ;9881;sc;压缩石锤;Stone Hammer;SH
 the-one-probe-community-edition;9882;theoneprobe;检测器-社区版;The One Probe Community Edition;TOPML
@@ -9675,18 +9664,18 @@ magnum-torch-forge;9896;magnumtorch;卓越火炬;Magnum Torch;
 universal-bone-meal-forge;9897;universalbonemeal;通用骨粉;Universal Bone Meal;UB
 ;9898;bottleofgender;Bottle of Gender;;
 ;9899;coretweaks;CoreTweaks;;
-leave-my-bars-alone;9900;leavemybarsalone;Leave My Bars Alone;;
+leave-my-bars-alone;9900;leavemybarsalone;改进的骑乘HUD;Leave My Bars Alone;
 all-enchantments-for-trade;9901;allenchantmentsfortrade;All Enchantments for Trade;;
 i-need-block;9902;ineedblock;I NEED BLOCK;;
 spiky-spikes;9903;sneakycurses;Spiky Spikes;;
-straw-statues;9904;strawstatues;稻草雕像;Straw Statues;
+straw-statues;9904;strawstatues;稻草雕像;Straw Statues;SS
 linear-xp;9905;linearxp;Linear XP;;
 save-gear-on-death;9906;sgod;Save Gear on Death;;
 curtain;9907;curtain;窗帘;Curtain;
 rrls;9908;rrls;移除重载界面;Remove Reloading Screen;RRLS
 entity-model-features;9909;entity_model_features;实体模型特性;Entity Model Features;EMF
 forgestory;9910;forgestory;ForgeStory;;FS
-armor-statues;9911;armorstatues;Armor Statues;;
+armor-statues;9911;armorstatues;Armor Statues;;AS
 ;9912;clocks_andchimes_mr;Axel's Clocks and Chimes;;
 world-of-bosses;9913;somebosses;World of bosses;;
 ;9914;mwdmgsrcfix;模块化武装伤害源修复;ModularWarfareDamageSourceFix;
@@ -9705,7 +9694,7 @@ ecospherical-depths;9927;ecod;Ecospherical Depths;;
 arrhys-simple-currency;9928;arrhys_simple_currency;Arrhy's Simple Currency;;
 better-wandering-trader;9929;wandering_trader;Prelaw's Better Wandering Trader;;
 creative-wireless-transmitter;9930;creativewirelesstransmitter;创造无线发送器;Creative Wireless Transmitter;
-cozy-home;9931;cozy_home;Cozy Home;;
+cozy-home;9931;cozy_home;Lucky's Cozy Home;;
 inventory-crafter;9932;inventorycrafter;Inventory Crafter;;
 ;9933;paimonfoodrecooked;应急食品：重烹;Paimon Food: Recooked;PFRe
 maxs-armory;9934;max_armory;Max 的武器库;Max's Armory;
@@ -9715,7 +9704,7 @@ dangerous-wasps;9937;klsts_wasps,wasps;Dangerous Wasps / Klsts' Wasps Mod;;
 createfabricreibugfix;9938;createreibugfix;机械动力Fabric版REI配方显示修复;Create&REIBugFix/CreateFabric&REIBugFix;CRBF/CREIBF/CFREIBF
 seasontweaks;9939;seasontweaks;SeasonTweaks;;
 ;9940;Potion_Tool;药水工具;Potion_Tool;PT
-;9941;villedit_mr;VillEdit;;
+;9941;mr_villedit;VillEdit;;
 ;9942;automessenger;AutoMessenger;;
 ;9943;equipsuit;装备套装;EquipSuit;EQ/EQC
 ;9944;bettercheesemodel;更好的奶酪模型;Better Cheese Model;BCM
@@ -9750,20 +9739,20 @@ restrictions;9973;restrictions;Restrictions;;
 create-modern-train-parts;9974;moderntrainparts;Create: Modern Train Parts;;
 ;9975;dstc;Don't Starve Together: Cuisine;;DSTC
 targetato;9976;targetato;Targetato;;
-;9977;messagetweaker;MessageTweaker;;
+messagetweaker;9977;messagetweaker;MessageTweaker;;
 ;9978;rubeAurora;Aurora Rubealis;;
 ;9979;endercore;末影核心非官方版;EnderCore Unoffical;
 tskimi-seirans-fruit-wine;9980;tksrwine;月见清兰的果酒;Tskimi Seiran's Fruit Wine;TSFW
 graduated-cylinders;9981;graduatedcylinders;刻度量筒;Graduated Cylinders;
 ;9982;EnderIO;末影接口GTNH非官方版;EnderIO-Unofficial;
 fps-monitor;9983;fps;FPS Monitor;;
-stitch;9984;stitch,athena;Stitch/Athena;;
+athena;9984;stitch,athena;Athena/Stitch;;
 calm-mornings;9985;calmmornings;Calm Mornings;;
 fog-looks-good-now;9986;foglooksgoodnow;Fog Looks Good Now;;
 guarding;9987;guarding;Guarding!;;
 cats-expanded;9988;catsexpanded;Cats Expanded;;
-modular-bosses;9989;examplemod;Modular Bosses;;MB
-experience-obelisk;9990;experienceobelisk;Experience Obelisk;;
+modular-bosses;9989;mb;Modular Bosses;;MB
+experience-obelisk;9990;experienceobelisk;Cognition/Experience Obelisk;;
 here-be-no-dragons;9991;here-be-no-dragons;Here be no Dragons!;;
 gnumus-settlement;9992;gnumus;Gnumus Settlement;;
 fading-night-vision;9993;fadingnightvision;Fading Night Vision;;
@@ -9779,7 +9768,7 @@ mannequins;10002;mannequins;Mannequins;;
 simple-mango;10003;simplemango;Simple Mango;;
 betterdrawhoveringtext;10004;bdht;更好的工具信息显示;betterDrawHoveringText;bdht
 ;10005;turn_into_eggs;Turn Into Eggs;;TIE
-badges-by-harmex;10006;badges;Badges by Harmex;;
+badges-by-harmex;10006;badges;CobbleBadges;;
 terrarian-arsenal;10007;terrarian_arsenal;Terrarian Arsenal;;
 zombie-veterinarian;10008;zombieveterinarian;僵尸科兽医;Zombie Veterinarian;
 just-enough-sculk-sensor;10009;justenoughsculksensor;Just Enough Sculk Sensor;;JESS
@@ -9787,14 +9776,14 @@ hearth-and-home;10010;hnh;Hearth & Home;;
 better-leveling;10011;betterleveling;更好的升级;Better Leveling;
 ;10012;mana_ae;应用魔法;Applied Mana;AM
 boundless-flux;10013;boundlessflux;Boundless Flux;;
-;10014;;起床战争工具包;JK's BedWars ToolPack;jkbw
+jkbw;10014;;起床战争工具包;JK's BedWars ToolPack;jkbw
 ;10015;axolotlclient,axolotlclient-common;Axolotl Client;;
 energy-nodes;10016;energynodes;Energy Nodes;;
-fog-looks-good-now-fabric;10017;fog-looks-good-now;Fog Looks Good Now;;
+fog;10017;fog;Fog;;
 thirst-was-taken;10018;thirst;口渴;Thirst Was Taken;
 ;10019;blazeandcave;BlazeandCave's Advancements Pack Terralith version;;
 unlimited-fluidity;10020;unlimitedfluidity;Unlimited Fluidity;;
-;10021;e4mc_minecraft;e4mc;;
+e4mc;10021;e4mc_minecraft;e4mc;;
 late-game-golems;10022;lategamegolems;Late Game Golems;;
 iter-rpg;10023;iter_rpg;Iter RPG;;
 ;10024;stationarysourceblocks;Stationary Source Blocks Potato Edition;;
@@ -9808,7 +9797,7 @@ workers;10031;workers;Villager Workers;;
 ;10032;cregtech;克瑞科技;CregTech;
 sculk-horde;10033;sculkhorde;幽匿部落;Sculk Horde;
 stratospherical-expansion;10034;strato;Stratospherical Expansion;;
-candlelight-lets-do-a-candlelight-dinner;10035;candlelight;烛火晚宴;[Let's Do] Candlelight;
+lets-do-candlelight-farm-charm-compat;10035;candlelight;烛火晚宴;[Let's Do] Candlelight;
 let-me-play-iris;10036;lmpi;Let me play Iris!;;
 dimensional-depths;10037;ecod;Dimensional Depths;;
 create-molten-vents;10038;molten_vents;Create: Molten Vents;;
@@ -9848,7 +9837,7 @@ arcane-world;10071;arcaneworld;Arcane World;;
 tiled-cauldron;10072;tiled_cauldron;Tiled Cauldron;;
 manyideas-christmas;10073;manyideas_christmas;ManyIdeas Christmas;;
 overflowing-bars;10074;overflowingbars;Overflowing Bars;;OB
-;10075;kokoalinux;KokoaLinux;;
+kokoalinux;10075;kokoalinux;KokoaLinux;;
 medievalweapons;10076;medievalweapons;MedievalWeapons;;
 completionists-index;10077;completionistsindex;Completionist's Index;;CI
 stoneworks;10078;stoneworks;Stoneworks;;SW
@@ -9860,8 +9849,8 @@ xk-perfect-glass-pane;10082;;完美玻璃板;Perfect glass pane;
 tarot-cards;10084;tarotcards;Tarot Cards;;
 ;10085;;TcpNoDelayMod;;
 chatmove;10086;chatmove;ChatMove;;
-;10087;forgedfabricloader;ForgedFabricLoaderAPI/ForgedLoaderAPI;;FFL
-public-transport-mod;10088;transportmod;Public Transport Mod;;
+;10087;forgedfabricloader;ForgedFabricLoaderAPI / ForgedLoaderAPI;;FFL
+public-transport-mod;10088;transportmod;Public Transport Mod;;PTM
 mineral-chance;10089;mineralchance;Mineral Chance;;
 random-bone-meal-flowers;10090;randombonemealflowers;Random Bone Meal Flowers;;
 now-playing-forge;10091;nowplaying;Now Playing;;
@@ -9879,7 +9868,7 @@ pigsteel;10100;pigsteel;Pigsteel;;
 ;10103;ofstream_t;导出乐;OfstreamT;
 ;10104;ofstream_advancement;导出乐<进度>;Ofstream Advancement;
 flowermap;10105;flowermap;花卉地图;Flower Map;
-hopo-better-mineshaft;10106;hopobettermineshaft;Hopo Better Mineshaft;;
+hopo-better-mineshaft;10106;hopobettermineshaft,hopo;Hopo Better Mineshaft;;
 ;10107;dip;伤害显示兼容;Damage Indicators Patch;
 reforgium;10108;reforgium;Reforgium;;
 spoorn-weapon-attributes;10109;spoornweaponattributes;Spoorn Weapon Attributes;;
@@ -9889,16 +9878,16 @@ fabrc-legacy-fixes;10111;legacy-fixes;Legacy (Fabric) Fixes;;
 ;10113;ofstream_fasrirr;导出乐<快速IRR>;OfstreamFastIRR;
 ;10114;;夜霸;Night Rogue;
 moa-decor-bath;10115;moa_decor_bath;MOA DECOR: BATH;;
-;10116;edf_remastered_mr;Ender Dragon Fight Remastered;;
+;10116;edf_remastered_mr,mr_edf_remastered;Ender Dragon Fight Remastered;;
 stealing-the-villagers-forge;10117;stealing_villagers;Stealing The Villagers;;
 spoorn-armorattributes;10118;spoornarmorattributes;Spoorn Armor Attributes;;
 connectedness;10119;connectedness;Connectedness;;
-epic-samurais;10120;epicsamurai;史诗武士;Epic Samurai's;
-sandwiches-n-more;10121;;Sandwiches N' More;;
+epic-samurais;10120;epicsamurai,samurai_dynasty;史诗武士;Epic Samurai's / Samurai Dynasty;
+sandwiches-n-more;10121;sandwichesnmore;Sandwiches N' More;;
 enchantments-plus-fabric;10122;enchantmentsplus;Enchantments-Plus;;
 purpeille;10123;purpeille;Purpeille;;
 carpet-sky-additions;10124;carpetskyadditions;Carpet Sky Additions;;
-spice-of-life-carrot-edition-unofficial;10125;;SOL - Carrot Unofficial;;
+spice-of-life-carrot-edition-unofficial;10125;;生活调味料：胡萝卜非官方版;SOL - Carrot Unofficial;
 ender-dragon-egg-respawn-fabric;10126;ender_dragon_egg_respawn;Ender Dragon Egg Respawn;;
 personal-space;10127;personalspace;私人维度;Personal Space;
 held-item-tooltips;10128;helditemtooltips;手持物品信息显示;Held Item Tooltips;IT
@@ -9907,35 +9896,35 @@ forgotten-delight;10130;forgotten_delight;Forgotten Delight;;
 enhancedlootbags;10132;;EnhancedLootBags;;
 recipe-reshaper;10133;recipe_reshaper;Recipe Reshaper;;
 hellish-blahaj;10134;blahaj;布罗艾 Hellish 版;Hellish Blåhaj;
-amber-jade;10135;jade;琥珀;Amber;
-mafglib;10136;malilib,mafglib;MaFgLib/MaLiLib-Forge;;
-;10137;;Fast Minecart;;
+amber-jade;10135;;琥珀;Amber;
+mafglib;10136;malilib,mafglib;MaFgLib / MaLiLib-Forge;;
+;10137;fastminecart;Fast Minecart;;
 ae2_tools;10138;ae2_tools;AE2 Tool's Complement Compat;;
 create-compats;10139;acc_nocube;Create Compats;;
 dont-drop-it;10140;dontdropit;Don't Drop It!;;
 nicemod-new-blocks;10141;nicemod;NiceMod - New blocks;;
-forgematica;10142;litematica;全息蓝图;Forgematica/Litematica-Forge;
+forgematica;10142;litematica,forgematica;全息蓝图;Forgematica / Litematica-Forge;
 framland;10143;;Framland;;
-;10144;blahaj;布罗艾：旧版;Blåhaj：Legacy;
+blahaj-legacy;10144;blahaj;布罗艾：旧版;Blåhaj：Legacy;
 deep-aether;10145;deep_aether;深入天境;Deep Aether;
 the-forgotten-dimensions;10146;the_forgotten_dimensions;The Forgotten Dimensions;;
 ;10147;Sink;水槽;The Sink;
 ;10148;killstreakhud;连杀HUD显示;;KST
 ;10149;stairjumper;stairjumper;;
 watchdog-anti-cheat;10150;watchdog;WatchDog Anti Cheat;;
-villagers-drop-emeralds-on-death;10151;;Villagers Drop Emeralds on Death;;
+villagers-drop-emeralds-on-death;10151;villagerdrops;Villagers Drop Emeralds on Death;;
 neydis-dragons;10152;;Neydis dragons;;
-colourful-goats;10153;;Colourful Goats;;
-perfect-spawn;10154;;Perfect Spawn;;PS
+colourful-goats;10153;colourfulgoats;Colourful Goats;;
+perfect-spawn;10154;perfectspawn;Perfect Spawn;;PS
 ;10155;vanilla_refresh_mr;Vanilla Refresh;;
 infinity-pickaxe;10156;infinity_pickaxe;Infinity Pickaxe;;
 biome-spawn-point;10157;biomespawnpoint;Biome Spawn Point;;
 smallbiomes;10158;smallbiomes;Biome Sizes;;
 enhanced-block-entities-reforged-unofficial;10159;enhancedblockentities;Enhanced Block Entities Reforged;;
-hopo-better-ruined-portals;10160;hopobetterruinedportal;Hopo Better Ruined Portals;;
+hopo-better-ruined-portals;10160;hopobetterruinedportal,hoporp;Hopo Better Ruined Portals;;
 wearthat;10161;wearthat;WearThat;;
 portable-crafting-table;10162;portablecraftingtable;便携工作台;Portable Crafting Table;
-structory-towers;10163;structory_towers;Structory: Towers;;
+structory-towers;10163;structory_towers,structorytowers;Structory: Towers;;
 everything-is-a-hat;10164;everythingisahat;Everything is a Hat;;
 skeletal-remains;10165;skeletalremains;Skeletal Remains;;
 tidbits;10166;tidbits;Tidbits;;
@@ -9947,8 +9936,8 @@ blue-archive-halos;10170;minecraftbluearchivehalo;Blue Archive Halos;;
 ;10172;flighthud;FlightHUD重置版;FlightHUD Reloaded;
 ;10173;manavisualizer;Mana Visualizer;;
 mhcraft;10174;mhcraft;Monster Hunter: Heaven and Hell / MHCraft;;
-irons-spells-n-spellbooks;10175;irons_spellbooks;Iron's Spells 'n Spellbooks;;
-infernal-enchantments;10176;;Infernal Enchantments;;
+irons-spells-n-spellbooks;10175;irons_spellbooks;Iron的法术与魔法书;Iron's Spells 'n Spellbooks;ISS
+infernal-enchantments;10176;infernalenchantments;Infernal Enchantments;;
 reimagined-world-menu;10177;reimaginedmenus;Reimagined World Menu;;
 origins-assassin;10178;assassinorigin;Origins - Assassin;;
 peculia;10179;peculia;Peculia;;
@@ -9975,8 +9964,8 @@ manyideas-doors;10200;manyideas_doors;ManyIdeas Doors;;
 end-origins;10201;end_origins;End Origins;;
 extra-classes-origins;10202;extra_classes_origins;Extra Classes - Origins;;
 wire-decoration;10203;tower;电线装饰;Wire Decoration;
-optimizationsandtweaks;10204;multithreadingandtweaks;OptimizationsAndTweaks;;
-the-flesh-that-hates;10205;;The Flesh That Hates;;
+optimizationsandtweaks;10204;optimizationsandtweaks;OptimizationsAndTweaks;;
+the-flesh-that-hates;10205;the_flesh_that_hates;The Flesh That Hates;;TFTH
 tabfaces;10206;tabfaces;TabFaces;;
 mob-armor-mod-v2;10207;mobarmormod;Mob Armor Mod V3;;
 umbral-skies;10208;umbral_skies;Umbral Skies;;
@@ -10026,7 +10015,7 @@ adorkable-dogs-pocky;10252;adorkabledogs;DK狗的Pocky;Adorkable dog's Pocky;
 ;10253;rip;配方藏在代码里！;Recipe In Programming;RIP
 realistic-explosion-physics;10254;rep;Realistic Explosion Physics;;
 nitwitification;10255;nitwitification;Nitwitification;;
-items-to-mobs;10256;items_to_mobs;Items to Mobs;;
+mutated-items;10256;items_to_mobs,mutated_items;Mutated Items / Items to Mobs;;
 ;10257;;烤矿;Bake that ORE!;BtO!
 homespun;10258;homespun;Homespun;;
 primitive-start;10259;primitivestart;Primitive Start;;
@@ -10036,10 +10025,10 @@ cataclysm-heaven-burner;10262;incinerator;灾变：焚天神兵;Cataclysm: Heave
 echo-chest;10263;echochest;回响箱子;Echo Chest;EC
 ;10264;healthnanfix;假死修复：重织版;Health NaN Fix:Refabricated;HNFR
 new-nether-chest;10265;netherchest,netherchested;下界箱子;Nether Chested;NC
-plenty-plates;10266;plentyplates;Plenty Plates;;
+plenty-plates;10266;plentyplates;Plenty Plates;;PP
 simple-sponge;10267;simplesponge;Simple Sponge;;
 new-paper-doll;10268;paperdoll;Paper Doll;;PD
-ender-zoology;10269;enderzoology;Ender Zoology;;EZ
+ender-zoology;10269;enderzoology;末影动物学;Ender Zoology;EZ
 vectorientation;10270;vectorientation;Vectorientation;;
 seven-days-to-fix-parasitus;10271;thesdtmfix;[7 Days To Fix];;
 dtm-integrations;10272;dtmintegrations;DTM Integrations;;
@@ -10048,8 +10037,8 @@ bushier-flowers;10274;bushierflowers;Bushier Flowers;;
 ender-space;10275;ender_space;Ender Space;;
 cataclysm-boss-bar;10276;cataclysmbossbar;灾变Boss血条显示;Cataclysm Boss Bar;
 unusual-gifts;10277;unusual_gifts;Unusual Gifts;;
-building-blocks-overhaul-forge;10278;;Building Blocks Overhaul;;
-;10279;;CraftGuide - BTW CE Fix;;
+building-blocks-overhaul-forge;10278;building_blocks_overhaul;Building Blocks Overhaul;;
+;10279;craftguide;CraftGuide - BTW CE Fix;;
 tick-info;10280;tickinfo;tick info;;
 primal-stage;10281;primalstage;Primal Stage;;
 spontaneous-replace;10282;spontaneous-replace,spontaneous_replace;自然更替;Spontaneous-Replace;SR
@@ -10060,16 +10049,16 @@ twilight-paintings;10286;twilight_paintings;Twilight Paintings;;
 twilight-origins;10287;tfo;Twilight Origins;;
 cpmoscc;10288;cpmoscc;自定义玩家模型OSC兼容;Customizable Player Models OSC Compat;CPM-OSC
 twilight-forest-portal-catalyst;10289;twilightforestportalcatalyst;暮色森林传送门催化石;Twilight Forest Portal Catalyst;
-better-fog;10290;;Better Fog;;BF
+better-fog;10290;betterfog;Better Fog;;BF
 tool-upgrades;10291;toolupgrades;工具升级;Tool Upgrades;
 visiblebarriers;10292;visiblebarriers;Visible Barriers;;
 aether-gravitation;10293;gravitation;天境之引;Aether Gravitation;
 ;10294;sublanguage;首选语言;Sublanguage;
-befriendmobs-api;10295;befriendmobs;友好化生物框架;BefriendMobs Framework;BM
+nff-services;10295;nffservices;NFF Services;;
 better-potion-visuals;10296;betterpotionvisuals;Better Potion Visuals;;
 modern-warfare-cubed;10297;mwc;现代战争方块化;Modern Warfare Cubed;MWC
 extraordinary-extra-totems;10298;extraordinary_extra_totems;Extraordinary Extra Totems;;
-;10299;;SquidFriends;;
+;10299;squidfriends;SquidFriends;;
 beachparty;10300;beachparty;沙滩派对;Let's Do Beachparty;
 ;10301;sittablescriptable_crt;SittableScriptable;;
 s33r-more-food;10302;s33r_more_food;S33R More Food;;
@@ -10079,7 +10068,7 @@ froglight-backport;10303;froglights;Froglight Backport;;
 exquisito;10306;exquisito;末域奇馔;Exquisito;
 species;10307;species;Species;;
 cles-battleitems;10308;battleitems;战斗物品;Cle's BattleItems;BI
-unu-parts-pack;10309;;UNU Parts Pack [MTS];;UNU
+unu-parts-pack;10309;unuparts;UNU Parts Pack [MTS];;UNU
 spleaves;10310;spleaves;Spleaves;;
 modernworldcreation;10311;modernworldcreation;Modern World Creation;;
 enchant-the-rainbow;10312;enchat_the_rainbow;Enchant the Rainbow;;
@@ -10122,9 +10111,9 @@ aether-expansion;10348;aetherexpansion;Aether Expansion;;
 barrels-2012;10349;barrels_2012;Barrels 2012;;
 ;10350;libzoomer;Libzoomer;;
 tfc-sample-drill;10351;tfcsampledrill;TFC Sample Drill;;
-tfc-rosia;10352;;TFC - Rosia;;
+tfc-rosia;10352;rosia;TFC - Rosia;;
 aether-additions;10353;aeadditions;Aether Additions;;
-custom-portal-api-forge;10354;customportalapi;Custom Portal API [Forge];;
+custom-portal-api-forge;10354;customportalapi;自定义传送门 API Forge 版;Custom Portal API [Forge];
 jaopca-extras;10355;jaopcaextras;JAOPCA Extras;;
 ;10356;scriptblock;脚本方块;With Script Blocks;
 enclosure;10357;enclosure;Enclosure;;
@@ -10134,7 +10123,7 @@ isleofberk;10360;isleofberk;博克岛;Isle of Berk;
 patpatpat;10361;patpatpat;PatPatPat;;
 ;10362;;搬箱器;Box Mover;
 wildberries;10363;wildberries;Wild Berries;;
-ir-chinese-train-pack;10364;immersiverailroading;三道岭余晖;JianShe in SanDaoLing;SDL
+ir-chinese-train-pack;10364;;三道岭余晖;JianShe in SanDaoLing;SDL
 kubejs-powah;10365;kubejspowah;KubeJS Powah;;
 ;10366;hexkinetics;咒法动力学;HexKinetics;
 ;10367;digi_tsuuruzu;Digi-tsuuruzu;;DTr
@@ -10151,8 +10140,8 @@ tinkers-disassembler;10377;tinkersdisassemble;Tinkers Disassembler;;
 piseks-tinkers-enchantments;10378;piseks_tinkers_enchantments;Pisek's Tinker's Enchantments;;
 tinkering-with-embers;10379;emberstic;Tinkering with Embers;;
 mob-despawn-timers;10380;despawntimers;Mob Despawn Timers;;
-tfc-towerheat;10381;;TFC TowerHeat;;
-tfc-toohotaroundhere;10382;;TFC TooHotAroundHere;;
+tfc-towerheat;10381;tfctowerheat;TFC TowerHeat;;
+tfc-toohotaroundhere;10382;thah;TFC TooHotAroundHere;;
 flower-patch;10383;flowerpatch;Flower Patch;;
 quickcure;10384;quick_cure;Quick Cure;;
 spoiled;10385;spoiled;Spoiled;;
@@ -10160,8 +10149,8 @@ spoiled;10385;spoiled;Spoiled;;
 hungryanimals;10387;hungryanimals;Hungry Animals;;
 opolis-utilities;10388;opolisutilities;Opolis Utilities;;
 better-breeding;10389;better_breeding;Better Breeding;;
-frostiful;10390;frostiful;Frostiful;;
-;10391;camocreepers;Camo Creepers;;
+frostiful;10390;frostiful;霜冻;Frostiful;
+camo-creepers;10391;camocreepers;Camo Creepers;;
 ;10392;coupons;Coupons;;
 simple-bracers;10393;simple_bracers;Simple Bracers;;
 baby-delight;10394;babydelight;Baby Delight;;
@@ -10169,9 +10158,9 @@ strategic-enchanting;10395;strategic_enchanting;Strategic Enchanting;;
 forged-in-fire;10396;forgedinfire;Forged In Fire;;
 lumy-skin-patch;10397;LumySkinPatch;Lumy Skin Patch;;
 ;10398;le0s_spoons;Le0s Spoons;;
-;10399;redstone_clock;Redstone Clock;;
+redstone-clock;10399;redstone_clock;Redstone Clock;;
 anti-mob-griefing;10400;antimobgriefing;Anti Mob Griefing;;
-nbtedit-reborn;10401;nbtedit;游戏内NBT编辑器重制版;In-game NBTEdit Reborn;NBTE
+nbtedit-reborn;10401;nbtedit;游戏内NBT编辑器重制版;In-game NBTEdit Reborn;IGNR
 ;10402;nucleoplasm_json_edit;核质JSON修改;Nucleoplasm Json Edit;NJS
 the-filler-update;10403;the_filler_update;The Filler Update;;
 custom-machinery-create;10404;custommachinerycreate;Custom Machinery Create;;
@@ -10182,20 +10171,20 @@ choruslib;10408;chorus_lib;ChorusLib;;
 frogs-can-eat-any-hostile-mob;10409;;Frogs Can Eat Any Hostile Mob;;
 artificial-thunder;10410;artificial_thunder;Artificial Thunder;;
 rp-renames;10411;rprenames;RP Renames;;
-openblocks-trophies;10412;openblocks_trophies;OpenBlocks Trophies;;
-;10413;;Shrug It Off;;
+openblocks-trophies;10412;openblocks_trophies,obtrophies;OpenBlocks Trophies;;
+;10413;shrugitoff;Shrug It Off;;
 ;10414;f3teverywhere;Resource Reload (F3+T) Everywhere;;
 ;10415;;九宫法令三;;
 lootbag-patches;10416;lootbags;LootBag Patches;;
-stargate-journey;10418;sgjourney;Stargate Journey;;
+stargate-journey;10418;sgjourney;星门之旅;Stargate Journey;
 xaero-arrow-fix;10419;xaeroarrowfix;Xaero Arrow Fix;;
 ornamental;10420;ornamental;Ornamental;;
 xaero-zoom-out;10421;xaerozoomout;Xaero Zoomout;;
 minecard;10422;minecard;Minecard;;
 ;10423;;允许作弊-TOW版;EnableCheats-TOW Edition;
 ydms-custom-camera-view;10424;customcameraview;YDM's Custom Camera View;;
-gravitational-modulating-additional-unit;10425;gravitationalmodulatingunittweaks;Gravitational Modulating Additional Unit;;
-;10426;edgerunner;边缘行者;Edgerunner;
+gravitational-modulating-additional-unit;10425;gravitationalmodulatingunittweaks,gmut;Gravitational Modulating Additional Unit;;
+edgerunner;10426;edgerunner;边缘行者;Edgerunner;
 nbt-autocomplete;10427;nbt_ac;NBT Autocomplete;;NBTac
 smells-fishy;10428;smellsfishy;Smells Fishy / Entity Rain Events;;
 primogem-craft;10429;primogemcraft;原石工艺;Primogems Craft;PGC
@@ -10204,8 +10193,8 @@ kubejs-tfc;10431;kubejs_tfc;KubeJS TFC;;
 precision-prospecting;10432;precisionprospecting;Precision Prospecting;;
 potatoos-custom-structure-for-hbms-nuclear-tech;10433;potatooscustomstructureforhbm;Potatoo's Custom Structure For HBM's Nuclear Tech Mod;;
 fabric-seasons-terraformers-compat;10434;seasonsterraformerscompat;Fabric Seasons: Terraformers Compat;;
-fabric-seasons-extras;10435;seasonsextras;Fabric Seasons: Extra;;
-better-f3-plus;10436;;Better F3 Plus;;
+fabric-seasons-extras;10435;seasonsextras;Fabric Seasons: 拓展;Fabric Seasons: Extra;
+better-f3-plus;10436;betterf3plus;Better F3 Plus;;
 fabric-seasons-delight-compat;10437;seasonsdelightcompat;Fabric Seasons: Delight Compat;;
 fabric-seasons-terralith-compat;10438;seasonsterralithcompat;Fabric Seasons: Terralith Compat;;
 marigolds;10439;marigolds;Marigold Flower!;;
@@ -10227,7 +10216,7 @@ kubejs-delight;10454;kubejsdelight;KubeJS Delight;;
 block-physics-overhaul;10455;bpo;Block Physics Overhaul;;BPO
 searchlight-forge;10456;searchlight;探照灯;Searchlight（& Wall Lights）;
 ancient-manuscripts;10457;ancient_manuscripts;Ancient Manuscripts;;
-gazebos;10458;gazebos;Gazebos;;
+gazebos;10458;gazebos,gazebo;Gazebos;;
 scoreboard-get-time;10459;nowtime;记分板获取时间;scoreboard get time;
 modern-keywizard;10460;mkw;现代化按键精灵;Modern KeyWizard;MKW
 chunk-sending-forge-fabric;10461;chunksending;Chunk Sending;;
@@ -10244,7 +10233,6 @@ continuumation;10471;continuumation;Continuumation;;
 ai-art-deco-1;10472;aiblock1;AI装饰一号;AI Art Deco 1;AI1
 ;10473;ocrenderfix_sodium;Sodium/Rubidium Occlusion Culling Fix;;
 easy-dungeons;10474;;简易地牢;Easy Dungeons;
-the-morbid-harvester-reborn-reborn;10475;morbid;变态的凋灵收割者;The Morbid Reborn Reborn;
 ars-armiger;10476;ars_armiger;Ars Armiger;;
 bettergolem;10477;bettergolem;Better Golems;;
 ;10478;end-poem-extension,end_poem_extension,endpoemext;终末之诗扩展补丁;End Poem Extension;EPX
@@ -10271,7 +10259,7 @@ arboria;10498;arboria;Arboria;;
 mekanism-evolution;10499;mekaevolution;Mekanism-Evolution;;
 ;10500;arboria_saplings;Arboria Saplings;;
 chiseledadditions;10501;chisableadditions;ChiseledAdditions;;
-;10502;tinkers_ingenuity;工匠匠心;Tinkers Ingenuity;TI
+;10502;tinkers_ingenuity;工匠匠心;Tinkers Ingenuity;
 gregtech-4;10503;gregtech_addon;格雷科技4移植版;GregTech 4 Rewritten;GT4
 lacrimis;10504;lacrimis;Lacrimis;;
 productive-villagers;10505;productivevillagers;Productive Villagers;;
@@ -10296,28 +10284,28 @@ stat-check;10523;stat_check;Stat Check;;
 hit-indication;10524;hitindication;Hit Indication;;
 multipart-machines-farming;10525;multipart_machines_farming;Multipart Machines: Farming;;
 ;10526;;机械动力矿石粉碎修复;Create Ore Crushing Fix;
-lotweakr;10527;lotrfixer,lotweakr;LOTRFixer;;
+lotweakr;10527;lotrfixer;LOTRFixer;;
 tru-first-person-mod;10528;TrueFirstPersonMod;First Person Realism;;
 reduced-music-delay;10529;rmd;Reduced Music Delay;;
 agers-giant-junkyard-dimension;10530;junkyard;Ager's Giant Junkyard Dimension;;
 jsmacros;10531;jsmacros;JS Macros;;
-great-big-world;10532;great_big_world;Great Big World;;
+great-big-world;10532;great_big_world;Great Big World;;GBW
 armored-mobs;10533;armored_mobs;Armored Mobs;;
-inversia;10534;inversia;Inversia;;
+astrological;10534;inversia,astrological;Astrological / Inversia;;
 end-expansion-the-lamented-islands;10535;the_lamented_islands;End Expansion - The Lamented Islands;;
 ;10536;;万物皆可造;;
 ;10537;;万物皆可钓;;
 ;10538;washable;洗刷刷;Washable;
 ;10539;compromise;折衷;Compromise;
-;10540;brute_force_rendering_culling;野蛮渲染剔除;BruteForceRenderingCulling;BFRC
+brute-force-rendering-culling;10540;brute_force_rendering_culling;野蛮渲染剔除;Brute force Rendering Culling;BFRC
 no-additional-repair-cost;10541;noaddrepcost;No Additional Repair Cost - Anvil / NoAddRepCost;;
 cave-dust;10542;cavedust;洞穴尘埃;Cave Dust;
-nocubes-better-grindstone;10543;;NoCube's Better Grindstone;;
+nocubes-better-grindstone;10543;nocubesbettergrindstone;NoCube's Better Grindstone;;
 create-weaponry;10544;create_weaponry;Create Weaponry;;
 nocubes-chinchillas;10545;Chinchillas;NoCube's Chinchillas;;
 create-applied-kinetics;10546;createappliedkinetics;机械动力：应用机械;Create: Applied Kinetics;CAK
 nocubes-zombie-mobs;10547;zombiemobs;NoCube's Zombie Mobs;;
-create-gourmet;10548;create_gourmet;Create Gourmet;;
+create-gourmet;10548;create_gourmet,gourmet;Create Gourmet;;
 medical;10549;medical;Medical;;
 yellowbrosss-extras;10550;yellowbrosss_extras;Yellowbross's Extras;;
 simply-caterpillar;10551;simplycaterpillar;Simply Caterpillar;;
@@ -10330,11 +10318,11 @@ cherry-blossom-grotto;10556;cherryblossomgrotto;Cherry Blossom Grotto;;
 ;10558;splash;闪烁;Splash;
 parties;10559;;Parties;;
 pots-and-mimics-rpg;10560;pots_and_mimics_rpg;Realm RPG: Pots & Mimics;;
-;10561;gamspark;Gemspark;;
+gemspark;10561;gamspark;Gemspark;;
 otakomod;10562;otakomod_anime_characters;OtakoMod;;
 wall-jumping;10563;wall_jumping;Wall Jumping;;
 new-life;10564;newlife;New Life;;
-reeves-furniture;10565;reevesfurniture;Reeves's Furniture;;
+reeves-furniture;10565;reevesfurniture;Furnitury/Reeves's Furniture;;
 ;10566;undying;不朽;Undying;
 creatania;10567;creatania;Creatania;;
 boat-rocked;10568;boatrocket;Boat Rocket;;
@@ -10356,19 +10344,19 @@ toroquest-revamped;10585;toroquest;ToroQuest Revamped;;
 ;10586;bosomlang;BosomLang;;
 tis-create;10587;tiscreate;TIS-Create;;
 tektopia-trader;10588;tektopiatrader;Tektopia Trader;;
-;10589;;WorldTime;;
+worldtime;10589;worldtime;WorldTime;;
 beasts;10590;beasts;Beasts;;
 alphabet-speedrun;10591;alphabet_speedrun,speedabc;自定义速通挑战;αβspeedrun;ABS
 ;10592;symlink-check,symlinkcheck;符号链接拦截;Symlink Check;
 tis-stringify;10593;tisstring;TIS Stringify;;
 ;10594;silkfalling;精准着陆;Silk Falling;SF
-;10595;dismountentity;Dismount Entity;;
+dismount-entity;10595;dismountentity;Dismount Entity;;
 dyeable-compasses;10596;dyeblecompasses,dyeablecompasses;染色指南针;Dyeable Compasses;
 supercompression;10597;super_compression;超级压缩;Super Compression;SC
 better-hungteen-s-plants-vs-zombies;10598;bhtpvz;更好的HTPVZ;Better HungTeen's Plants vs. Zombies;BHTPVZ
 piglinsafety;10599;piglinsafety;猪灵：多喝岩浆;PiglinSafety;
 gatewayer;10600;gatewayer;Gatewayer;;
-bocchud;10601;minihud;孤独HUD;BoccHUD/MiniHUD-Forge;BHUD
+bocchud;10601;bocchud;孤独HUD;BoccHUD / MiniHUD-Forge;BHUD
 arrowcollector;10602;arrowcollector;你返箭吗;Arrow Collector;
 saplingslayer;10603;saplingslayer;鸽子衔枝;SaplingSlayer;
 quality-quails;10604;taigachicken;Quality Quails;;
@@ -10377,8 +10365,8 @@ hydration;10605;hydration;Hydration;;
 halohud;10607;halohud;Halo HUD;;
 resourcify;10608;resourcify;Resourcify;;
 ioclias;10609;ioclias;Ioclias;;IOC
-twilights-flavors-delight;10610;twilightdelight;暮色风味乐事;Twilight Flavors & Delight;
-;10611;clean-debug;Clean F3;;
+twilights-flavors-delight;10610;twilightdelight;暮色风味乐事;Twilight's Flavors & Delight;
+clean-f3;10611;clean-debug;Clean F3;;
 enchanted-lib;10612;enchantedlib;Enchanted Lib;;
 architect-tools-converter-1-7-10;10613;arctools;建筑师工具 - 转换器;Architect Tools - Converter;
 ;10614;stntr;StabilizeAndTransform;;
@@ -10389,7 +10377,6 @@ photon;10618;photon;光子;Photon;
 voice-chat-interaction;10619;vcinteraction;Voice Chat Interaction;;
 replay-voice-chat;10620;replayvoicechat;Replay Voice Chat;;
 ships-mod-unofficial;10621;ship;船：非官方版;Cuchaz Ships Unofficial;
-no-nether-portals;10622;nonetherportals;No Nether Portals;;
 storage-overhaul;10623;;Storage Overhaul;;
 chorus-warps;10624;choruswarps;Chorus Warps;;
 aureate-reliquary;10625;aureatereliquary;Aureate Reliquary;;
@@ -10453,7 +10440,7 @@ tetras-delight;10681;tetrasdelight;Tetra's Delight;;
 avaritia-reset-version;10683;avaritia;无尽贪婪重置版;Avaritia Reset Version;
 archeology-plus;10684;archeologyplus;Archeology Plus;;
 mobification;10685;mobificationtwo;Mobification;;
-trimseffects;10686;trimseffects;TrimsEffects;;
+trimseffects;10686;trimseffects,trimeffects;TrimsEffects;;
 tough-glass;10687;toughglass;Tough Glass;;
 celestisynth;10688;celestisynth;天神剑技;Celestisynth;
 golems-plus-plus;10689;golemsplusplus;Golems++;;
@@ -10472,7 +10459,7 @@ fuzzymobs;10700;fuzzymobs;FUZZYMOBS;;
 ;10702;arsmagica2;魔法艺术2.5;Ars Magica 2.5;
 delightful-froge;10703;delightful-froge;Delightful Froge;;
 enhancedsnowman;10704;enhanced_snowman;Enhanced Snowmen;;
-new-world-height-and-depth;10705;;Shattered World Limits;;
+new-world-height-and-depth;10705;swl_fabric,swl;Shattered World Limits;;
 ;10706;inertiaanticheat;Inertia Anti Cheat;;
 ;10707;tprequest;传送请求;TeleportationRequest;
 scroll-of-harvests;10708;harvests;Scroll of Harvests;;
@@ -10485,8 +10472,8 @@ iron-bows-forge;10713;ironbows;Iron Bows;;
 filtered-chests;10715;filteredchests;Filtered Chests;;
 ;10716;pineapple_item_export;图片渲染导出凤梨版;Pineapple Item Export;PIE
 ;10717;lobotomycorp;脑叶公司;Lobotomy Corp;LC
-;10718;antixray;AntiXray;;
-special-strength;10719;;Special Strength;;
+antixray;10718;antixray;AntiXray;;
+special-strength;10719;specialstrength;Special Strength;;
 armorpoints;10720;armorpointspp;Armor Points ++;;
 easy-enchanting;10721;easyenchanting;轻松附魔;Easy Enchanting;
 elitia;10722;;Create: Elitia Addon;;
@@ -10496,18 +10483,18 @@ death-backup;10725;deathbackup;Death Backup;;
 bear-with-me;10726;;Bear With Me;;
 create-diesel-generators;10727;createdieselgenerators;机械动力：柴油动力;Create: Diesel Generators;
 vintagefix;10728;vintagefix;VintageFix;;
-nostalgic-tweaks;10730;nostalgic_tweaks;Nostalgic Tweaks;;
+nostalgic-tweaks;10730;nostalgic_tweaks;Nostalgic Tweaks;;N.T
 suspicious-sand-maker;10731;suspiciouser;Suspicious Sand Maker;;
 create-cobblemon-industrialized;10732;cobblemon_industrialized;Create: Cobblemon Industrialized;;CCI
 create-pixelfactory;10733;createpixelmon;Create: Pixelfactory;;
 ies-tweaks;10734;ietweaks;IE's Tweaks;;
-;10735;haunt_furnace;Haunt Furnace;;
+haunt-furnace;10735;haunt_furnace;Haunt Furnace;;
 player-ladder;10736;playerladder;Player Ladder;;
 orb-of-origin-plus;10737;orboforiginplus;Orb of Origin Plus;;
 ;10738;hashs_falcons_mr;Hashs's Falcons;;
 firework-minecart-mod;10739;fireworkminecart;Firework Boosted Minecarts;;
 soots-sandwichcraft;10740;breadcraft;Soot's Sandwichcraft;;
-rpg-origins;10741;;RPG Origins;;
+rpg-origins;10741;rpg_origins;RPG Origins;;
 ;10742;zombie_lag_fix;Zombie Lag Fix;;
 classic-minecraft-icon;10743;classic_minecraft_icon;Classic Minecraft Icon;;
 ;10744;tboi_suzu;The Binding Of Isaac | Useful Items;;TBOI_UI
@@ -10515,7 +10502,7 @@ classic-minecraft-icon;10743;classic_minecraft_icon;Classic Minecraft Icon;;
 some-useful-ores;10746;some_useful_ores;Some Useful Ores;;
 ;10747;stardew_valley;Stardew Valley;;
 rainy-harvest;10748;;Rainy Harvest;;
-mythic-mobs;10749;mythic_mobs;Mythic Mobs;;
+mythic-mobs;10749;mythic_mobs;Mobs of Mythology;;
 lost-features;10750;lostfeatures;Lost Features;;
 bagus-lib;10751;bagus_lib;Bagus Lib;;
 ;10752;noprivateorprotected;我讨厌权限修饰符;NoPrivateOrProtected;NPOP
@@ -10540,7 +10527,7 @@ not-just-biomes;10770;njb;Not Just Biomes;;NJB
 agricultural-enhancements;10771;agriculturalenhancements;农业增强;Agricultural Enhancements;
 ;10772;evolution_upgrading;进化：升级;evolution:upgradings;EU
 ;10773;copperandcystalforfabric;铜与晶：Fabric;;CACFF
-lorrys-sword-breakers;10774;sword_breakers;罗毅的锏;Lorry's sword breakers;
+lorrys-sword-breakers;10774;sword_breakers;罗毅的锏;Lorry's sword breakers;LSB
 ramel;10775;ramel;Ramel;;
 ;10776;assembly;Ansamblu;;
 ;10777;chattools;聊天工具箱;Chat Tools;
@@ -10577,12 +10564,12 @@ haste-enchantment;10807;hasteenchantment;Haste Enchantment;;
 workshop-for-handsome-adventurer;10808;workshop_for_handsome_adventurer;Workshop for handsome adventurer;;
 desert-upgrade;10809;desert_upgrade;Desert Upgrade;;
 ocean-recovery;10810;ocean_recovery;Ocean Recovery;;
-more-armor-trims;10811;more_armor_trims;More Armor Trims;;
+more-armor-trims;10811;more_armor_trims;更多盔甲纹饰;More Armor Trims;
 all-the-trims;10812;allthetrims;All The Trims;;
 ;10813;signeditgui;告示牌编辑器;Bamboo Sign Editor;
 revival-orb;10814;revivalorb;Revival Orb;;
-stackable-trims;10815;;Stackable Trims;;
-keepcuriosinventory;10816;KeepCuriosInventory;饰品栏优化;KeepCuriosInventory;
+stackable-trims;10815;stackabletrims;Stackable Trims;;
+keepcuriosinventory;10816;KeepCuriosInventory,keepcuriosinventory;饰品栏优化;KeepCuriosInventory;
 megachicken;10817;megachicken;MegaChicken;;
 s33r-iris-azalea-mod;10818;seer_iris_azaleas;S33R Iris Azalea;;
 difficultyplus;10819;difficultyplus;Difficulty+;;
@@ -10596,7 +10583,7 @@ irons-rpg-tweaks;10825;irons_rpg_tweaks;Iron's Rpg Tweaks;;
 tokenable-decoration;10827;tokenabledecoration;Tokenable Decoration;;
 emogg;10828;emogg;emogg;;
 ;10829;festival_delicacies;节日佳肴;Festival Delicacies;
-elytra-trims;10830;elytra_trims;Elytra Trims;;
+elytra-trims;10830;elytra_trims,elytratrims;Elytra Trims;;
 benefits-of-reading;10831;benefitsofreading;雕纹书架注魔/阅页读著;Benefits of Reading;
 gothic-rpg;10832;gothic;Gothic RPG;;
 arcadian-dream;10833;arcadiandream;幻想之梦;Arcadian Dream;AD
@@ -10635,7 +10622,7 @@ responsive-shields;10865;responsive-shields;Responsive Shields;;
 beehave;10866;beehave;蜜蜂信息显示;Beehave;
 ;10867;;生命值显示;Hit Point;
 sign-clipboard;10868;sign_clipboard;Sign Clipboard;;
-nocubes-better-frogs;10869;betterfrogs;NoCube's Better Frogs;;
+nocubes-better-frogs;10869;betterfrogs,nocubes_better_frogs;NoCube's Better Frogs;;
 ;10870;vanilla-permissions;Vanilla Permissions;;
 create-dreams-desires;10871;flavored,create_dd;机械动力：梦想与欲望;Create: Dreams & Desires;
 trails-and-tales;10872;trailsandtalesplus;Trails and Tales +;;
@@ -10653,7 +10640,7 @@ create-air-forge;10882;createair;Create Air;;
 ;10884;mr_endermite_expansion;Endermite Expansion;;
 ;10885;mr_cherry_villages;Cherry Grove Villages;;
 inhibited;10886;inhibited;Inhibited;;
-;10887;crf;中国铁路设施;;CRF
+china-railway-facilities;10887;crf;中国铁路设施;;CRF
 sekc-physics;10888;sekcphysics;SekC Physics;;
 ;10889;artificial_lightning;Artificial Lightning Mod;;
 do-api;10890;doapi,terraform;Let's Do API;;
@@ -10662,17 +10649,17 @@ do-api;10890;doapi,terraform;Let's Do API;;
 grabby-mobs;10893;grabbymobs;Grabby Mobs;;
 pandas-falling-trees;10894;fallingtrees;Panda's Falling Trees;;
 iron-ender-chests;10895;iron_ender_chests;Iron Ender Chests;;
-delightful-creators-fabric;10896;delightfulcreators;Delightful Creators;;
+delightful-creators-fabric;10896;delightfulcreators;动力乐事;Delightful Creators;
 deathbutthree;10897;deathbutthree;逝不过三;Death But Three;
 ;10898;fnrt;王抹布の火影忍者模组;FnrtMod;Fnrt
 comparties;10899;comparties;组队兼容;Comparties;
 dusty-decorations;10900;dustydecorations;Dusty Decorations;;
-simple-double-jump;10901;;Simple Double Jump;;
+simple-double-jump;10901;derecs_double_jump;Simple Double Jump;;
 simple-ore-generation;10902;simpleoregen;简单的矿石生成;Simple Ore Generation;
 save-the-monument;10903;savethemonument;Save the Monument;;
 snifferiety;10904;snifferiety;Snifferiety;;
 light-the-night;10905;ltn;Light The Night;;
-tweakerge;10906;tweakeroo;Tweakerge;;
+tweakerge;10906;tweakeroo,tweakerge;Tweakerge;;
 terrafirmaships;10907;terrafirmaships;TerraFirmaShips;;
 better-ocelots;10908;;Better Ocelots;;
 actually-useful-smithing-table;10909;actuallyusefulsmithingtable;Actually Useful Smithing Table;;
@@ -10688,7 +10675,6 @@ ghostz;10918;ghostz;GhostZ;;
 better-totem-of-undying;10919;better_totem_of_undying;Better Totem Of Undying;;
 modonomicon;10920;modonomicon;Modonomicon;;
 moreyoyos;10921;moreyoyos;More Yoyos;;
-effortless-fabric;10922;effortless;Effortless Fabric;;
 onetwenty-1-20-backport;10923;onetwenty;Trails&Tales Backport;;
 xtra-arrows;10924;xtraarrows;Xtra Arrows;;
 secrets-of-forging-revelations-a-tetra-addon;10925;secrets_of_forging_revelations;Secrets of Forging: Revelations;;
@@ -10696,14 +10682,14 @@ trolldom;10926;trolldom;Trolldom;;
 ;10927;made_in_china;中国制造;Made In China;
 soundlimitextends;10928;soundlimitextends;SoundLimitExtends;;
 artemis-flower-pots;10929;flowerpots;Artemis' Flower Pots;;
-sculky-bits;10930;sculky_bits;Sculky Bit;;
+sculky-bits;10930;sculky_bits;Sculky Bits;;
 minecolonies-for-computercraft;10931;colony4cc;MineColonies for ComputerCraft;;
 flame-sweeping-potato-edition;10932;flamesweeping;烈焰横扫：土豆版;Flame Sweeping Potato Edition;
 skinned-carts;10933;skinnedcarts;Skinned Carts;;
 quick-effect;10934;quickeffect;Quick Effect;;
 block-log;10935;blocklog;Block Log;;
 ;10936;memorycleanermissnotoredict;青春内存清理不会梦到矿物词典学姐;Memory Clearer Miss-not Ore Dict;MCMOD
-equipment-benediction;10937;equipmentbenediction;装备祝福;Equipment Benediction;EB
+equipmentbenediction;10937;equipmentbenediction;装备祝福;Equipment Benediction;
 ;10938;gamemode;现代游戏模式选择器;Modern Gamemode Switcher;GMS
 dimension-localized-inventories;10939;;Dimension Localized Inventories;;
 skillcraft-modpack-tool;10940;skillcraft;Skillcraft;;
@@ -10712,11 +10698,11 @@ ghostjump;10942;ghostjump;死者为大;GhostJump;
 ;10943;notsoessential;Not So Essential;;
 worldsalads-opulence;10944;wsopulence;WorldSalad's: Opulence;;
 ;10945;pvz;HungTeen的植物大战僵尸95版;HungTeen's Plants vs Zombies 95;HTPVZ95
-;10946;wyrmsofnyrus;Wyrms of Nyrus;;WoN
+wyrms-of-nyrus;10946;wyrmsofnyrus;Wyrms of Nyrus;;WoN
 pearfection;10947;pearfection;Pearfection;;
 enderchests;10948;enderchests;Ender Chests;;
 dragon-rider;10949;;Dragon Riders;;
-create-utilities-fabric;10950;create_utilities;机械动力：实用物品;Create Utilities;
+createutilities;10950;create_utilities,createutilities;机械动力：实用物品;Create Utilities;
 ;10951;cregtech;克瑞科技重制版 / 科雷格科技;CregTech Remake;CgT
 creeperhost-presents-chickens;10952;chickens;CreeperHost Presents Chickens;;
 inet;10953;inet;INet;;
@@ -10750,7 +10736,7 @@ lively-forests;10981;;Lively Forests;;
 ;10982;nz_mod;星光的逆战模组;Stars_NZ;NZ
 dynamic-fullbright;10983;dynamic-fullbright;Dynamic Fullbright;;
 ;10984;modularwarfare;模块化武装：烨熠;ModularWarfare-Shining;MWFS
-;10985;;Don't Clear Chat History;;
+dont-clear-chat-history;10985;dcch;Don't Clear Chat History;;
 difficulty-locker;10986;difficultylocker;Difficulty Locker;;
 virus-disease-mod;10987;virusdiseasespread;Virus Disease Mod;;VDM
 this-boat-is-mine;10988;tbim;这是我的船！;This boat is MINE!;TBIM
@@ -10772,7 +10758,7 @@ ctov-advanced-peripheral-compat;11002;mr_ctov_advancedperipheralcompat;CTOV - Ad
 comfy-beds;11004;comfy-beds;Comfy Beds;;
 twerk-crop-dusting-mod-fabric;11005;danceofgrowth;Twerk / Crop Dusting Mod [FABRIC];;
 extra-damage-enchantments;11006;extra-damage-enchantments;Extra Damage Enchantments;;ExtraDE
-lemon-core;11007;;Lemon Core;;
+lemon-core;11007;lemon_core;Lemon Core;;
 rightclickharvest;11008;rightclickharvest;RightClickHarvest;;
 planters-forge;11009;planters;Planters;;
 passive-charms;11010;passivecharms;Passive Charms;;
@@ -10796,10 +10782,10 @@ ctov-friends-and-foes-compat;11027;mr_ctov_friendsandfoescompat;CTOV - Friends &
 ctov-bountiful-compat;11028;ctov_bountifulcompat_mr;CTOV - Bountiful compat;;
 ;11029;randombirth;随机出生点;RandomBirth;RB
 mobs-info;11030;mobsinfo;Mobs Info;;
-;11031;ngrok-api;Ngrok Api;;
+ngrok-api;11031;ngrok-api;Ngrok Api;;
 ;11032;ctapi;寰缔科技API;CraftTech-API;CTAPI
 ;11033;;水力魔法;HydroMagicalPower;WPM
-;11034;unsheathe_r;利刃出鞘：重铸;Sword Unsheathe Recasting;SUR
+;11034;unsheathe_r;利刃出鞘：重铸;Sword Unsheathe Reforged;SUR
 rpgloot;11035;rpgloot;RPG Loot;;
 ;11036;sus_saver;Sus Saver;;
 ;11037;advancementsaddition;进度追加-糖块;Advancements addition candy;AAc
@@ -10834,7 +10820,7 @@ yeetem-potions;11067;yeetem_potions;YEETem Potions;;
 incapacitated;11068;incapacitated;Incapacitated;;
 ;11069;fys;锻汝砧上;Forge Yourself;FYS
 ;11070;mcopper;梧桐物语;MCopper;
-no-ranged-knockback;11071;;No Ranged KnockBack;;
+no-ranged-knockback;11071;resist;No Ranged KnockBack;;
 industrial-agriculture;11072;industrialagriculture;Industrial Agriculture;;
 macaws-bridges-sajevius;11073;mcwbridgessajevius;Macaw的桥梁：Sajevius 附属;Macaw's Bridges - Sajevius;
 ;11074;getwebbed;GetWebbed;;
@@ -10860,17 +10846,17 @@ despawning-eggs-hatch;11093;despawningeggshatch;Despawning Eggs Hatch;;
 mob-death-messages;11094;mobdeathmessages;Mob Death Messages;;
 chunkapi;11095;chunkapi;ChunkAPI;;
 ;11096;betterwaystonesmenu;BetterWaystonesMenu;;
-;11097;bigfish;Big Fish;;
+big-fish;11097;bigfish;Big Fish;;
 nulltal;11098;nulltal;Nulltal;;
 caffeinefilled;11099;caffeinefilled;CaffeineFilled;;
 pet-transfer-trade-your-pets;11100;pettransfer;Pet Pass: Trade Your Pets!;;
-lets-do-bakery;11101;bakery;Let's Do: Bakery;;
+lets-do-bakery-farm-charm-compat;11101;bakery;馥郁烘焙;Let's Do: Bakery;
 searchables;11102;searchables;Searchables;;
 dixtas-armory;11103;dixtas_armory;Dixta's Armory;;
 ingamestats;11104;ingamestats;InGameStats;;
 hanger-system-overhaul;11105;hanger_system_overhaul;Hunger System Overhaul;;
 isaidnosnow;11106;isaidnosnow;ISaidNoSnow;;
-jarsauth;11107;jarsauth;客户端验证;JarsAuth;
+jarsauth;11107;jarsauth;客户端管理;JarsAuth;
 autoelytrapanic;11108;autoelytrapanic;AutoElytraPanic;;
 more-crossbows-cj;11109;morecrossbows;More Crossbows CJ;;
 multipart-machines-cooking;11110;mm_cooking;Multipart Machines: Cooking;;
@@ -10917,7 +10903,7 @@ emoji-type;11150;emojitype;Emoji Type;;
 soul-bound-enchantment;11151;soulbound;灵魂绑定;SoulBound;
 tower-defense-units;11152;;Tower Defense Units;;
 barrier-block-mod;11153;barrierblock;屏障方块;Barrier Block Mod;
-;11154;;SimpleHealthOrbs;;
+;11154;healthorbs;SimpleHealthOrbs;;
 misctweaks_;11155;misctweaks;MiscTweaks;;
 dynamic-music-updated;11156;dynmus;Dynamic Music Updated;;
 spartan-netherite;11157;spartannetherite;Spartan Netherite;;
@@ -10935,14 +10921,14 @@ accurate-block-placement-reborn;11168;;Accurate Block Placement Reborn;;
 favorite-items;11169;favoriteitems;Favorite Items;;
 ;11170;;纸灯笼;Paper Lanterns;
 ;11171;smart-villagers-follow-emeralds;见钱眼开;Smart Villagers Follow Emeralds;
-;11172;;FPS++;;
+;11172;fps15;FPS++;;
 ;11173;villager-pickup;Villager Pickup;;
 step-it-up;11174;stepitup;Step It Up;;
 fantasy-trees;11175;fantasy_trees;奇幻树;Fantasy Trees;
 ;11176;;AudioMod;;
 remodified;11177;modifiers;你再造！;Remodifier;
 ;11178;;Death Chest;;
-;11179;;Shelf;;
+;11179;mod_Shelf;Shelf;;
 better-fusion-reactor-for-mekanism;11180;bfr;Better Fusion Reactor for Mekanism;;
 growableores;11181;growableores;GrowableOres;;
 golemsarefriends;11182;golemsarefriends;Golems Are Friends Not Fodder;;
@@ -10951,7 +10937,7 @@ golemsarefriends;11182;golemsarefriends;Golems Are Friends Not Fodder;;
 keep-command-history;11185;keepcommandhistory;Keep Command History;;
 ;11187;technomagic;TechnoMagic;;
 generatorgalore;11188;generator_galore;Generator Galore;;
-;11189;map_shirts;Map Shirts;;
+map-shirts;11189;map_shirts;Map Shirts;;
 fireproof-boats;11190;fireproof_boats;Fireproof Boats;;
 dyenamicsandfriends;11191;dyenamicsandfriends;Dyenamics and Friends;;
 ;11192;mod_Timber;Timber!;;
@@ -10965,14 +10951,14 @@ placeable-mobs;11199;placeable _mobs;Placeable Mobs;;
 potion-blender;11200;potion_blender;Potion Blender;;
 t6-auto-attack-mod;11201;autoattack;T6's Auto Attack Mod;;
 forceasciifont-backport;11202;forceasciifont;ForceASCIIFont-Backport;;
-;11203;vmtranslationupdate;VM汉化更新;VM Translation Update;
+vmtranslationupdate;11203;vmtranslationupdate;VM汉化更新;VM Translation Update;VMTU
 trample-no-more;11204;tramplenomore;Trample No More;;
 ;11205;new_chests;New Chests;;
-directional-damage-indicator;11206;damageindicator;Directional Damage Indicator;;
-;11207;;CheffCraft;;
+jeremyseq-damage-indicator;11206;damageindicator;JeremySeq's Damage Indicator;;
+;11207;CheffCraft;CheffCraft;;
 digs-dnd-origins;11208;digs_dnd_origins;Dig's DnD Origins;;
 superior-flat;11209;superior_flat;Superior Flat;;
-fungal-infection-spore;11210;spore;Fungal Infection:Spore;;
+fungal-infection-spore;11210;spore;真菌感染:孢子;Fungal Infection:Spore;F:S
 ;11211;easytweak;Easy Tweak;;
 ;11212;;BitDepthFix;;
 netherless-quartz;11213;;Netherless Quartz;;
@@ -10989,7 +10975,7 @@ ants-unleashed;11222;ants_unleashed;Ants Unleashed;;
 gold-fish;11224;;Gold Fish;;
 pipeplus;11225;pipeplus;PipePlus;;
 ;11226;malilib;MaLiLib for Forge;;
-;11227;;Litematica for Forge;;
+;11227;litematica;Litematica for Forge;;
 deuf-refabricated;11228;deuf_refabricated;DEUF Refabricated;;
 ;11229;moon_phase;Moon Phase Info-;;
 runic-items;11230;runic_items;Runic Items;;
@@ -10998,7 +10984,7 @@ twist;11231;twist;诡变;Twist;
 oil-refinery;11233;;Oil Refinery;;
 themangonewadvent;11234;the_mango_new_advent,mango_mod;The Mango New Advent / Mango Legacy;;
 ;11235;worthy_food;Worthy Food;;
-;11236;;Biosphere;;
+;11236;mod_Biosphere;Biosphere;;
 better-nether-continuation;11238;;更好的下界延续;BetterNether Continuing;
 stygian-end-continuation;11239;stygian;末地：生物群系扩展延续;Stygian End Continuation;
 skill-slots;11240;skillslots;技能槽;Skill Slots;
@@ -11010,7 +10996,7 @@ xp-from-harvest-forked;11245;;XP From Harvest (Stoutscientist's Fork);;
 papi-project;11246;papi;Papi;;
 eventhorizon;11247;eventhorizon;事件视界;EventHorizon;EH
 mob-options;11248;moboptions;Mob Options;;
-mod-sets;11249;mod-sets;模组集;Mod Sets;
+mod-sets;11249;mod-sets,mod_sets;模组集;Mod Sets;
 ;11250;mr_upgraded_mobs;Upgraded Mobs;;
 ;11251;;SCP 096;;
 hold-that-chunk;11252;holdthatchunk;Hold That Chunk;;
@@ -11037,7 +11023,7 @@ gensokyo-ontology;11272;gensokyoontology;幻想存有论;Gensokyo Ontology;GSKO
 recipe-book-delight;11273;recipe-book-delight;配方书乐事;Recipe Book Delight;
 chest-hoppers;11274;chesthopper;箱子漏斗;Chest Hoppers;
 ;11275;gravydelight;Gravy Delight;;
-ubes-delight;11276;ubes_delight;Ube's Delight;;
+ubes-delight;11276;ubes-delight;香芋乐事;Ube's Delight;UD
 torcherino-unofficial;11277;torcherino;Torcherino(Unofficial);;
 more-bows-and-arrows;11278;morebowsandarrows;More Bows and Arrows;;
 xp-shop;11279;xp_shop;XP shop;;
@@ -11056,10 +11042,10 @@ custom-villagers;11291;customvillagers;自定义村民;Custom Villagers;
 turtlematic;11292;turtlematic;Turtlematic;;
 remove-base-origins;11293;remove_base_origins;Remove Base Origins;;
 ;11294;cfarmersint;方块宝可梦乐事;Cobblemon Delights;
-redirectionor;11295;redirectionor,redirector;异引定址;Redirector;
+redirector;11295;redirectionor,redirector;异引定址;Redirector;
 villager-mantle-fix;11296;villagermantlefix;村民帽子修复;Villager Mantle Fix;
 rechiseled-create;11297;rechiseled_create,rechiseledcreate;Rechiseled: Create;;
-xaeroplus;11298;xaeroplus;Xaero的地图增强;XaeroPlus;
+xaeroplus;11298;xaeroplus;Xaero的地图增强;XaeroPlus;XP
 cosmetic-nametags;11299;cosmetic_nametags,nametags;Cosmetic Nametags;;
 thirdlife-rts;11300;thirdlife_rts;Thirdlife RTS;;
 real-peaceful-mode;11301;real_peaceful_mode;真正的和平模式;Real Peaceful Mode;RPM
@@ -11068,7 +11054,7 @@ elfs-dark-dimension;11303;rk;Dimension Dark Florest;;
 xaeros-minimap-world-map-waystones-compability;11304;w2w2;Xaero's Minimap & World Map - Waystones Compability;;
 jagms-kiwis;11305;jagms_kiwis;Jagm's Kiwis;;
 ;11306;masaadditions;MasaAdditions;;
-;11307;ite;Improved Trident Enchantments;;
+improved-trident;11307;ite;Improved Trident;;
 mystic-bows;11308;mystic_bows;Mystic Bows;;
 forgiving-world;11309;forgivingworld;Forgiving World;;
 ;11310;skillcloaks;Skillcloaks;;
@@ -11079,7 +11065,7 @@ yamato-gun-mod;11314;yamato_gun;Yamato Gun;;
 ;11315;fzsd;FZ生存数据包;FZ Survival Datapack;FZSD
 ars-mage-fight;11316;ars_mage_fight;Ars Mage Fight;;
 ;11317;shieldexp;Shield Expansion Potato Edition;;
-epicfight-pirates;11318;efmpirates;Epicfight Pirates;;
+epic-sanji;11318;efmpirates;Epic Sanji;;
 kubejs-entity-events-extension;11319;kubejs_entity_events_ext;KubeJS Entity Events Extension;;
 mc-dungeons-enchanting;11320;mc_dungeons_enchantments,mcd_enchantments;我的世界：地下城附魔;MC Dungeons Enchanting;MCDE
 rei-custom-command;11321;rei_custom_command;REI自定义命令;REI Custom Command;
@@ -11092,38 +11078,38 @@ makecold;11327;ims;冷境;MakeCold;MC
 ;11328;kazzmon.daycount;Kazzmon's DayCount;;
 ;11329;kazzmon.extravanilla;Kazzmon's ExtraVanilla;;
 sculk-redstone-components;11330;sculk_redstone_components;Sculk Redstone Components;;
-toggle-enchantments;11331;;Toggle Enchantments;;
+toggle-enchantments;11331;togenc;Toggle Enchantments;;
 unbreakable-enchantment-forge;11332;g_abun;Unbreakable Enchantment;;
 immersive-portal-gun;11333;portalgun;沉浸式传送枪;Immersive Portal Gun;
 tac-craft-tactical-armor-pack;11334;pretaccraft;Tac Craft;;
 ;11335;flexible_arms;灵巧双手;Flexible Arms;
 boat-tweaks;11336;boattweaks;船只调整;Boat Tweaks;
-;11337;effectdescriptions;Effect Descriptions;;ED
-;11338;;Diagonal Windows;;DW
+new-effect-descriptions;11337;effectdescriptions;Effect Descriptions;;ED
+diagonal-windows;11338;diagonalwindows;Diagonal Windows;;DW
 ;11339;lunar_eyes;Eyes In The Sky;;
-illager-invasion;11340;illager_invasion;灾厄侵扰;Illager Invasion;
+illager-invasion;11340;illager_invasion;灾厄侵扰;Illager Invasion;IN
 ;11341;littlemaidmodelloader;LittleMaid ModelLoader;;
 ;11342;;一键挖矿;One Click Dig Ore;
-;11343;;Touhou Origins: Blessings;;
+;11343;touhoublessings;Touhou Origins: Blessings;;
 ;11344;hard_game;较为困难的合成;HardGame;
 altorigingui;11345;altorigingui;Alternate Origin GUI;;
-dynamic-trees-pams-harvestcraft-2;11346;dtphc2;Dynamic Trees Pam's Harvestcraft 2: Trees;;
-dynamic-trees-hexerei;11347;dthexerei;Dynamic Trees - Hexerei;;
+dynamic-trees-pams-harvestcraft-2;11346;dtphc2;动态的树：潘马斯农场2 - 果树附属;Dynamic Trees Pam's Harvestcraft 2: Trees;
+dynamic-trees-hexerei;11347;dthexerei;动态的树：魔法巫师附属;Dynamic Trees - Hexerei;
 minium-stone;11348;minium_stone;Minium Stone;;MS
 ;11349;;Kazzmon's Silk Touch Spawners;;
 ;11350;fast-rtp;FastRTP;;
 tech-decorators;11351;tech_decorators;科技装饰商;Tech Decorators;TD
-dynamic-trees-ars-nouveau;11352;dtarsnouveau;Dynamic Trees - Ars Nouveau;;
+dynamic-trees-ars-nouveau;11352;dtarsnouveau;动态的树：新生魔艺附属;Dynamic Trees - Ars Nouveau;
 ;11353;flighthud;FlightHUD玩家移植版;;
 ;11354;kazz.magecraft;Kazzmon's MageCraft;;
-;11355;metal_bundles;Metal Bundles;;MB
+metal-bundles;11355;metal_bundles;Metal Bundles;;MB
 ;11356;fuckvoid;FuckVoid;;
 ;11357;kazz.extraincendium;ExtraIncendium;;
-tidal-towns;11358;tidal_towns;Tidal Towns;;
+tidal-towns;11358;tidal_towns,mr_tidal_towns;潮汐小镇;Tidal Towns;
 blossom-blade;11359;blossom_blade;Blossom Blade;;
 ;11360;;Phantom Curse;;
 cute-kiwi-birds-new-animal;11361;;Cute Kiwi Birds;;
-moremobheads;11362;more_mob_heads;More Mob Heads+;;
+moremobheads;11362;more_mob_heads;More Mob Heads Mod;;
 ouchies;11363;ouchies;Ouchies - Injuries mod;;
 ;11364;traditional_asphalt;Traditional Asphalt;;
 ;11365;thaumic_boots;Thaumic Boots;;
@@ -11131,15 +11117,15 @@ carpeted-stairs;11366;carpeted;Carpeted Stairs & Slabs;;
 just-enough-archaeology;11367;just_enough_archaeology,jearchaeology;Just Enough Archaeology;;
 bedrock_world;11368;bedrock_world;Bedrock World;;
 ;11369;mr_shared_life;Shared Life;;
-world-preview;11370;world_preview;World Preview;;
+world-preview;11370;world_preview;世界预览;World Preview;
 ;11371;;Not Enough Trinket Slots;;NETS
 the-five-nights-at-freddys-mod;11372;fanf_mod;玩具熊的五夜后宫;The Five Nights at Freddy's Mod;FNAF
 easylan;11373;easylan;自定义LAN局域网联机服务器;EasyLAN;ELAN
 pelagic-prehistory;11374;pelagic_prehistory;Pelagic Prehistory;;
-;11375;minerally;Minerally;;
+minerally;11375;minerally;Minerally;;
 better-jukeboxes;11376;betterjukebox;Better Jukeboxes;;
 patboxs-brewery;11377;brewery;Patbox's Brewery;;
-;11378;;死神;Bleach Mod;
+;11378;bleach;死神;Bleach Mod;
 stackable-stew-and-soup;11379;stackabowls;Stackable Stew and Soup;;
 mindful-darkness;11380;mindfuldarkness;Mindful Darkness;;MD
 ;11381;;Subjectively Better Enchantment Tooltips;;SBET
@@ -11152,9 +11138,9 @@ permanent-sponges;11387;permanentsponges;Permanent Sponges;;PS
 hang-glider;11388;hangglider;Hang Glider;;HG
 ;11389;auto_twerk;Auto Twerk;;
 block-beams;11390;block_beams;Block Beams;;
-adorabuild-structures;11391;;AdoraBuild: Structures;;
+adorabuild-structures;11391;adorabuild_structures;AdoraBuild: Structures;;
 ;11392;mr_limitless;Limitless;;
-moogs-end-structures;11393;mes;MES - Moog's End Structures;;
+moogs-end-structures;11393;mes;Moog's End Structures;;MES
 ;11394;brew_guide;Brew guide;;
 ;11395;one-click-crafting;One Click Crafting;;
 ;11396;genshinui;Genshin UI;;
@@ -11177,10 +11163,10 @@ dangerousstonecutter;11412;dangerousstonecutter;Dangerous Stone Cutter;;
 normal-damage;11413;normaldamage;Normal Damage;;
 ftb-xmod-compat;11414;ftbxmodcompat;FTB XMod Compat;;
 crabbers-delight;11415;crabbers_delight,crabbersdelight;蟹农乐事;Crabber's Delight;
-slot-cycler;11416;slotcycler;Slot Cycler;;
+slot-cycler;11416;slotcycler;Slot Cycler;;SC
 resource-pack-overrides;11417;resourcepackoverrides;Resource Pack Overrides;;RO
-respawning-animals;11418;respawninganimals;动物重生;Respawning Animals;
-arcane-lanterns;11419;arcane_lanterns;Arcane Lanterns;;
+respawning-animals;11418;respawninganimals;动物重生;Respawning Animals;RA
+arcane-lanterns;11419;arcane_lanterns;Arcane Lanterns;;AL
 ;11420;;Pillage the Village;;
 crashma;11421;crashma;Crashma;;
 ;11422;;🦇蝙蝠悲伤MOD;🦇 Bat Sad Mod;
@@ -11190,11 +11176,11 @@ gigeresque;11425;gigeresque;Gigeresque;;
 lookaround;11426;lookaround;Lookaround!;;
 projectileimmunityfix;11427;;ProjectileImmunityFix;;
 ;11428;;BetterZoom;;
-;11429;;Player Visibility;;
-bag-of-holding-forge;11430;bagofholding;Bag Of Holding;;
+;11429;player-visibility;Player Visibility;;
+bag-of-holding-forge;11430;bagofholding;Bag Of Holding;;BH
 ;11431;;原初修真-法术附属;InitialImmortalSkill;
 ;11432;ssfsb;四方食事;Cuisine of World;CW
-;11433;forge;NeoForge;;Neo
+;11433;neoforge;NeoForge;;Neo
 fish-of-thieves;11434;fishofthieves;Fish of Thieves;;
 qualitys-delight;11435;qualitys_delight;Quality's Delight;;
 arrows-info;11436;cr-arrows-info;Arrows Info;;
@@ -11206,7 +11192,7 @@ skin-and-bones;11440;skin_and_bones;Skin And Bones;;
 maxs-deco;11442;maxs_deco;Max的装饰;Max's deco;
 more-nugget;11443;more_nuggets,morenugget;更多矿物粒;More Nugget;
 dual-swords;11444;dual_swords;Dual Swords;;
-organizable-play-screens;11445;organizableplayscreens;Organizable Play Screens (Fabric);;
+organizable-play-screens;11445;organizableplayscreens;Folders!;;
 labelling-containers;11446;labellingcontainers;Labelling Containers;;
 inventory-pause-forge;11447;inventorypause;Inventory Pause (Forge);;
 ready-player-fun;11448;readyplayerfun;Ready Player Fun;;
@@ -11223,7 +11209,7 @@ reactive;11458;reactive_alchemy;Reactive Alchemy;;
 simple-deepslate;11459;simple_deepslate_mod;SimpleDeepslate;;
 minunrpg;11460;minunrpg;MinunRPG;;
 more-sheep-wools;11461;morewoolmod;More Sheep Wools;;
-maturi-delight;11462;maturi_delight;Maturi Delight;;
+maturi-delight;11462;maturi_delight;祭典乐事;Maturi Delight;
 ;11463;dont_destroysuspiciousblocks_mr;不要破坏可疑的方块;Don't destroy Suspicious blocks;
 forgified-fabric-api;11464;fabric_api;Forgified Fabric API;;FFAPI
 artisanat;11465;artisanat;Artisanat;;
@@ -11263,7 +11249,6 @@ silence-mobs;11498;silencemobs;Silence Mobs;;
 utilitix;11500;utilitix;UtilitiX;;
 ;11501;nutrition;营养学：非官方版;Nutrition Unofficial;
 tiny-coal;11502;tinycoal;Tiny Coal;;
-replay-mod-for-forge-reborn;11503;replaymod;Replay for Forge Reborn;;
 flib;11504;flib;FLIB;;
 ;11505;caiqiu;才囚学园-澪吹寒;Cai Qiu Xue Yuan;
 copper-revisioned;11506;copperrevisioned;Copper Revisioned;;
@@ -11283,7 +11268,7 @@ flightem;11519;flightem;我要骑着你飞;Flightem;
 ;11520;leashmod;Leashable Players;;
 snowballs-freeze-mobs;11521;snowballsfreezemobs;Snowballs Freeze Mobs;;
 guinea-pigs;11522;guinea_pigs;Guinea Pigs;;
-;11523;;Smash Bats Mod;スマッシュバットMOD;
+;11523;smashbat;Smash Bats Mod;スマッシュバットMOD;
 ;11524;;禁忌方块;Taboo Blocks;TB
 vault-research;11525;vault_research;Vault Research;;
 the-chaser;11526;;The Chaser;;
@@ -11294,7 +11279,7 @@ mother-silverfish;11530;mother_silverfish;Mother Silverfish;;
 mcretector;11531;mcretector;MCretector;;
 ;11532;;TextCraft;;
 little-botanics;11533;little_botanics;Little Botanics;;
-ex-pattern-provider;11534;expatternprovider;AE2扩展;ExtendedAE;
+ex-pattern-provider;11534;expatternprovider,extendedae;AE2扩展;ExtendedAE;
 ;11535;integrated-circuit;Integrated circuit;;
 creative-disk;11536;;Creative Disk;;
 engineers-construct;11537;engineers_construct;Engineer's Construct;;
@@ -11303,7 +11288,7 @@ witch-mobility;11539;witch_mobility;Witch Mobility;;
 gravestones-die-classy;11540;gravestones;Subaraki's Gravestone;;
 ;11541;mr_ctov_ironsspellsnspellbookscompat;CTOV - Iron's Spells 'n Spellbooks compat;;
 ;11542;;CTOV - PneumaticCraft: Repressurized compat;;
-;11543;;CTOV - Jellyfishing compat;;
+;11543;mr_ctov_jellyfishingcompat;CTOV - Jellyfishing compat;;
 ;11544;pebbles_begone;Pebbles Begone;;
 eternal-eats;11545;eternaleats;Eternal Eats;;
 zombiegame;11546;zombiegame;僵尸游戏;Zombie Game;
@@ -11321,18 +11306,18 @@ tactical-aid;11556;tactical_aid;战术医疗;Tactical Aid;TA
 fishing-bobber-detector;11558;bobberdetector;Create: Fishing Bobber Detector;;
 ;11559;unfixmc181190;村民折扣叠加;Unfix MC-181190;
 create-balanced-flight;11560;balancedflight;Create: Balanced Flight;;
-brewin-and-chewin-remastered;11561;brewinandchewin;Brewin' And Chewin' Remastered;;
+brewin-and-chewin-remastered;11561;brewinandchewin;B&C Fan-Made 1.20 Port;;
 cupboard;11562;cupboard;Cupboard;;
 mcinstance-loader;11563;mcinstanceloader;MCInstance Loader;;
 pre-fish-feed;11564;prefishfeed;打窝;Pre Fish Feed;PFF
 armor-trim-item-fix;11565;armortrimItemfix;Armor Trim Item Fix;;
 waffles-moss;11566;waffles_moss;Waffle's Moss;;
-delightful-cuisine-for-woodheads;11567;cookingforblockheads;Delightful Cuisine for Woodheads;;
+delightful-cuisine-for-woodheads;11567;;Delightful Cuisine for Woodheads;;
 towers-of-the-wild-modded;11568;totw_modded;旷野之息高塔 : 再重制;Towers of the Wild Modded;
 ;11569;;T算法库;;TAL
 waffles-terracotta-plaster;11570;waffles_terracotta_plaster;Waffle's Terracotta Plaster;;
 watermedia;11571;watermedia;WATERMeDIA;;
-;11572;;Inverse Phantoms;;
+;11572;inverse_phantoms;Inverse Phantoms;;
 ;11573;cactus_storage;Cactus Storage;;
 ;11574;;暮色森林光影兼容;;
 etcetera;11575;etcetera;Etcetera;;
@@ -11351,7 +11336,7 @@ mob-animations;11587;;Mobs Animations Plus;;
 platter;11588;platter;Platter;;
 i-want-that-back;11589;iwtb_mr;I Want That Back;;IWTB
 presence-not-required;11590;presencenotrequired;Presence Not Required;;
-;11591;wnboi;Why Not Be One Item;;wnboi
+wnboi;11591;wnboi;Why Not Be One Item;;wnboi
 ;11592;sfssfz;四方食事-福州DLC;Cuisine of World for Fuzhou;CW-Fuzhou
 ;11593;biomecompass;Biome Compass: Maya Edition;;
 eye-collector-mod;11594;eyecollectormod;Eye Collector;;
@@ -11360,16 +11345,16 @@ cozy-foods-milk-tea;11596;cozyfoods;Cozy Foods: Milk Tea;;
 opolis-miners;11597;miners;Opolis Miners;;
 netherite-but-cheaper;11598;nbc_mr;Netherite But Cheaper;;NBC
 ;11599;fabric-hammers;Fabric Hammers;;
-items-displayed-forge;11600;items_displayed;Items Displayed;;
-;11601;;Wood Converter;;
+items-displayed-fabric;11600;items_displayed;物品陈列;Items Displayed;
+wood-converter;11601;woodconverter;Wood Converter;;
 hammer-mod;11602;;Hammer Mod;;
 ;11603;enderstimecontrol;Ender的时间控制;Ender's time control;ETC
-realisticsleepfabric;11604;realisticsleep;Realistic Sleep;;
+realisticsleepfabric;11604;realisticsleep;Steve's Realistic Sleep;;
 zombies-actually-siege;11605;actual_zombie_siege;Zombies Actually Siege;;
 hex-gloop;11606;hexgloop;咒法凝浆;Hex Gloop;
 the-void;11607;thevoid;The Void;;
 the-shadowlands;11608;;The Shadowlands;;
-bloxys-structures;11609;bloxys_structures;Bloxy's Structures & Dimensions;;
+bloxys-structures;11609;bloxys_structures;Bloxy's Structures;;
 enhanced-hordes;11610;;Enhanced Hordes;;
 niftycarts;11611;niftycarts;NiftyCarts;;
 wither-dimension-whitelist;11612;wither_spawn_control;Wither Dimension Whitelist;;
@@ -11387,19 +11372,19 @@ potion-bundles;11623;potionbundles;药水捆;Potion Bundles;
 kofi-table;11624;kofitable;Ko-fi Table;;
 better-mcdonalds-mod;11625;better_mcdonalds_mod;Better McDonald's Mod;;
 ;11626;itemframesplus;ItemFrames+;;
-sinytra-connector;11627;connectormod;Sinytra Connector;;
+sinytra-connector;11627;connectormod;信雅互联;Sinytra Connector;
 noclip;11628;noclip;noclip;;
 diamond-in-the-rough-as-in-obsidian;11629;diamond_in_the_rough;Diamond In The Rough;;
 factioncraft;11630;faction_craft;FactionCraft;;
-better-ender;11631;;Jawsy's Better Ender;;
+better-ender;11631;betterenderfabric,better_ender;Jawsy's Better Ender;;
 mlmanimator;11632;mlmanimator;Multi Limbed Model Animator;;
 playlist;11633;playlist;Playlist;;
-;11634;;Villagers: Far From Home;;V:FFH
+;11634;villagersffh;Villagers: Far From Home;;V:FFH
 cultivationcraft;11635;cultivationcraft;异道修仙;CultivationCraft;
 ;11636;legend_sword;传说之剑;Legendary Sword;LS
 ;11637;carpet-las-addition;Carpet LAS Addition;;CLA
 ;11638;whoami;我是谁?;Who am i?;
-;11639;verticality;Verticality;;
+verticality-hotbar;11639;verticality;Verticality;;
 the-slender-man;11640;slenderman;The Slender Man;;
 automodpack;11641;automodpack;AutoModpack;;
 bella-quilt;11642;bella;Bella;;
@@ -11416,7 +11401,7 @@ infernal-damage-indicators;11652;infernalhealth;Infernal Damage Indicators;;
 ;11653;unofficial-sodium-culling-patch;Sodium非官方剔除补丁;Unofficial Sodium Culling Patch;USCP
 ;11654;justenoughspeed;Just Enough Speed;;
 remion;11655;soullike_armors,remion;soul-like armors: medieval weapons & armors;;
-;11656;;Elytra Time;;
+;11656;elytratime;Elytra Time;;
 ;11657;yankailoginprotect;玩家重生保护;Yankai Login Protect;YLP
 squaremap;11658;squaremap;squaremap;;
 roots-classic-fabric;11659;rootsclassic;Roots Classic (Fabric);;
@@ -11430,8 +11415,8 @@ ars-oscura;11666;ars_oscura;黑暗魔艺;Ars Oscura;
 bobby-reforged;11667;bobby;Bobby Reforged;;
 shut-up-gl-error;11668;shut_up_gl_error;Shut Up GL Error;;
 no-spider;11669;no-spider;No spider;;
-terracart-reloaded;11670;;Terracart Reloaded;;
-dme;11671;dme;Deep Mob Evolution;;
+terracart-reloaded;11670;terracart;Terracart Reloaded;;
+dme;11671;dme;Deep Mob Evolution;;DME
 fruit-stack;11672;fruitstack;果栈丰萦;Fruit Stack;
 gregtech-drawers;11673;;Gregtech Drawers;;
 marine-iguana;11674;marine_iguana;海鬣蜥;Marine Iguana;
@@ -11448,7 +11433,7 @@ quickstack;11684;quickstack;Quickstack;;
 ;11685;blackholestorage;黑洞储存;Black Hole Storage;
 collectors-album;11686;collectorsalbum;Collector's Album;;
 head-name-fix;11687;headfix;Head Name Fix;;
-hostile-delight;11688;hostiledelight;宿敌乐事;Unusual Delight (Hostile Delight);
+hostile-delight;11688;hostiledelight;异趣乐事/宿敌乐事;Unusual Delight (Hostile Delight);
 vivecraft-compat;11689;vivecraftcompat;ViveCraft兼容;ViveCraft Compat;
 wildlife-expanded-skunk;11690;skunk;Wildlife Expanded: Skunk;;
 keepheadnames;11691;keepheadnames;Keep Head Names;;
@@ -11487,9 +11472,9 @@ invisible-frames;11723;invisframes;Invisible Frames;;
 ultimatebackportmod;11724;ultimatebackport;Ultimate Backport Mod;;
 ;11725;ExnihiloSequentiaPlus;无中生有：传承扩展;Exnihilo Sequentia Plus;ESP
 ;11726;refined_advancements_mr;Refined Advancements;;
-;11727;mr_true_ending;True Ending: Ender Dragon Overhaul;;
+true-ending;11727;mr_true_ending;True Ending: Ender Dragon Overhaul;;
 ;11728;sorted-enchants;附魔排序;Sorted Enchants;
-constructs-armory-1-18-2-port;11729;constructsarmory;Construct's Armory Port;;
+constructs-armory-1-18-2-port;11729;constructsarmory;Construct's Armory Port / Construct Armory updated;;
 ;11730;;冬之纪行诗;The Poetry Of Winter;
 ;11731;videotape;Video Tape;;
 ;11732;enchantmenttweaker;Enchantment Tweaker;;
@@ -11517,7 +11502,7 @@ dangerous-oceans;11752;dangerous_oceans;Dangerous Oceans;;
 ;11754;fefafly;Feather Fall Flying;;
 ;11755;lidar;Lidar;;
 anvil-never-too-expensive;11756;ante;Anvil Never Too Expensive;;ANTE
-;11757;crossbow;Crossbow;;
+;11757;crossbow;弩;Crossbow;
 ;11758;placeitem;Place Item;;
 ;11759;infinite_storage;无限收纳;Infinite Storage;
 controlify;11760;controlify;Controlify;;
@@ -11541,21 +11526,21 @@ nb_mod;11777;nb_mod;Nb_Decor;;
 ;11778;;Bedrock Wither: Recreation for Java Minecraft;;
 stacked-armor-trims;11779;;Stacked Armor Trims;;
 ;11780;finalbeta;Final Beta;;
-;11781;better-trim-tooltips;Better Trim Tooltips;;
+better-trim-tooltips;11781;better-trim-tooltips;Better Trim Tooltips;;
 totally-enough-pain;11782;tep;Totally Enough Pain;;TEP
 custom-village;11783;custom_village_hileb;村民调教;Custom Village;CVH
 animaticareforged;11784;animatica;AnimaticaReforged;;
 shear-cows;11785;shear_cows;Shear Cows;;
-better-fps;11786;betterfps;FPS Boost;;
-;11787;;AFKfish;;
-;11788;;我的幻想生物;MetalMax;MFC
+fps-boost;11786;betterfps;FPS Boost;;
+;11787;autofish;AFKFish;;
+;11788;myfantasycreatures;我的幻想生物;MetalMax;MFC
 ;11789;rend;Rend;;
 more-trails-more-tales;11790;moretrailsmoretales;More Trails & More Tales;;MTMT
 good-tea;11791;good-tea;馥郁良茶;Good Tea;
 screen-size;11792;screensize,screen-size;Screen Sizer;;
 botany-ores;11793;botanyores;Botany Ores;;
 ;11794;cauldronfix;炼药锅修复;Cauldron Fix;
-foods-plants-cooking-with-mindthemoods;11795;cooking_with_mindthemoods;Cooking with Mindthemoods;;
+foods-plants-cooking-with-mindthemoods;11795;cooking_with_mindthemoods;Foods & Plants (Cooking with Mindthemoods);;
 ;11796;customgui;自定义 GUI;Custom GUI;
 keebszs-battletowers-fabric;11797;keebsz;Keebsz's Battle Towers;;
 as-a-creeper;11798;as_a_creeper_hileb;*的和你爆了;As a creeper;AACH
@@ -11575,14 +11560,14 @@ chromatic-arsenal;11811;chromatic _arsenal;Chromatic Arsenal;;
 ore-visual-detector;11812;orevisualdetector;Ore Visual Detector;;
 dank-null-no_rce;11813;danknull;/dank/null/no_RCE/;;
 kubejs-additions;11814;kubejsadditions;KubeJS Additions;;
-;11815;;死亡交换;DeathSwap;
+;11815;mr_deathswap;死亡交换;Death Swap;
 ;11816;;死亡交换-游戏模式定时切换;DeathSwap-Gmchange;
 ;11817;abyq;我的世界但是除了你都很快;;abyq
 betterdays;11818;betterdays;Better Days;;
 ;11819;;Seedy Place;;
 extradetails;11820;extradetails;ExtraDetails;;
 ;11821;signed_paintings;Signed Paintings;;
-inenchantment-reconstruction;11822;;负魔与改造;Inenchantment ＆ Reconstruction;I&R
+inenchantment-reconstruction;11822;inenchantment_and_reconstruction;负魔与改造;Inenchantment ＆ Reconstruction;I&R
 ;11823;glbshop;全球商店;;
 nae2;11824;nae2;Neeve的AE2:EL附加工具;Neeve's AE2: Extended Life Additions;NAE2
 the-microworld;11825;;The Microworld;;
@@ -11592,7 +11577,7 @@ blueflame;11829;blueflame;Blue Flame Burning;;
 nocubes-craftable-music-discs;11830;nocubes_craftable_md;NoCube's Craftable Music Discs;;
 enderlicious;11831;enderlicious;Enderlicious;;
 quarry-reborn;11832;quarrymod;Quarry Reborn;;
-;11834;noodlesmusketrm;面条的火枪重铸版;Noodles Musket Remarstered;
+;11834;noodlesmusketrm;面条的火枪重铸版;Noodles Musket Remastered;
 morematerials;11835;mmt;Lopy's More Materials;;
 foodmod-for-fabric;11836;foodmod;FoodMod;;
 cursed-mod-for-fabric;11837;cursed;Cursed Mod;;
@@ -11601,7 +11586,7 @@ epic-paragliders-but-sekiro;11839;epicparaglidersbutsekiro;史诗狼之伞;Epic 
 visualores;11840;visualores;VisualOres;;
 d-furnace;11841;furnace3d;3D Furnace;;
 flickerfix;11842;flickerfix;闪烁修复;FlickerFix;
-;11843;spongesucc;SpongeSucc/Lava Sponge;;
+;11843;spongesucc;SpongeSucc / Lava Sponge;;
 ;11844;phosphor-legacy;Phosphor Legacy;;
 random-crits;11845;random_crits;Random Crits;;
 simple-enchantments;11846;simple_enchantments;Simple Enchantments;;
@@ -11620,7 +11605,7 @@ kurisus-passable-leaves;11858;passableleaves;叶间穿梭;Passable Leaves;
 ;11859;gvclibsa;GVClibSA;;
 armorful;11860;armorful;Armorful;;
 ;11861;aaaahidechat4s;直播隐藏聊天框;HideChatForStreaming;
-;11862;;Ornithe Standard Libraries;;OSL
+;11862;osl;Ornithe Standard Libraries;;OSL
 fix-gpu-memory-leak;11863;gpumemleakfix;修复GPU内存泄漏;fix GPU memory leak;
 cake-delight;11864;cakedelight;蛋糕乐事;Cake Delight;
 autoslabs;11865;autoslabs;AutoSlabs;;
@@ -11647,7 +11632,7 @@ rendertypecache;11885;rendertypecache;RenderTypeCache;;
 autotag;11886;autotag-convention;AutoTag;;
 libz;11887;libz;LibZ;;
 autotools;11888;autotools;自动工具;AutoTools;
-;11889;threadtweak;Thread tweak;;
+;11889;threadtweak;ThreadTweak;;
 nbt-editor;11890;nbteditor;NBT Editor;;
 ;11891;secular_seven_reigns;尘世七执政;Secular Seven Reigns;S7R
 ;11892;betterendsky;BetterEnd Sky;;
@@ -11665,7 +11650,7 @@ more-creepers;11901;;更多苦力怕;More Creepers;
 cryptic-registry;11904;cmregistry;Cryptic Registry;;
 level-text-fix;11905;leveltextfix;Level Text Fix;;
 binnies-mods-patched;11906;binniecore,extrabees,extratrees,botany,genetics;Binnie's Mods Patched;;
-cyanide-forge;11907;cyanide;氰化物;Cyanide;
+cyanide;11907;cyanide;氰化物;Cyanide;
 ;11908;particlesenhanced;Particles Enhanced;;
 ;11909;atum;Random and set seed autoresetter;;Atum
 ;11910;worldpreview;WorldPreview;;
@@ -11681,7 +11666,7 @@ create-new-age;11918;create_new_age;机械动力：电气时代;Create: New Age;
 ;11920;sauces;涂酱;Sauces;
 ;11921;zenith;天顶剑;zenith;
 ;11922;sophring;十泉汤;Sophring;
-;11923;;原神：星穹铁道;Genshin:StarRail;GSR
+;11923;ysxqtd;原神：星穹铁道;Genshin:StarRail;GSR
 nekoui;11924;anmao.idoll.nekoui;NekoUI;;
 ;11925;grimoireofpatchouli;帕秋莉的魔法书;Grimoire of Patchouli;GoP
 xpteleporters-2;11926;xpt;经验传送器;XPTeleporters 2;
@@ -11693,9 +11678,9 @@ ctov-wares-compatibility-pack;11931;mr_ctov_warescompat;CTOV - Wares compat;;
 ctov-monobank-compatibility-pack;11932;mr_ctov_monobankcompatibilitypack;CTOV - Monobank compat;;
 prehistoric-nature-cambrian-dimension;11933;;Prehistoric Nature Cambrian Dimension;;
 ;11934;mushroommod;Mushroom Mod;;
-better-end-sky;11935;;Better End Sky;;
+better-end-sky;11935;endsky;Better End Sky;;
 valkyrie;11936;valkyrie;Valkyrie;;
-soaring-structures-2;11937;;Soaring Structures 2;;
+soaring-structures-2;11937;soaringstructures2;Soaring Structures 2;;
 prehistoric-nature-ordovician-dimension;11938;;Prehistoric Nature Ordovician Dimension;;
 fadeless;11939;fadeless;Fadeless;;
 create-tweaked-controllers;11940;create_tweaked_controllers;Create: Tweaked Controllers;;
@@ -11727,7 +11712,7 @@ omnom;11965;omnom;OmNom;;
 forest-x-reborn;11966;forest;Forest X Reborn;;
 exlines-bark-carpets;11967;barkcarpets;Exline's Bark Carpets;;
 exlines-more-carpets;11968;morecarpets;Exline's More Carpets;;
-nekoenchantment;11969;anmao.mc.ne;猫艺：附魔;NekoEnchantment;NE
+ne;11969;anmao.mc.ne;猫艺：附魔;NekoEnchantment;NE
 unearthed-journey;11970;unearthed_journey;出土之旅;Unearthed Journey;
 prehistoric-nature-devonian-dimension;11971;;Prehistoric Nature Devonian Dimension;;
 mwtis-stone-expansion;11972;stoneexpansion;Mwti's Stone Expansion;;
@@ -11736,10 +11721,10 @@ title-fixer;11974;titlefixer;Title Fixer;;
 exstrangefood-reborn;11975;exstrangefoodreborn;更多奇怪的食物：重生;ExStrangeFood:Reborn;ExSFR
 frog-legs;11976;froglegs;Frog Legs;;
 ohoy-scallywag;11977;;O'Hoy Scallywag;;
-ylf-your-flying-pet;11978;;Ylf : your flying pet;;
-;11979;bedrock_edition_features;"基岩"特性;BedrockEditonFeature;
+ylf-your-flying-pet;11978;ylf_mod;Ylf : your flying pet;;
+bedrock-edition-features;11979;bedrock_edition_features;"基岩"特性;Bedrock Editon Features;BEF
 simply-hot-springs;11980;simplyhotsprings;Simply Hot Springs;;
-magma-monsters;11981;;Magma Monsters;;
+magma-monsters;11981;magma_monsters;Magma Monsters;;
 mystics-biomes;11982;mysticsbiomes;Mystic's Biomes;;
 super-block-world;11983;SuperBlockWorld;Super Block World [Forge];;
 create-train-additions;11984;create_train_additions;Create Train Additions;;
@@ -11778,7 +11763,7 @@ tin-ore;12016;tinore;Tin Ore;;
 dark-elves-of-underdark;12017;dark_elves;Dark Elves of Underdark;;
 titan-biomes;12018;titan_biomes;Titan Biomes;;
 depth-striders;12019;depth_striders;Depth Striders;;
-endercage;12020;endercage;Endercage;;
+endercage;12020;endercage;末影笼;Endercage;
 mutationcraft;12021;mutationcraft;Mutationcraft;;
 aftershock;12022;aftershock;Aftershock;;
 limitless-concert;12023;ywzj_midi;永无止境: 音乐会;Limitless Concert;
@@ -11798,7 +11783,7 @@ apothic-attributes;12036;attributeslib;Apothic Attributes (AttributesLib);;
 ;12037;random_block;随机方块;Random Block;
 ;12038;21points;21点;21 Points;21P
 wall-jump-txf;12039;walljump;Wall-Jump TXF;;
-;12040;fastmove;FastMove - Parkour Movement;;
+;12040;fastmove;FastMove - Parkour MovementSinytra Connector;;
 ;12041;genshincraft;原的世界;Genshin Craft;
 and-there-was-only-one-bed;12042;and_there_was_only_one_bed;And There Was Only One Bed;;
 hex;12043;hex;Hex;;
@@ -11815,7 +11800,7 @@ oryls-adventures;12053;oryls_adventure;Oryl's Adventures;;
 elden-craft;12054;elden_craft;Elden Craft;;
 ruok;12055;ruokmod;钌;RuOK;
 deep-dark-regrowth;12056;deep_dark_regrowth;Deep Dark: Regrowth;;
-textrues-embeddium-options;12057;textrues_embeddium_options;TexTrue的Embeddium视频界面;TexTrue's Embeddium Options;TEO
+textrues-embeddium-options;12057;textrues_embeddium_options;TexTrue 的 Embeddium 视频界面;TexTrue's Embeddium Options;TEO
 silent-mine;12058;silent_mine;Silent Mine;;
 headhunter-mod;12059;headhunter_mod;Shadow's Formidable Foes: The HeadHunter;;
 yungs-better-jungle-temples;12060;betterjungletemples;YUNG的丛林神庙优化;YUNG's Better Jungle Temples;
@@ -11828,7 +11813,7 @@ simpletweaker;12065;simpletweaker;SimpleTweaker;;ST
 ;12067;pebbles;石子;Pebbles;
 zens-mmorpg;12068;zens_mmorpg;Zen's MMORPG;;
 ;12069;chp,crosshairpatch;自定义准心补丁;Custom Crosshair Core Patch;CCCP
-enchantment-lore;12070;;Enchantment Lore;;
+enchantment-lore;12070;enchantment_lore;Enchantment Lore;;
 zenrecipereload;12071;zenrecipereloading;配方热重载;ZenRecipeReload;
 lovable-chest;12072;maus_chester;The Lovable Chest;;
 critters-cryptids;12073;critters_and_cryptids;Critters & Cryptids;;
@@ -11844,10 +11829,10 @@ better-impaling-fabric;12082;betterimpaling;Better Impaling (Fabric);;
 vanadium-mod;12083;vanadium;钒;Vanadium;
 loginar-storage;12084;loginar;Loginar Storage;;
 ;12085;jewelry;Jewelry (RPG Series);;
-;12086;;Elytra Drag;;
+elytra-drag;12086;elytradrag;Elytra Drag;;
 night-vision-flash-be-gone;12087;nightvisionflashbegone;Night Vision flash be gone;;
 ;12088;better_creepers;Better Creepers;;
-;12089;ancient _return;Ancient Return;;
+ancient-return;12089;ancient _return;Ancient Return;;
 allayed;12090;allayed;Allayed;;
 honkai-star-rail-12;12091;starrail12;星铁12;Honkai Star Rail 12;
 torchflower-relit;12092;torchflowerrelit;Torchflower: Relit;;
@@ -11863,10 +11848,10 @@ above-and-below;12100;above_and_below;Above and Below;;
 freeze-it-and-heat-it;12102;fiahi;冷汗：食物冷冻与加热;Freeze It, and Heat It!;FIAHI
 ;12103;keybindsgalore;KeybindsGalore 1.20.x (HVB007);;
 never-full;12104;alwayshungry;Never Full;;
-blooming-blossom;12105;bloomingblossom;Blooming Blossom;;
+nemos-blooming-blossom;12105;nemos-blooming-blossom,bloomingblossom;Nemo's Blooming Blossom;;
 legacies-and-legends;12106;legacies_and_legends;Legacies and Legends;;
 ;12107;better_trees;Better Trees;;
-;12108;travel;Villager Transportation;;
+;12108;travel,mr_villager_transportation;Villager Transportation;;
 your-log-saw-something-last-night;12109;ylssln;Your Log Saw Something Last Night;;YLSSLN
 tubes-reloaded;12110;tubesreloaded;Tubes Reloaded;;
 ;12111;romantictp;Romantic Tp;;
@@ -11881,7 +11866,7 @@ history-of-middle-earth-legacy;12119;lotrta;中洲历史：传承;History of Mid
 hostile-humans;12120;hostile_humans;Hostile Humans;;
 classic-and-simple-status-bars;12121;classicandsimplestatusbars;经典且简易的状态栏;Classic and simple status bars;CSSB
 ;12122;turtlechargingstation;Turtle Charging Station;;
-;12123;reputation;Your Reputation;;
+your-reputation;12123;reputation;Your Reputation;;
 futurediary;12124;futurediary;未来日记;FutureDiary;FD
 infiniverse;12125;infiniverse;Infiniverse;;
 use-item-on-block-event;12126;useitemonblockevent;Use Item on Block Event;;
@@ -11899,7 +11884,7 @@ toad-terror;12137;toadterror;Toad Terror;;
 ;12138;mi_sound_addon;Modern Industrialization Sound Addon;;
 achievements-optimizer;12139;achiopt;Achievements Optimizer;;
 automessage;12140;automessage;AutoMessage;;
-ftb-quests-optimizer;12141;ftbquestsoptimizer;FTB Quests Optimizer;;
+ftb-quests-optimizer;12141;ftbquestsoptimizer,ftbqoptimizer;FTB Quests Optimizer;;
 gfarm;12142;gfarm;GFarm;;
 ryoamiclights;12143;ryoamiclights;RyoamicLights;;RDL
 patchouli-rofl-edition;12144;patchouli;Patchouli ROFL Edition;;
@@ -11917,10 +11902,9 @@ yippee;12155;yippee;Yippee;;
 friends-forever;12156;friendsforever;永恒的伙伴;Friends Forever;
 de-extinction-mod;12157;deextinction;De-Extinction Mod;;
 custom-world-generation;12158;custom_worldgen;自定义世界生成;Custom World Generation;CWG
-cataclysm-tweaks;12159;cataclysmtweaks;Cataclysm Tweaks;;
-;12160;euphoria_patcher;Euphoria Patches;;
+euphoria-patches;12160;euphoria_patcher,euphoria_patches;Euphoria Patches / Euphoria Patcher;;EP
 poke-ball;12161;pokeballhv;精灵球;pokeballhv;PBHV
-aquamirae-mod-music;12162;aquamirae_music;♬ Aquamirae Mod EXTRA Music ♬;;
+aquamirae-mod-music;12162;aquamirae_music;♬ Aquamirae - Boss Music Tweaks ♬;;
 deathmatch;12163;genshin_weapons;Deathmatch: Genshin Impact Weapons;;
 ;12164;animatimc,smoothscroll;平滑滚动;Smooth Scroll;
 toad-terror-battle-music;12165;;♪ Toad Terror Battle Music ♪;;
@@ -11930,7 +11914,6 @@ fusion;12168;fusion;Fusion;;
 machines;12169;simple_machines;Machines;;
 tenms-discs;12170;tenms_discs;T_en_M's Discs;;
 netherrocks;12171;netherrocks;Netherrocks;;
-invasion-code-red;12172;invasion_code_red;Invasion Code Red;;
 efw-forgotten-place;12173;efw;EFW: Forgotten Place;;
 ;12174;vulkanite;Vulkanite;;
 yungs-better-end-island;12175;betterendisland;YUNG的末地岛屿优化;YUNG's Better End Island;
@@ -11947,23 +11930,23 @@ repurposed-structures-gazebo-compat;12185;;结构变体：Gazebo 兼容数据包
 longer-chat-history;12186;longerchathistory;Longer Chat History;;
 ;12187;secret-spectator;Secret Spectator;;
 shoot-glass;12188;shootglass;Shoot Glass;;
-modification-of-critical-hit;12189;modification_of_critical_hit;暴击改革;Modification Of Critical Hit;
+modification-of-critical-hit;12189;modification_of_critical_hit,modification-of-critical-hit;暴击改革;Modification Of Critical Hit;
 improved-damage-framework;12190;idf;Improved Damage Framework;;IDF
-;12191;;Shulker+;;
+;12191;shulkerplus;Shulker+;;
 ;12192;;Biome Tag Villagers;;
-combat-bash;12193;;Combat Bash;;
+combat-bash;12193;combat_bash;Combat Bash;;
 ;12194;;SimplePrivateChest;;
 marbleds-villager-hats;12195;marbleds_villager_hats;Marbled's Villager Hats;;
 ;12196;mm;Manningham Mills;Fabric ASM;MM
 connector-extras;12197;connectorextras;Connector Extras;;
 akkamaddis-simple-tungsten;12198;simpletungsten;Simple Tungsten;;
 just-enough-beacons-reforged;12199;just_enough_beacons;Just Enough Beacons Reforged;;
-;12200;;Dusk Autumns Worldgen;;
+;12200;mr_dusk_autumnsworldgen;Dusk Autumns Worldgen;;
 simple-cobalt;12201;simplecobalt;Simple Cobalt;;
 akkamaddis-ashenwheat;12202;ashenwheat;Ashenwheat;;
 prehistoriclegacy;12203;prehistoric_legacy;Prehistoric Legacy;;
 redyed;12204;redyed;Redyed;;
-enchantmentdisabler;12205;;Enchantment Disabler;;
+enchantmentdisabler;12205;enchantmentdisabler;Enchantment Disabler;;
 miners-glasses;12206;miners_glasses;Miner's Glasses;;
 relics-and-alchemy;12207;relics_and_alchemy;Relics And Alchemy;;
 ;12208;greate;Greate;;
@@ -11988,9 +11971,9 @@ rotted-forge;12226;rotted;Rotted;;
 rustic-furniture-compat;12227;rusticcompat;Rustic Furniture Compat;;
 ;12228;norealmsbutton;Realms按钮移除;No Realms Button;
 ;12229;benchantments;BEnchantments;;
-epic-fight-indestructible;12230;;Epic Fight - Indestructible;;
+epic-fight-indestructible;12230;indestructible;坚不可摧;Epic Fight - Indestructible;
 ;12231;set_bonus;Set Bonus（TeamPancake）;;
-;12232;;聊天栏时间显示（TeamPancake 版）;When Was That Again（TeamPancke）;
+;12232;chat_bar_time_display;聊天栏时间显示（TeamPancake 版）;When Was That Again（TeamPancke）;
 ;12233;;逃离塔块夫-重铸;Escape From Tarcraft Reforged;EFTR
 ;12234;;右键文本清除（TeamPancake 版）;Right Click Clear（TeamPancake）;
 catwalks-llc;12235;catwalksinc;Catwalks LLC.;;
@@ -12005,13 +11988,13 @@ shrug-it-off-stb-edition;12243;;Shrug it Off - STB Edition;;
 enchantsmith;12244;enchantsmith;Enchantsmith;;
 snifferent;12245;snifferent;Snifferent;;
 jei-recipe-history;12246;jeirecipehistory;JEI Recipe History;;
-;12247;;Yeet;;
+;12247;yeet;Yeet;;
 macaws-paths-and-pavings;12248;macaws_paths_and_pavings,mcwpaths;Macaw's Paths and Pavings;;
 ;12249;;Chiseled Bookshelf Visualizer;;
 ;12250;elytra_skins;Elytra Skins;;
 mcv-biome-makeover-lieonlion;12251;mcv_biome_makeover_lieonlion;More Chest Variants - Biome Makeover;;
-more-chest-variants-lieonlion;12252;more_chest_variants_lieonlion;More Chests Variants;;MCV
-more-crafting-tables-mct;12253;more_crafting_tables_lieonlion;More Crafting Tables;;MCT
+more-chest-variants-lieonlion;12252;more_chest_variants_lieonlion,lolmcv;More Chests Variants;;MCV
+more-crafting-tables-mct;12253;more_crafting_tables_lieonlion,lolmct;More Crafting Tables;;MCT
 ;12254;;Cobblemon Quests;;
 akkamaddis-classical-alchemy;12255;classicalalchemy;Classical Alchemy;;
 ;12256;bigpony;彩虹大马;Big Pony;
@@ -12022,11 +12005,11 @@ akkamaddis-golden-glitter;12259;goldenglitter;Golden Glitter;;
 enhanced-annihilation-planes;12261;enhanced_annihilation_planes;Enhanced Annihilation Planes;;
 akkamaddis-simple-cthon;12262;cthon;Simple Cthon;;
 ;12263;headshurttoo;Heads Hurt Too!;;
-pooping-animals;12264;pooping_animals;Pooping animals;;
+pooping-animals;12264;pooping_animals;Pooping Animals;;
 good-boy;12265;goodboy;Good Boy;;
 nethers-overhaul;12266;netheroverhaul;Nether's Overhaul;;
-;12267;battletowers;战斗高塔，启动！;Better Battle Towers;BBT
-gregtech-ce-unofficial-child-happy-edition;12268;gregtech;格雷科技社区版非官方版儿童快乐版;GregTech CE Unofficial : Child Happy Edition;GTCEu:CHE
+better-battle-towers;12267;battletowers;战斗高塔，启动！;Better Battle Towers;BBT
+;12268;gregicality_kids;GCY：儿童快乐🎉;Gregicality Kids;GCYK
 ;12269;the_beasts;The Beasts;;
 ;12270;axiom;Axiom;;
 ;12271;elib;ELib;;EL
@@ -12038,7 +12021,7 @@ sterling-and-black;12276;sterlingblack;Sterling and Black;;
 the-devourer-of-skulls-datapack;12277;;The Devourer of Skulls 『𝔹𝕠𝕤𝕤 𝔽𝕚𝕘𝕙𝕥』;;
 ;12278;birds_nests;鸟巢（TeamPancake 版）;Birds Nests(Team Pancake);
 boss-and-magic-raid-compat;12279;;Boss And Magic: Raid Compat;;
-animated-mobs;12280;animatedmobsmod;Boss And Magic / Animated Mobs;;
+animated-mobs;12280;animatedmobsmod;Boss And Magic / AME's Mobs / Animated Mobs;;
 ;12281;GTQTCore;量子跃迁：纠缠核心;GTQTcore;GTC
 backlytra;12282;backlytra;鞘翅;Backlytra;
 neapolitans-quality;12283;neapolitansquality;Neapolitan's Quality;;
@@ -12054,10 +12037,10 @@ configurable-boss-bars;12292;configurablebossbars;Configurable Boss Bars;;
 nuclearcraft-neoteric;12293;nuclearcraft;NuclearCraft: Neoteric;;
 beastly-beacons;12294;beastly_beacons;Beastly Beacons;;
 creeplets;12295;creeplets;Creeplets;;
-thermoo;12296;Thermoo;Thermoo;;
+thermoo;12296;Thermoo,thermoo;Thermoo;;
 restapi;12297;restapi;RestApi;;
 ;12298;;Advanced UI Scaling;;
-;12299;cfb;Chemistry For Blockheads;;CFB
+;12299;cfb,umines;Unmovable Mines / Chemistry For Blockheads;;umines
 health-disease;12300;health_and_disease;健康&疾病;health&disease;HAD
 ;12301;ThermalExpansion;热力膨胀1;Thermal Expansion 1;TE1
 ;12302;ThermalExpansion;热力膨胀2;Thermal Expansion 2;TE2
@@ -12082,11 +12065,11 @@ terraria-calamity-mod;12320;tcal;泰拉瑞亚灾厄;Terraria Calamity;
 darkrtp-rtp-random-teleport;12321;darkrtp;DarkRTP - RTP Random Teleport;;
 cute-bears;12322;cutebear;Cute Bears;;
 additional-fruits;12323;additional_fruits;Additional Fruits;;
-bigger-better-end-cities;12324;bigendcitiesmod;Bigger Better End Cities;;
+bigger-better-end-cities;12324;bigendcitiesmod;更好的末地城;Bigger Better End Cities;
 ;12325;some_peripherals;Some Peripherals;;
 reden;12326;reden;Reden;;
 sparse-structures;12327;sparsestructures;Sparse Structures;;
-;12328;persistentcooldowns;物品冷却持久化;Persistent Cooldowns;
+persistentcooldowns;12328;persistentcooldowns;物品冷却持久化;Persistent Cooldowns;
 ;12329;command_extractor;Command Extractor;;
 advancement-based-spawning;12330;abs;Advancement Based Spawning;;
 ;12331;npop;我讨厌权限修饰符-增强;NoPrivateOrProtected-Plus;NPOPP
@@ -12099,7 +12082,7 @@ pesky-pirates;12337;peskypirates;Pesky Pirates (Anti-Piracy);;
 subterrestrial;12338;subterrestrial;Subterrestrial;;
 illusioners-tower;12339;illusioners_tower;Illusioner's Tower;;
 bad-npcs;12340;bad_npcs;Bad NPCs;;
-darkfeather-golden-feather;12341;darkfeather;DarkFeather - Golden Feather;;
+darkfeather-golden-feather;12341;darkfeather;Golden Feather;;
 darkspawn-teleport-to-spawn;12342;darkspawn;DarkSpawn - Teleport to Spawn or Lobby;;
 darksmelting-smelt-armor-and-tools;12343;darksmelting;DarkSmelting - Smelt Armor, Tools & Weapons;;
 fast-build;12344;fastbuildyaztatili;Fast Build;;
@@ -12116,7 +12099,7 @@ recipe-enhancements;12354;recipe_enhancements;Recipe Enhancements;;RE
 oceanopolis;12355;;Oceanopolis;;
 ;12356;miod;内存增减;;MIOD
 pumpkillagers-quest;12357;pumpkillagersquest;Pumpkillager's Quest;;
-cryogenic-construct-heavily-incomplete;12358;;Cryogenic Construct 『𝔹𝕠𝕤𝕤 𝔽𝕚𝕘𝕙𝕥』;;
+cryogenic-construct-heavily-incomplete;12358;;Cryogenic Construct;;
 cumulomenace-boss-fight-datapack;12359;;Cumulomenace 『Boss Fight』;;
 hydro-fury-datapack;12360;;Hydro Fury!;;
 waterlogged-chests;12361;waterlogged_chests;Waterlogged Chests;;
@@ -12132,16 +12115,16 @@ fizzle;12370;fizzle;Fizzle;;
 ;12371;foamflower;Foamflower;;
 grimoire-api;12372;grimoire;Grimoire API;;
 cristel-lib;12373;cristellib;Cristel Lib;;
-more-sleeps;12374;;More Sleeps;;
+more-sleeps;12374;more_sleeps;More Sleeps;;
 o-coracao-da-selva;12375;cds;O Coração da Selva;;
-creative-experience;12376;;Creative Experience;;
-more-than-50;12377;;More Than 50;;
+creative-experience;12376;creative_experience;Creative Experience;;
+more-than-50;12377;morethan50;More Than 50;;
 underground-jungle;12378;underground_jungle;Underground Jungle;;
 forge-soul-like-armors-reworked;12379;soul_like_armors_reworked;soul like armors reworked;;
-;12380;meds_and_herbs;Meds and Herbs;;
+meds-and-herbs;12380;meds_and_herbs;Meds and Herbs;;
 soul-like-monsters-epic-fight-addon;12381;soul_like_monsters_epic_fight_addon;soul like monsters: epic fight addon;;
 souls-like-parry;12382;souls_like_parry;Souls-like Parry;;
-;12383;;TCDCommons API;;TCDC
+tcdcommons;12383;tcdcommons;TCDCommons API;;TCDC
 ;12384;pinyined-masa;pinyined-masa;;
 autotranslation;12385;autotranslation;自动翻译;AutoTranslation;
 villages-and-pillages;12386;villagesandpillages;Villages&Pillages;;
@@ -12164,7 +12147,7 @@ darkmobs-increase-mob-difficulty;12402;darkmobs;DarkMobs - Increase Mob Difficul
 ;12403;apollo_the_parrot;Apollo the Parrot;;
 mob-variants;12404;frycmobvariants;Mob Variants;;
 galvanization;12405;galvanization,necromantic_expansion;Galvanization / Necromantic Expansion;;
-biome-grass-available;12406;;Biome Grass Available;;
+biome-grass-available;12406;biome_grass_available;Biome Grass Available;;
 pigment;12407;pigment;Pigment;;
 ;12408;sunrise_sunset_audio;Sunrise & Sunset Audio;;SSA
 halloween-nighmare;12409;halloween_nighmare;Halloween Nightmare;;
@@ -12173,22 +12156,22 @@ halloween-luckyblocks;12411;halloween_luckyblock;Halloween LuckyBlocks;;
 spooky-halloween;12412;spookyhalloween;Spooky Halloween!;;
 isle-of-berk-variant-loader;12413;Isle of Berk Variant Loader;Isle of Berk Variant Loader;;
 spooky-arms;12414;spookyarms;Spooky Arms;;
-;12415;;qrafty's End Villages;;
+;12415;mr_qraftys_endvillages;qrafty's End Villages;;
 bed-is-not-too-far-away;12416;bedisnottoofaraway;Bed Is Not Too Far Away;;
 ;12417;;Enderman Tweaks;;
-;12418;;qrafty's Bamboo Villages;;
+;12418;mr_qraftys_bamboovillages;qrafty's Bamboo Villages;;
 ;12419;;qrafty's Jungle Villages;;
 ;12420;oceanic;Oceanic;;
 decoration-and-furniture;12421;decoration_mod;Decoration and Furniture;;
 ;12422;mr_nyctophobia_dread;Nyctophobia Dread;;
 formations;12423;formations;Formations;;
-formations-overworld;12424;formations_overworld;Formations Overworld;;
-formations-nether;12425;formations_nether;Formations Nether;;
+formations-overworld;12424;formations_overworld,formationsoverworld;Formations Overworld;;
+formations-nether;12425;formations_nether,formationsnether;Formations Nether;;
 halloween-spirit;12426;halloween_spirit;Halloween Spirit;;
 glitches-halloween;12427;glitches_halloween;Glitches Halloween;;
-;12428;rei_collapsible_entries;REI Collapsible Entries QOL;;
+rei-collapsible-entries;12428;rei_collapsible_entries;REI Collapsible Entries QOL;;
 ;12429;mr_brain_overbrawn;Brain Over Brawn;;
-;12430;;Gardener's Dream;;
+;12430;mr_gardeners_dream;Gardener's Dream;;
 kubevs;12431;kubevs;KubeVS;;
 halloween-expansion-food;12433;halloween_xpansion;Halloween Expansion - Food!;;
 fishy-business-more-fish;12434;fishybusiness;Fishy Business;;
@@ -12198,7 +12181,7 @@ crab-mob-vote-2023;12437;crab;CRAB Mob Vote 2023;;
 ;12438;banner_flags,mr_banner_flags;Banner Flags;;
 ;12439;mr_banner_bedsheets;Banner Bedsheets;;
 enderswords;12440;enderswords;Enderswords;;
-;12441;re;随机附魔;;RE
+;12441;re;随机附魔;RandomEnchant;RE
 lemons-halloween;12442;lemons_halloween_1_16_5;Lemon's Halloween;;
 moon-reborn;12443;moon_reborn_mod;Moon Reborn;;
 the-witching-hour;12444;witching_hour;The Witching Hour;;
@@ -12210,7 +12193,7 @@ unifytags;12449;;UnifyTags;;
 ;12450;blissful_butterflies;Blissful Butterflies;;
 mltpojectmonster;12451;mltpojectmonster;銘洛天的怪物增强;MLTPojectMonster;MLTPM
 ;12452;relicsofthesky;空岛遗物;Relics of the Sky;
-;12453;hy;隐藏之年;Hidden Years;HY
+;12453;hy;隐藏之年²;Hidden Years²;HY
 ae2-stuff-extended;12454;ae2stuff;AE2 Stuff: Extended;;
 butchers-delight-foods;12455;butchersdelightfoods;Butcher's Delight Foods;;
 better-falling;12456;better_falling;Better Falling;;
@@ -12227,14 +12210,14 @@ enchantgiver;12466;enchant_giver;EnchantGiver;;
 diabolical-delights;12467;diabolicaldelights;Diabolical Delights;;
 ore-growth;12468;ore_growth;Ore Growth;;
 ;12469;real-arrow-tip;Real Arrow Tip;;
-;12470;;Dungeons and Taverns Ancient City Overhaul;;
+;12470;mr_dungeons_andtavernsancientcityoverhaul;Dungeons and Taverns Ancient City Overhaul;;
 repurposed-structures-better-jungle-temples-compat;12471;;结构变体：YUNG的丛林神庙优化兼容数据包;Repurposed Structures - Better Jungle Temples Compat;
 cropariaplus;12472;cropariaplus;CropariaPlus;;
 soularia;12473;soularia;Soularia;;
 stemaria;12474;stemaria;Stemaria;;
 spelunkers-charm-ii;12475;spelunkers_charm;Lucky's Spelunker's Charm II;;
 structure-essentials-forge-fabric;12476;structureessentials;Structure Essentials;;
-;12477;;Dungeons and Taverns Pillager Outpost Rework;;
+;12477;mr_dungeons_andtavernspillageroutpostrework;Dungeons and Taverns Pillager Outpost Rework;;
 tiny-pals;12478;tiny_pals;Tiny Pals;;
 ;12479;amethystcraft;紫水晶工艺;Amethyst Craft;AC
 weapons-of-miracles-epicfight;12480;wom;Weapons of Miracles;;
@@ -12242,8 +12225,8 @@ weapons-of-miracles-epicfight;12480;wom;Weapons of Miracles;;
 ;12482;hsrpaths;Honkai: Star Rail - Origins;;
 ;12483;rm_portalgun;Rick & Mortys Portal Gun;;
 mcdar;12484;mcdar;我的世界：地下城法器;MC Dungeons Artifacts;MCDAR
-;12485;;Dungeons and Taverns Stronghold Rework;;
-;12486;;Dungeons and Taverns Swamp Hut Rework;;
+;12485;mr_dungeons_andtavernsstrongholdrework;Dungeons and Taverns Stronghold Overhaul;;
+dnt-swamp-hut-overhaul;12486;mr_dungeons_andtavernsswamphutrework;Dungeons and Taverns Swamp Hut Rework;;
 jaopcagt;12487;jaopca;Just A Ore Processing Compatibility Attempt: GregTech;;JAOPCAGT
 smidgeon-o-bliss;12488;sob;Smidgeon O' Bliss;;
 cable-flux;12489;cableflux;CableFlux;;
@@ -12259,15 +12242,15 @@ tf2-stuff-reloaded;12498;rafradek_tf2_weapons;军团要塞2重制版;TF2 Stuff -
 time-in-a-bottle-curio-support;12499;curiotiab;Time in a bottle Curio Support;;
 absolute-ultracraft;12500;ultracraft;Absolute ULTRACRAFT;;
 more-layered-blocks;12501;more_layered_blocks;More Layered Blocks;;
-;12502;hybrid-aquatic;Hybrid Aquatic;;
+hybrid-aquatic;12502;hybrid-aquatic;Hybrid Aquatic;;
 spectre-creep;12503;spectr;Spectre Creep;;
 resource-chickens;12504;resourcechickens;Resource Chickens;;
 ;12505;campfire_resting;休憩营火;Campfire Resting;
-storage-crate;12506;storage_crate;板条箱;Storage Crate;
+storage-crate;12506;storage_crate;板条箱;Storage Crate;SC
 oculus-particle-fix;12507;oculusparticlefix;Oculus Particle Fix;;
 urkaz-moon-tools;12508;urkazmoontools;Urkaz Moon Tools;;
 the-midnight-lurker;12509;midnightlurker;The Midnight Lurker;;
-realm-rpg-imps-demons;12510;realm_rpg_imps_demons;Realm RPG: Imps & Demons;;
+realm-rpg-imps-demons;12510;realm_rpg_imps_demons,realmrpg_demons;Realm RPG: Imps & Demons;;
 multiverse;12511;multiverse;Multiverse;;
 ;12512;imlib;ImGuILib;;imlib
 ;12513;redstonehooker;偷盗工程师;RedstoneHooker;Rh
@@ -12293,7 +12276,7 @@ dungeons-in-dimensions;12533;dungeons_in_dimensions;Dungeons in Dimensions;;
 infernal-bugz;12534;infernal_bugz;Infernal BugZ;;
 ;12535;gts;Cobblemon GTS;;
 cobblepedia;12536;cobblepedia;Cobblepedia;;
-;12537;;Ash-Greninja Datapack/Resourcepack;;
+;12537;;Battle-Bond;;
 ;12538;cobblemonintegrations;Cobblemon Integrations;;
 fruitstack-jei-support;12539;fruitstackjeisupport;果栈丰萦JEI支持;Fruitstack Jei Support;FJS
 dungeons-artifacts;12540;dungeonsartifacts;Dungeons & Artifacts;;
@@ -12304,25 +12287,25 @@ beavery;12544;beavery;Beavery;;
 ;12545;qraftys_halloween_villages;qrafty's Halloween Villages;;
 vemerioraptor;12546;vemerioraptor;Vemerioraptor;;
 technique-to-kill-thrasher;12547;technique_to_kill_thrasher;毙鲨技;technique to kill thrasher;
-;12548;toastkiller;The Open Sauce Toast Killer;;
+the-open-sauce-toast-killer;12548;toastkiller;The Open Sauce Toast Killer;;
 ;12549;chicken_nerf;Chicken Nerf Reforged;;
 regex-search;12550;re_search;Regex Search;;
 better-wake-up-position;12551;better_wake_up_position;更好的起床位置;Better Wake-up Position;BWP
 railroad-blocks-forge;12552;railroadblocksaddon;Railroad Blocks;;
 copper-4-beacon;12553;;Copper 4 Beacon;;
-;12554;fossilmon;Fossilmon;;
-opack2reload;12555;opack2reload;资源包惰性重载/抑验怠载;OPack2Reload;OP2R
-;12556;;WITS;;
+fossilmon;12554;fossilmon;Fossilmon;;
+opack2reload;12555;opack2reload;资源包惰性重载/抑验怠载;0Pack2Reload;0P2R
+wits;12556;wits;WITS;;
 ;12557;motleysmusicdiscs;Motley's Music Discs;;
-;12558;;Various Starting Loot;;
-husks-drop-sand;12559;huskssand;Husks drop sand;;
+;12558;mr_various_startingloot;Various Starting Loot;;
+husks-drop-sand;12559;huskssand;Husks Drop Sand;;
 patched;12560;patched;Patched;;
 ;12561;snakewheel_attack;Snakewheel Attack!;;
 ;12562;;All mobs from the voting [Minecraft LIVE: 2023];;
 ;12563;gt6scan;GT6 Scanner;;
-;12564;;Configurable Falls;;
+configurable-falls;12564;configurable_falls;Configurable Falls;;
 just-enough-mekanism-multiblocks;12565;jei_mekanism_multiblocks;Just Enough Mekanism Multiblocks;;
-throwableslimeball;12566;throwable_slimeball;圆液多掷;ThrowableSlimeball;
+throwableslimeball;12566;throwable_slimeball;可投掷黏液球/圆液多掷;ThrowableSlimeball;
 death-note;12567;deathnote;死亡笔记;Death Note;DN
 ;12568;;Frost Wolf Boss Battle [WINNER of Datapack Jam 6];;
 icicle;12569;icicle;Icicle;;
@@ -12330,7 +12313,7 @@ icicle;12569;icicle;Icicle;;
 minecraft-shadowlands-battle-music-datapack;12571;;♪ Shadowlands Battle Music ♪ {Datapack};;
 ;12572;;Shadow Lands | Boss Battle;;
 surface-mushrooms;12573;surfacemushrooms;Surface Mushrooms;;
-dont-void-arrows;12574;;Don't void Arrows;;
+dont-void-arrows;12574;dont_void_arrows;Don't void Arrows;;
 potion-cauldron;12575;potioncauldron;Potion Cauldron;;
 hippo-keystrokes;12576;keystrokeshippo;Hippo Keystrokes;;
 spiritcaller-backport;12577;spiritcaller_backport;Spiritcaller Backport;;
@@ -12353,18 +12336,18 @@ bow-spam-be-gone;12593;bowspambegone;Bow Spam Be-Gone;;
 lmdcraft;12594;lmdmod;LMDCraft;;
 hardcore-survival;12595;hcs;硬核生存;Hardcore Survival;HCS
 ;12596;shanhaicontinent;山海大陆;Mountain Sea and Continent;
-;12597;;Better Deepslate Ore Drops;;
+;12597;mr_better_deepslateoredrops;Better Deepslate Ore Drops;;
 dynamic-village;12598;dynamic_village,dynamicvillage;Create: Dynamic Village;;
 ;12599;;Even Better Archeology;;
 ;12600;;New in Town: Dimensions Expansion Data Pack;;
 jammies;12601;jammies;Jammies;;
-dj-villager;12602;;DJ Villager;;
+dj-villager;12602;djvillager;DJ Villager;;
 ars-energistique;12603;arseng;Ars Énergistique;;
-chatimages;12604;chatimage;聊天图片;ChatImage;ci
+chatimages;12604;chatimage;聊天图片;ChatImages;ci
 create-more-drill-heads;12605;createmoredrillheads;机械动力：更多钻头;Create: More Drill Heads;
 create-liquid-fuel;12606;createliquidfuel;机械动力：液体燃料;Create: Liquid Fuel;
 ;12607;coolarmor;Ray's Cool Armor;;
-eeeabs-mobs;12608;eeeabsmobs;EEEAB's Mobs;;
+eeeabs-mobs;12608;eeeabsmobs;EEEAB's Mobs;;EMobs
 ;12609;obfuscatedaccessibility;Obfuscated Accessibility;;
 regional-chat;12610;Regional Chat;Regional Chat;;
 zenith-attributes;12611;zenith_attributes;Zenith Attributes;;
@@ -12379,14 +12362,14 @@ omniwand;12620;omniwand;全能魔杖;Omniwand;
 ;12621;really_forge;真的锻造！;Really Forge!;RFG
 ;12622;;破晓2;Dawn 2;
 ;12623;upgradedbread;面包增强;Upgraded Bread;UpB
-key-binding-patch;12624;key_binding_patch;按键绑定补丁;;kbp
+key-binding-patch;12624;key_binding_patch;按键绑定补丁;Key Binding Patch;KBP
 packet-fixer;12625;packetfixer;Packet Fixer;;
 new-xenchant;12626;xenchant;New XEnchant;;
 more-brewable-potions;12627;morepotions;More Brewable Potions;;
 ;12628;tlauncher_custom_cape_skin,tlskincape;TL Skin and Cape;;
 forge-cit;12629;citresewn;Forge CIT;;
 ;12630;diamethyst_golem;Diamethyst Golem;;
-you-are-seeing-dungeons;12631;youre_seeing_dungeons;You Are Seeing Dungeons🏰;;
+you-are-seeing-dungeons;12631;youre_seeing_dungeons;You Are Seeing Dungeons🏰;;YASD
 ;12632;mobsenhancement;怪物增强附属;Mobs Enhancement Addon;MEA
 just-leveling;12633;justleveling;Just Leveling;;
 create-edible-belts;12634;;Create: Edible Belts;;
@@ -12399,12 +12382,12 @@ laendli-transport;12640;laendli_transport;Laendli Transport;;
 witchs-artifacts;12641;witchs_with_a_use;Witch's Artifacts;;
 the-pumpkin-challenge;12642;the_pumpkin_challenge;The Pumpkin Challenge;;
 loot-crates-plus;12643;lootboxesplus;Loot Crates Plus!;;
-;12644;Untranslator;语言全球化;Untranslator;
-;12645;sakurawald;藤;Fuji;
+;12644;Untranslator;未转译者;Untranslator;
+fuji;12645;sakurawald;藤;Fuji;
 legendary-origins;12646;legendary_origins;Legendary Origins;;
 flow;12647;flow;Flow;;
 lit-it-up;12648;lititup;Lit It Up;;
-;12649;;Lucky Cat;;
+lucky-cat;12649;lucky_cat;招财猫;Lucky Cat;
 all-the-wizard-gear;12650;all_the_wizard_gear;All the Wizard Gear;;
 better-tools-and-armor;12651;better_tools;Better Tools and Armor;;BT+A
 berrfect;12652;berrfect;完莓无缺;Berrfect;
@@ -12412,10 +12395,10 @@ mazemanicore;12653;mazemanicore;MazeManicore;;
 uncanney-valley;12654;uncanneyvalley;Uncanney Valley;;
 ;12655;cannibal;Cannibal Conundrum;;
 ;12656;glasscarpet;Glass Carpet;;
-;12657;;Quality Sounds;;
+;12657;qualitysounds;Quality Sounds;;
 dolt-compat;12658;dolt_compat;Dolt Compat;;
 embeddium-extension;12659;embeddiumextension;Embeddium Extension;;
-;12660;wakes;Wakes;;
+wakes;12660;wakes;Wakes;;
 create-immersive-portal-integration;12661;trainportals;Create - Immersive Portal Integration;;
 dangers-in-the-darkness;12662;fear_the_dark;Dangers in the Darkness;;
 spookycraft;12663;spookycraft;SpookyCraft;;
@@ -12423,7 +12406,7 @@ kelpie;12664;kelpie;Kelpie;;
 ;12665;viavanillaplus;ViaVanillaPlus;;
 dead-mans-abyss;12666;bansheenight;Dead Man's Abyss;;DMA
 the-leagues-of-the-dead;12667;the_leagues_of_the_dead;The Leagues of the Dead;;
-;12668;centered-crosshair;Centered Crosshair;;
+centered-crosshair;12668;centered-crosshair;Centered Crosshair;;
 ;12669;;Create Fabric Sodium Fix;;
 realm-rpg-creep-crop;12670;realmrpg_creep;Realm RPG: Creep & Crop;;
 fexcraft-common-library;12671;fcl,tmt,frl;Fexcraft Common Library;;FCL
@@ -12440,15 +12423,15 @@ johnnys-biological-notes;12680;johnnys_biological_notes;Johnny的生物笔记;Jo
 mutation-rerun;12682;mutation_rerun;Mutation-RERUN;;
 ;12683;telekinesis;Telekinesis;;
 ;12684;compactspawners;CompactSpawners;;
-;12685;;整块冶炼;Whole'block'smelting;Wbs
+;12685;whole_block_smelting;整块冶炼;Whole'block'smelting;Wbs
 corundum-guardian-reborn;12686;corundum_guardian;Corundum Guardian Reborn;;
-autofire-bow-enchant;12687;autofire_bow_enchant;AutoFire Bow Enchant;;
+autofire-bow-enchant;12687;autofire_bow_enchant;Instinctive Release;;
 ;12688;;Vertical Rails with Ladders!;;
 ;12689;the_project_for_the_prevention_of_cruelty_to_animals;动物保护计划;the Project for the Prevention of Cruelty to Animals;PPCA
 rideableravagers;12690;rideableravagers;Rideable Ravagers;;
 passive-searchbar;12691;passivesearchbar;被动搜索栏;Passive SearchBar;
 flower-mimics;12692;;Flower Mimics;;
-vegan-delight;12693;vegandelight;Vegan Delight;;
+vegan-delight;12693;vegandelight;纯素乐事;Vegan Delight;
 bloodmooncmsfix-bmcmsfix;12694;;BloodmoonCMSFix;;BMCMSFix
 evoodooers;12695;Evoodooers;Evoodooers;;
 giant-overhaul;12696;giantoverhaul;Giant Overhaul;;
@@ -12459,7 +12442,7 @@ fabled-weaponry;12700;fabled_weaponry;Fabled Weaponry;;
 lazurite;12701;lazurite;Lazurite;;
 lets-do-nethervinery;12702;nethervinery;Let's Do: NetherVinery;;
 shinnyladders;12703;shinnyladders;发光梯子/洇荧登纵;Shinny Ladders;
-macaws-holidays;12704;macaws_holidays;Macaw's Holidays;;
+macaws-holidays;12704;macaws_holidays,mcwholidays;Macaw's Holidays;;
 unions-upgrade-scrolls;12705;unions_upgrade_scrolls;Union's Upgrade Scrolls;;
 torohealth-unofficial;12706;torohealth;ToroHealth Unofficial;;
 rebindallthekeys;12707;rebind_all_the_keys;RebindAllTheKeys;;
@@ -12467,7 +12450,7 @@ pocketwatch2;12708;pocketwatch;Pocketwatch;;
 pick-blockstate;12709;pickblockstate;Pick BlockState;;
 ;12710;epimorphism;满同态核心;Epimorphism Core;EPCore
 oh-my-sherd;12711;ohmysherd;Oh My Sherd;;
-archaeology-banners;12712;archaeology_banners;Archaeology Banners;;
+archaeology-banners;12712;archaeology_banners,archaeologybanners;Archaeology Banners;;
 mobvote-2023-crab;12713;crab;Mobvote 2023 - Crab;;
 totem-curse;12714;totem_curse;Totem Curse;;
 ;12715;playtimeremake;游戏时长计数器重置版;Playtime Counter Remake;PCR
@@ -12489,7 +12472,7 @@ modular-item-api;12730;miapi,arsenal,archery,armory;Truly Modular;;
 ;12732;action_hunger;ActionHunger;;
 trafficcraft;12733;trafficcraft;TrafficCraft;;
 banilla-hammers;12734;banilla_hammers;Banilla Hammers;;
-;12735;everyxhotpot;一起火锅;EveryXHotpot;
+everyx-hotpot;12735;everyxhotpot;一起火锅;EveryXHotpot;
 ;12736;hira_hira;Hira Hira;;
 tierability;12737;tierability;Tierability;;
 soul-collector;12738;soulcoll;Soul Collector;;
@@ -12503,12 +12486,12 @@ echo;12743;echo;Echo+;;
 lanthanum;12746;lanthanum;镧;Lanthanum;
 charge-thrower;12747;chargethrower;Charge Thrower;;
 ;12748;mr_2032_worldheight;2032 World Height;;
-;12749;;闪魂：王者遗灰;Lightning Souls: Champion's Ashes;
+;12749;;王者遗灰;Champion's Ashes;
 ;12750;mixinextras,com_github_llamalad7_mixinextras;MixinExtras;;
 jade-addons-ic2classic;12751;jadexic2c;Jade Addons - IC2Classic;;
 sit1;12752;sit;Sit!;;
 monnef-core;12753;;Monnef Core;;
-robs-floating-islands;12754;;Rob's Floating Islands;;
+robs-floating-islands;12754;robs_floating_islands;Rob's Floating Islands;;
 ;12755;wheatfieldwitlwolf;麦香狼田;Wheatfrild With Wolf;W3
 glasses;12756;glasses;眼镜;Glasses;
 ;12757;simeplesign;简单标记;SimpleSign;SSi
@@ -12519,7 +12502,7 @@ archers;12760;archers;Archers (RPG Series);;
 inventorylogger-backups;12762;inv_logger;InventoryLogger;;
 rideablepolarbears;12763;rideablepolarbears;RideablePolarBears;;
 cobblemon-lucky-blocks;12764;cobblelucky;CobbleLucky;;
-egg-delight;12765;eggdelight;Egg Delight;;
+egg-delight;12765;eggdelight;鸡蛋乐事;Egg Delight;
 portable-nether;12766;portablenether;Portable Nether;;
 ;12767;resourcefulblocksounds;Resourceful Block Sounds;;
 ;12768;apprentice;学徒的热诚;Apprentice's Zeal;Asz
@@ -12540,7 +12523,7 @@ from-another-world;12782;fromanotherworld;From Another World;;
 pumpkin-moon;12783;pumpkinmoon;Pumpkin Moon;;
 zombie-onslaught;12784;zombie_onslaught;Zombie Onslaught;;
 neighborly;12785;neighborly;Neighborly;;
-natural-progressions;12786;natprog;Natural Progression;;
+natural-progressions;12786;natprog,natural-progression;Natural Progression;;
 charged-explosives;12787;charged_explosives;Charged Explosives;;
 pulver;12788;pulver;Pulver;;
 ;12789;allow-editing-player-data;Allow Editing Player Data;;
@@ -12552,20 +12535,20 @@ ciscos-armoury;12794;cisco_mod;Cisco's Armoury;;
 portable-mobs;12795;portablemobs;Portable Mobs;;
 deserts-and-dunes;12796;deserts_and_dunes;Deserts and Dunes;;
 ;12797;minecraftfunctioncompiler;Function Compiler;;
-box-of-horrors;12798;boh;The Box of Horrors;;
+box-of-horrors;12798;boh;The Box of Horrors;;BOH
 chat-colours;12799;chatcolours;Chat Colors;;
 mekanism-weapons;12800;mekaweapons;通用机械武器;Mekanism: Weapons;
 vanilla-reflex;12801;vare;Generation Reflex;;
 flighthud-reborn;12802;flighthud;鞘翅飞行抬头显示：重生;FlightHUD: Reborn;
-;12803;celestial_enchantments;星月附魔;Celestial Enchantments;CE
+celestial-enchantments;12803;celestial_enchantments;星月附魔;Celestial Enchantments;
 clearsky;12804;clearsky;洁净天空;ClearSky;
-educate-nitwit;12805;;Educate Nitwit;;
+educate-nitwit;12805;educatenitwit;Educate Nitwit;;
 damage-spawns-mobs;12806;;Damage Spawns Mobs;;
 decorative-sniffer-egg;12807;decorative_sniffer_egg;Decorative Sniffer Egg;;
 gilded-sherds;12808;gilded_sherds;Gilded Sherds;;
 camps-castles-carriages;12809;camps_castles_carriages;Camps. Castles. Carriages.;;
 rainbow-reef;12810;rainbow_reef;Rainbow Reef;;
-;12811;nomoreadvancement;Advancement... No More !!!;;
+advancement-no-more;12811;nomoreadvancement;Advancement... No More !!!;;
 aqua-geode;12812;aqua_structure;Aqua Geode;;
 ;12813;jl;Jar Loader;;JL
 medieval-buildings;12814;medieval_buildings;Medieval Buildings;;
@@ -12574,25 +12557,25 @@ medieval-buildings;12814;medieval_buildings;Medieval Buildings;;
 ;12817;;You Thief: Remastered Edition;;
 ;12818;hero_proof;Hero Proof;;
 more-slabs-stairs-and-walls;12819;more_slabs_stairs_and_walls;More Slabs Stairs & Walls;;
-;12820;caves_&_canyons;Caves & Canyons;;
+caves-canyons;12820;caves_&_canyons;Caves & Canyons;;
 dragon-mounts-legacy-continued;12821;dragonmounts;龙骑士重制版延续;Dragon Mounts Legacy Continued;
-embeddium-plus;12822;embeddiumplus;Embeddium++;;
+embeddiumplus;12822;embeddiumplus;Embeddium++;;
 aggro-indicator;12823;aggroindicator;Aggro Indicator;;
-haveasoltime;12824;haveasoltime;Have A Sol Time;;
-tothestars;12825;tothestars;To The Stars;;
+haveasoltime;12824;haveasoltime;HaveASolTime;;
+tothestars;12825;tothestars;ToTheStars;;
 translater;12826;translater;Translater;;
 localized-chat;12827;localizedchat;Localized Chat;;
-prominent-create;12828;create;Prominent Create;;
+prominent-create;12828;;Prominent Create;;
 bad-lightning-no-cookie;12829;badlightningnocookie;Bad Lightning No Cookie;;
 equipment-standard;12830;equipment_standard;装备标准;EquipmentStandard;ES
-snowly;12831;snowly;Snowly;;
+terra-armory;12831;snowly,terra_armory;Terra Armory;;
 advanced-enchantments;12832;advanced_enchantments;进阶附魔;Advanced Enchantments;AE
 oaks-nature;12833;oaks_nature;Oaks Nature;;
-geophilic-reforged;12834;;Geophilic Reforged – Biome Additions;;
+geophilic-reforged;12834;geophilic_reforged;Geophilic Reforged – Biome Additions;;
 lglegacy;12835;laggoggles;延迟监视：移植版;LagGogglesLegacy;
-;12836;smoothscrollingrefurbished;Smooth Scrolling Refurbished;;
+smooth-scrolling-refurbished;12836;smoothscrollingrefurbished;Smooth Scrolling Refurbished;;
 medieval-weapons-pack;12837;medievalvrpack;Medieval Weapons Pack;;
-;12838;celestial_artifacts;星月遗物;Celestial Artifacts;CA
+celestial-artifacts;12838;celestial_artifacts;星月遗物;Celestial Artifacts;
 ;12839;;史诗战斗：一染订正;efrenderfix;ERF
 perfect-mob-farm;12840;perfectmobfarm;Perfect Mob Farm;;
 smart-render;12841;smartrender;Smart Render;;
@@ -12617,11 +12600,10 @@ forgiving-border;12859;forgivingborder;仁慈的世界边界;ForgivingBorder;
 snow-mercy;12860;snowmercy;Snow Mercy ⛄;;
 ;12861;show_key;按键显示;show key;SK
 ;12862;blocky-bubbles;Blocky Bubbles;;
-airdrop-supply;12863;airdrop-supply;空投供应;Airdrop Supply;
+airdrop-supply;12863;airdrop-supply;空投供应;Airdrop Supply;AS
 refined-proxy;12864;refinedproxy;Refined Proxy;;
-;12865;;Better Lush Caves;;
+;12865;mr_better_lushcaves;Better Lush Caves;;
 pickable-pets;12866;pickablepets;Pickable Pets;;
-snow-mercy-forge;12867;snowmercy;Snow Mercy [Forge] ⛄;;
 ;12868;Protocol4;Protocol4;;
 ;12869;connect_to_1_12_x;Connect to 1.12.X;;
 bouncestyles;12870;;BounceStyles;;
@@ -12650,16 +12632,16 @@ weather-2-remastered;12892;weather2remaster;局部气候&风暴 - 重置版;Weat
 ;12893;mwfexplosionfix;模块化武装爆炸修复;ModularWarfarePacketExplosionFix;
 phantoms-of-the-end;12894;;Phantoms of The End;;
 diamond-and-emerald-farming-mod;12895;diamond_and_emerald_farming_mod;Diamond and emerald farming;;
-blood-and-gore;12896;;Blood and Gore;;
+blood-and-gore;12896;blood_and_gore;Blood and Gore;;
 nonetherportal;12897;nonetherportal;No Nether Portal;;
 necronomicon;12898;necronomicon;Necronomicon API;;
-;12899;showcaseitem;Showcase Item;;
+showcase-item;12899;showcaseitem;Showcase Item;;
 eldritch-end;12900;eldritch_end;Eldritch End;;
 ;12901;nitrogen_cycling;Nitrogen cycling;;
 quit-or-not;12902;quitornot;Quit or Not;;
-spelled-mobs;12903;;Spelled Mobs;;
+spelled-mobs;12903;spelling_mobs;Spelled Mobs;;
 let-fish-love;12904;let_fish_love;Let Fish Love;;
-exposure;12905;exposure;Exposure;;
+exposure;12905;exposure;底片;Exposure;
 ;12906;fast-portals,fastportalsforge;Fast Portals;;
 pick-up-me-please;12907;pickupme;Pick Up Me;;
 bouncy-creepers;12908;;Bouncy Creepers;;
@@ -12685,12 +12667,12 @@ asmc-performance-patch;12927;asmc;ASMC Performance Patch;;
 mrcrayfishs-gun-mod-unofficial;12928;cgm;MrCrayfish的枪：非官方版;MrCrayfish's Gun Mod: Unofficial;CGMu
 ;12929;fishtanks;Fish Tanks;;
 ram-compat;12930;ram_compat;Relics: Alex's Mobs Compat;;
-;12931;school;万言兔的学校模组;Wanyantu's School Mod;
+;12931;school,schoolnext;中国式学校;Chinese School Mod;
 zombies-reworked-forge;12932;zombies_reworked;Zombies Reworked;;
 legendary-monsters;12933;legendary_monsters;Legendary Monsters;;
 catontoasts-mobs;12934;catontoasts_mobs;CatOnToast's Mobs;;
 combatify;12935;combatify;Combatify;;
-go-fish-updated;12936;;一起钓鱼吧！(updated);Go Fish (updated);
+go-fish-updated;12936;;一起钓鱼吧！(更新版);Go Fish (updated);
 ;12937;ki;杀戮光环;Killaura;KA
 what-are-they-up-to;12938;watut;What Are They Up To;;Watut
 ;12939;fumo;Fumo;;
@@ -12698,7 +12680,7 @@ what-are-they-up-to;12938;watut;What Are They Up To;;Watut
 mcaic;12941;mcaic;MCAIC;;
 ;12942;zombification;Zombification;;
 ;12943;stutterfix;StutterFix;;
-extrasounds-forge;12944;extrasounds;ExtraSounds Forge;;
+extrasounds-forge;12944;extrasounds;ExtraSounds Next;;
 resource-mod-loader;12945;rml;资源模载器;Resource Mod Loader;RML
 regrown;12946;mr_regrown;Regrown;;
 carcass;12947;carcass;Carcass;;
@@ -12709,13 +12691,13 @@ grassnotfloating;12951;grassnotfloating;浮的古原草送别;GrassNotFloating;
 ;12952;reclamation;填海/压液丢泽;Reclamation;
 ;12953;mr_subsurface;Subsurface;;
 ;12954;xmmod;小萌的皇冠;XMCROWN;XMC
-;12955;therm;Thermite;;
+thermite;12955;therm;Thermite;;
 restriction;12956;restriction;Restriction;;
 ;12957;collisionfix;Collision Fix;;
 ;12958;backrooms;pertaz的后室生成;pertaz'es Backrooms Generator;pBrG
 dynamic-name-tags;12959;dynamicnametags;Dynamic Name Tags;;
 ;12960;profundis;Profundis: Seven New Quality Cave Biomes;;
-ctlib;12961;ctlibfabric;ctLib;;CL
+ctlib;12961;ctlib;ctLib;;CL
 ;12962;lib_for_derumin;derumin的库;lib for derumin;LFD
 building-packs;12963;buildingpacks;Building Packs;;
 styled-sidebars;12964;styled-sidebars;Styled Sidebars;;
@@ -12737,7 +12719,7 @@ corniergun;12979;corniergunmod;CornierGun;;
 better-flight-forge;12980;betterflight;Better Flight;;
 ;12981;;Run It Anyway;;
 farmers-delight-cookbook-reforged;12982;fdcookbook;农夫乐事：烹饪书重制版;Farmer's Delight: CookBook Reforged;
-momentariycore;12983;momentariycore2;MomentariyModder'Applications;;
+applications;12983;momentariycore2;MomentariyModder'Applications;;
 k-clear-lag;12984;clearlag;Clear Lag;;
 ;12985;hexxy-dimensions;咒法维度;Hexxy Dimensions;
 simple-backups;12986;simplebackups;简单备份;Simple Backups;
@@ -12756,11 +12738,11 @@ traders-in-disguise-the-illager-assassin-project;12998;tradersindisguise;Traders
 cherished-items;12999;cherisheditems;Cherished Items;;
 verdantvibes;13000;verdantvibes;绿意盎然;VerdantVibes;
 crafting-manipulator;13001;craftingmanipulator;Crafting Manipulator;;
-beware-the-rain;13002;bwrtherain;Beware The Rain;;
+beware-the-rain;13002;bwrtherain;Beware The Rain;;BTR
 the-sasquatch;13003;the_sasquatch;The Sasquatch;;
 potion-pizzas;13004;potionpizzas;药水披萨;Potion Pizzas;
 pot-breaker;13005;potbreaker;砸罐子;Pot Breaker;PBK
-disable-vanilla-tool;13006;disable_vanilla_tool;禁用原版工具;Disable Vanilla Tool;DVT
+disabletools;13006;disable_vanilla_tool;禁用工具;Disable Tools;
 ;13007;humility-se;Humility SE;;
 ;13008;epicdragonfight;史诗战斗：萤眼订正;EpicFight DragonEye Fix;EDF
 push-everything-away;13009;push_everything_away;推开一切;Push Everything Away;
@@ -12774,7 +12756,7 @@ hammers-and-smithing;13016;hammersandtables;Hammers and Smithing;;
 ;13017;aaaahidechat4s_fix;直播隐藏聊天框修复补丁;HideChatForStreamingFix Patcher;
 tetra-booster-pack;13018;witheringboon;Withering Boon For Tetra;;
 everlasting-skins;13019;everlastingskins;Everlasting Skins;;
-;13020;decorated_pot_minecart;饰纹陶罐矿车;Decorated Pot Minecart;
+decorated-pot-minecart;13020;decorated_pot_minecart;饰纹陶罐矿车;Decorated Pot Minecart;
 legacy-console-sounds;13021;consolesounds;Legacy Console Sounds;;
 eye-spy;13022;eyespy;Eye Spy;;
 sonicraft-demons;13023;sonicraft_demons;SoniCraft Demons;;
@@ -12793,14 +12775,14 @@ ore-discovery-broadcast;13035;orediscoverybroadcast;Ore Discovery Broadcast;;
 alchemists-garden;13036;alchemists_garden;Alchemist's Garden: Regrowth;;
 opolis-strainers;13037;strainers;BBL Strainers;;
 book-eater;13038;book_eater;Book Eater;;
-rotom-phone;13039;rotom_phone;Rotom Phone;;
+rotom-phone-cobblemon;13039;rotom_phone;Rotom Phone Cobblemon;;
 ;13040;worldcomment;随处随笔;World Comment;
 ultramarine-refabricated;13041;ultramarine;群青：重织;Ultramarine Refabricated;
 long-nbt-killer;13042;longnbtkiller;Long NBT Killer;;
 ;13043;curioattribute;饰品属性;CurioAttribute;
 consistent-aim;13044;consistentaim;持久瞄准/移眼盯住;Consistent Aim;
-;13045;wats;无迹蜘谈;Where the Spiders, Get out!;WATS
-;13046;arrow_pointers;Arrow pointers;;
+;13045;wats;无迹蜘谈/蛛灭;Where the Spiders, Get out!;WATS
+arrow-pointers;13046;arrow_pointers;Arrow pointers;;
 bareback-horse-riding;13047;barebackhorseriding;Bareback Horse Riding;;
 what-the-gecko;13048;what_the_gecko;WHAT THE GECK'O!?;;
 forgotten-pots-forge;13049;forgottenpots;Forgotten Pots;;
@@ -12826,13 +12808,12 @@ geotagged-screenshots;13066;geotagged_screenshots;Geotagged Screenshots;;
 ;13069;optifabric;Legacy OptiFabric;;
 oneironaut;13070;oneironaut;Oneironaut;;
 ;13071;pt;ETools;;ET
-;13072;celestial_core;星月核心;celestial_core;CeC
-;13073;celestial_custom1;诅咒饰品;celestial_custom1;CC1
+celestial-core;13072;celestial_core;星月核心;Celestial Core;
+;13073;celestial_custom1;诅咒饰品;Curse Jewelry;
 colorablefox;13074;colorablefox;可染色狐狸/色绘你狐革;Colorable Fox;
-archaeology-api;13075;archaeology_api;Archaeology API;;
 rpg-parties;13076;mmoparties;RPG Parties;;
-astikor-carts-tfc;13077;astikorcarts;Astikor Carts TFC;;
-nanexs-mobs;13078;nanexmobs;Nanex s Mobs;;
+astikor-carts-tfc;13077;tfcastikorcarts;Astikor Carts TFC;;
+nanexs-mobs;13078;nanexmobs;Nanex's Mobs;;
 no-feather-trample;13079;nofeathertrample;No Feather Trample;;
 embers-extended-life;13080;embers;余烬非官方延续版;Embers Unofficial Extended Life;
 terrafirmajousting;13081;tfjousting;TerraFirmaJousting;;
@@ -12853,7 +12834,7 @@ thorium-reactors;13095;thoriumreactors;Thorium Reactors;;
 eugenes-guan-dao;13096;eugenes_guan_dao;Eugene's Guan Dao;;
 ;13097;chainimprove;锁链强化;ChainImprove;CI
 eugenes-wealthy-plains-village;13098;mr_eugenes_wealthyplainsvillage;Eugene's Wealthy Plains Village;;
-lets-do-herbal-brews;13099;lets_do_herbal_brews;煨茶酝露;HerbalBrews;
+lets-do-herbal-brews;13099;lets_do_herbal_brews,herbalbrews;煨茶酝露;HerbalBrews;
 enchant-icon;13100;enchant_icon;附魔标签;Enchant Icon;
 vintage-delight;13101;vintagedelight;腌渍乐事;Vintage Delight;
 ;13102;hotshot;HotShot;;
@@ -12875,30 +12856,30 @@ create-curio-goggles;13117;creategogglescurio;Create Curio Goggles;;
 ;13118;lootballs;Cobblemon - Loot Balls;;
 dontusecommand;13119;dontusecommand;请别用指令;DontUseCommand;DUC
 beans-backpacks;13120;beans_backpacks;Beans Backpacks;;
-;13121;projectreflection;反射计划;Project Reflection;PR
+;13121;projectreflection;反射计划实验室;PRLabs/Project Reflection;PRLabs
 randomjs;13122;randomjs;RandomJS;;
 ;13123;pistonpushmod;Piston Push;;
 erinium-automation;13124;erinium_automation;Erinium Automation;;
-;13125;angelica;Angelica;;
+angelica;13125;angelica;Angelica;;
 explosiont;13126;explosiont;Explosion't;;
 spider-caves;13127;spider_caves;Spider Caves;;
 cams-lights;13128;cams_lights;Cam's Better Lights;;
 ;13129;cirno_fumo;Cirno Fumo Boss;;
 lemon-kindom-artifacts;13130;lemon_kindom_artifacts;柠檬王国：传说之物;Lemon Kindom: Artifacts;
 when-dungeons-arise-seven-seas;13131;dungeons_arise_seven_seas;地牢浮现之时 - 海洋扩展;When Dungeons Arise - Seven Seas;
-mob-battle-extra;13132;mob_battle_extra;Mob Battle Extra;;
+mob-battle-extra;13132;mob_battle_extra;Mob Battle Extra / MBE Utility Tools;;
 lios-overhauled-villages;13133;lios_overhauled_villages;Lios Overhauled Villages;;
-lost-relics;13134;lost_relics;Lost Relics;;
+lost-relics;13134;lost_relics,lostrelics;Lost Relics;;
 provihealth;13135;provihealth;Provi's Health Bars;;
 metabolism;13136;metabolism;新陈代谢;Metabolism;
 adv-js;13137;advjs;Advancement JS;;AdvJS
 teleportcraft;13138;teleportcraft;TeleportCraft;;
-frights-delight;13139;frightsdelight;Fright's Delight;;
+frights-delight;13139;frightsdelight;惊悚乐事;Fright's Delight;FrD
 travelers-compass;13140;travelerscompass;Traveler's Compass;;
 ;13141;artemis_thin_logs;Artemis' Thin Logs;;
 configjs;13142;configjs;ConfigJS;;
-hardrock-tools-materials;13143;hardrock_tools_materials;HardRock Tools & Materials;;
-animals-trap;13144;animals_trap;Animals Trap;;
+hardrock-tools-materials;13143;hardrock_tools_materials,htm;HardRock Tools & Materials;;
+animals-trap;13144;animals_trap,animaltrap;Animals Trap;;
 armor-damage-scaling-forge-fabric;13145;armordamagescale;Armor & damage scaling;;
 hornet;13146;hornets;Hornets;;
 exotelcraft;13147;exotelcraft;Exotelcraft;;
@@ -12906,15 +12887,15 @@ jujutsu-kaisen-gt;13148;jujutsu_craft_gt;Jujutsu Kaisen GT;;
 ;13149;updatedhud;UpdatedHud;;
 mapwriter;13150;MapWriter;MapWriter Mini Map;;
 ;13151;realdamage;真实伤害;RealDamage;
-;13152;celestial_forge;星月再锻;Celestial Forge;CF
-;13153;toolleveling,toollevelingrework;异延锻造;ToolLeveling: Rework / ToolLeveling: Legacy;TLL
+;13152;celestial_forge;星月再锻（旧版）;Celestial Forge;
+;13153;toolleveling,toollevelingrework;异延锻造;ToolLeveling: Rework / ToolLeveling: Legacy;TLR/TLL
 clickmanaita;13154;clickmanaita;ClickManaita;;
-;13155;dayshower;日期显示;dayshower;
+;13155;dayshower;日期显示;Dayshower;
 ;13156;gateofbabylon;王之财宝：无限版;Gate of Babylon：Infinity Editon;
 command-toast;13157;command_toast;指令面包机;Command Toast;
 ;13158;hexresearch;咒法研究;Hex Research;
 cwg-far-plane-view;13159;cwgfarplaneview;CWG Far Plane View;;
-firmacivilization;13160;firmaciv;Firma: Civilization;;
+firmacivilization;13160;firmaciv;群峦传说：航海文明;Firma: Civilization;
 catbop-things;13161;catbopthings;Catbop Things;;
 player-mobs;13162;player_mobs;Player Mobs;;
 ;13163;create-trimmed;Create: Trimmed;;
@@ -12948,14 +12929,13 @@ ash-api;13191;ash_api;Ash API;;
 ;13192;tutescnsitems;Tutes塔兹的物品;Tutes-cn's Items;TsI
 stylecolonies;13193;stylecolonies;Stylecolonies;;
 hyperbox;13194;hyperbox;Hyperbox;;
-respite-creators-fabric;13195;;Respite Creators;;
+respite-creators-fabric;13195;respitecreators;Respite Creators;;
 simple-pizzas;13196;pizzas;简单比萨;Simple Pizzas;
 rapscallions-and-rockhoppers;13197;rapscallions_and_rockhoppers;Rapscallions and Rockhoppers (Penguins);;
 pescatore;13198;pescatore;Pescatore;;
 apocalypse-now;13199;apocalypsenow;Apocalypse Now;;
 cenozoic-nightmare-the-horror-of-prehistory;13200;cenozoicnightmare;Cenozoic Nightmare - The Horror of Ancient Prehistory;;
-;13201;more_enchanting;剑附魔拓展;;
-;13202;quickbackupmulti;多槽位备份;QuickBackupMulti-Fabric;QBM-Fabric
+quickbackupmulti;13202;quickbackupmulti;多槽位备份;QuickBackupMulti-Fabric;QBM-Fabric
 slashblade-japanese-addon-pack-reforked;13203;ex_blades;拔刀剑日系附属重置版;SlashBlade Japanese Addon Pack Reforked;SJAPRE
 ;13204;createfabricfixes;Create Fabric Fixes;;
 ;13205;commandsceptre;命令方块权杖;Command Sceptre;CmdSc
@@ -12987,18 +12967,18 @@ aylyth;13230;aylyth;Aylyth;;
 no-shade;13231;noshade;No Shade;;
 dimensional-threads;13232;dimthread;Dimensional Threading Reforked;;
 jonns-trophies;13233;trophymanager;Jonn's Trophies;;
-;13234;it-follows;It Follows!;;
+it-follows-exclamation;13234;it-follows;It Follows!;;
 ;13235;loggerhead_luminancies;Loggerhead Luminancies;;
 asteorbar;13236;asteorbar;Asteor的状态栏和血量显示;AsteorBar;
 better-f1-reborn;13237;betterf1;更好的F1重制版;Better F1 Reborn;
-create-tipsy-n-dizzy;13238;createtipsy;Create: Tipsy n' Dizzy;;
+create-tipsy-n-dizzy;13238;createtipsy;Create: The Kitchen Must Grow/Create: Tipsy n' Dizzy;;
 ars-expanded-combat;13239;ec_ars_plugin;Ars Expanded Combat;;
 ;13240;revamped_piles;Revamped Piles;;
 ;13241;fluiwid;FLUIwID;;
 revamped-phantoms;13242;revamped_phantoms;Revamped Phantoms;;
 defaultserverlist;13243;defaultserverlist;DefaultServerList;;DSL
-green-delights;13244;greendelights;绿里乐事;Green Delight;
-;13245;modmenu;Mod Menu Ornithe;;
+green-delights;13244;greendelights;翠绿乐事;Green Delights;
+;13245;;Mod Menu Ornithe;;
 lost-city;13246;lostcity;Lost city;;
 digestive;13247;digestive;Digestive;;
 ;13248;;Mowzie's mobs结构重建;Rebuilt of Mowziemob's Structure;
@@ -13006,15 +12986,15 @@ digestive;13247;digestive;Digestive;;
 ;13250;inventorybinds;Inventory Binds;;
 ;13251;decorativeblock;颜色方块;MoreColorsquare;MCS
 octo-lib;13252;octolib;OctoLib;;
-farmers-utils;13253;farmersutils;Farmer's Utils;;
+farmers-plus;13253;farmersutils,farmersplus;Farmer's Plus;;
 architects-friend;13254;ArchitectFriend;Architect's Friend;;
 bagus-cosmetic;13255;bagus_cosmetic;Bagu's Cosmetic;;
 floatingitems;13256;floatingitems;FloatingItems;;
 ars-ocultas;13257;ars_ocultas;Ars Ocultas;;
 tetracelium;13258;tetracelium;tetracelium;;
 ;13259;fugue;Fugue;;
-create-food-fabric;13260;create_food;Create: Food;;
-;13261;mr_formula_additionsaltblock,formula_additions_salt_block,fasb;配方追加-盐块;Formula Addition - Salt Block;FASB
+create-food;13260;create_food,createfood;Create: Food;;
+;13261;mr_formula_additionsaltblock,formula_additions_salt_block,fasb,RAP;配方追+;Recipe Addition Plus;RAP
 ;13262;dropfoodafterdied;殪焉掉则;Drop Food After Died;DFAD
 a-block-of-charcoal;13263;charcoalblock;木炭块;A Block of Charcoal;
 a-block-of-flint;13264;flintblock;燧石块;A Block of Flint;
@@ -13037,7 +13017,7 @@ tanukidecor;13280;tanukidecor;Tanuki Decor;;
 ;13281;ccm;ChatCommandsManager;;CCM
 cit-reforged;13282;citresewn;CIT Reforged;;
 ultreonlib;13283;ultreonlib;Ultreon Modding Library;;
-undergarden-delight;13284;undergardendelight;Undergarden Delight;;
+undergarden-delight;13284;undergardendelight;深暗之园乐事;Undergarden Delight;
 medieval-deco;13285;medieval_deco;Medieval Deco;;
 ;13286;;MCBE Debug Screen;;
 limi;13288;LiMI;轻量化模组名称显示;Lightweight Mod Indicator;LiMI
@@ -13048,7 +13028,7 @@ harder-underground;13292;HarderUnderground;更难的地下;Harder Underground;
 harder-wildlife;13293;HarderWildlife;更难的野生动物;Harder Wildlife;
 harder-farming;13294;harderfarming;更难的农作;Harder Farming;
 waterproof;13295;Waterproof;Waterproof;;
-entityculling-unofficial;13296;entityculling;实体渲染机制优化：非官方版;EntityCulling Unofficial;
+entityculling-unofficial;13296;;实体渲染机制优化：非官方版;EntityCulling Unofficial;
 ;13297;syncprojecte;Sync ProjectE Knowledge;;
 ;13298;ccpacrcompact;Config Custom Portal API And Create Rail Compact;;CCPA&CRC
 ;13299;eventtweaker;EventTweaker;;evt
@@ -13060,7 +13040,7 @@ mxtune;13304;mxtune;mxTune;;
 customui;13305;customui;自定义UI;CustomUI;
 deadly-monsters-patched;13306;dmonsters;Deadly Monsters Patched;;
 glodium;13307;glodium;Glodium;;
-aether-delight;13308;aetherdelight;Aether Delight;;
+aether-delight;13308;aetherdelight;天境乐事;Aether Delight;
 ;13309;tclgraphics;Animatrix and GraphicsExpanded 1.7.10;;
 dungeonz;13310;dungeonz;DungeonZ;;
 cazfps-axolotls;13311;cazfps_axolotls_dimension;CAZfps Axolotls;;
@@ -13083,7 +13063,7 @@ visible-offhand;13328;visible_offhand;可见副手;Visible Offhand;VO
 phosphorcrashfix;13329;phosphorcrashfix;Phosphor Crash Fix;;
 sound-physics-remixin;13330;soundphysics;籁;Sound Physics Remixin;
 hextended-staves;13331;lanishextendedstaves;Hextended Staves;;
-aquaculture-delight;13332;aquaculturedelight;Aquaculture Delight;;
+aquaculture-delight;13332;aquaculturedelight;水产乐事;Aquaculture Delight;
 vics-point-blank;13333;pointblank;Vic's Point Blank;;VPB
 occultism-kubejs;13334;occultism_kubejs;Occultism KubeJS;;
 tetra-extras;13335;tetraextrassro,TetraExtras;Tetra Extras;;
@@ -13113,7 +13093,7 @@ mmm-lib;13357;MMMLib;MMM-Lib / MMMLib;;
 ;13359;nt;NoFire;;NT
 create-design-n-decor;13360;design_decor;Create: Design n' Decor;;
 ;13361;yc;YesCheat+;;YC
-enviromine-lite;13362;enviromine;EnviroMine Lite;;
+enviromine-lite;13362;enviromine;更多生存要素：精简版;EnviroMine Lite;
 knaves-needs;13363;knavesneeds;Knaves' Needs;;
 azurelib-armor;13364;azurelibarmor;AzureLib Armor;;
 ;13365;container-tooltips;Container Tooltips;;
@@ -13143,10 +13123,10 @@ create-trains-on-trains;13386;create_trains_on_trains;Create: Trains on Trains;;
 flux-networks-fabric;13389;fluxnetworks;Flux Networks (Fabric);;
 ;13390;surface;Surface;;
 poof-sounds;13391;poofsound;Poof Sounds;;
-;13392;crash-pipe;Crash Pipe;;
+crash-pipe;13392;crash-pipe;Crash Pipe;;
 gradeus-epic-fight-addon-soul-like-boss;13393;gradeus;gradeus: epic fight addon & soul like boss;;
 zombie-more;13394;zombie_more;Zombies More;;
-gunscraft;13395;gunscraft;枪械工艺;Guns Craft;GF
+gunscraft;13395;gunscraft;枪械工艺;Guns Craft;GCS
 audino;13396;audino;Audino;;
 tabbychat-unofficial;13397;tabbychat;TabbyChat Unofficial 1.7.10;;
 heracles;13398;heracles;Heracles;;
@@ -13167,11 +13147,11 @@ create-oxidized;13412;create_oxidized;Create: Oxidized;;
 ;13413;nf;移动工具;MoveTools;MT
 green-soul;13414;green_soul;Green Soul;;
 everyxdance;13415;everyxdance;一起跳舞！;EveryXDance;EXD
-applied-flux;13416;appflux;Applied Flux;;
+applied-flux;13416;appflux;应用通量;Applied Flux;
 ;13417;campfire_torch;Campfire Torches;;
 ;13418;tinkers_delight;匠魂乐事;Tinkers' Delight;TD
 unnamed-desert-structures;13419;u_desert;Unnamed Desert Structures;;
-bloomingnature;13420;bloomingnature;Let's Do: BloomingNature;;
+bloomingnature;13420;bloomingnature;绽芳自然;Let's Do: BloomingNature;
 waila-inhibitors;13421;wailainhib;Waila Inhibitors;;
 thingamabobs-and-doohickeys;13422;thingamabobs_and_doohickeys;Thingamabobs and Doohickeys;;
 waila-events;13423;wailaevents;Waila Events;;
@@ -13179,12 +13159,12 @@ march-of-the-ents;13424;marchofents;恩特的进军;March Of The Ents;MOE
 rndtp;13425;rndtp;RndTp;;
 in-world-buoyancy;13426;inworldbuoyancy;In-World Buoyancy;;
 ;13427;starminer;Simply Starminer;;
-macos-input-fixes;13428;macos_input_fixes;MacOS Input Fixes;;
+macos-input-fixes;13428;macos_input_fixes;MacOS输入修复;MacOS Input Fixes;
 ;13429;maxhealthfixfixfix;MaxHealthFixFixFix;;
 ;13430;astronomical;Astronomical;;
 ;13431;yagate_kimi_ni_naru;终将成为你;yagate kimi ni naru;
 ;13432;milletdelight;小米乐事;Millet Delight;
-ned;13433;anmao.mc.ned;猫艺：无尽难度;Neko Endless Difficulty;NED
+ned;13433;anmao.mc.ned;猫艺：终焉;Neko End;NED
 magical-torches;13434;magical_torches;Magical Torches;;
 dynamical-compass;13435;dynamical_compass;Dynamical Compass;;
 better-questing-lord-of-the-rings-addon;13436;bqlotr;更好的任务-魔戒扩展;Better Questing - Lord of the Rings addon;
@@ -13198,7 +13178,7 @@ demimortality;13443;demimortality;Demimortality;;
 biome-beans;13444;biome_beans;Biome Beans;;
 cats-workshop;13445;cats_workshop;Cat's Workshop;;
 soulless-steeds;13446;soulless_steed;Soulless Steeds;;
-openblocks-elevator-fabric;13447;openblocks;OpenBlocks Elevator;;
+openblocks-elevator-fabric;13447;openblocks;OpenBlocks Elevator (Fabric);;
 aurorasdecorations;13448;aurorasdeco;Aurora's Decorations;;
 choups-drakvyrn-mod;13449;choups_drakvyrn_mod;Choup's Drakvyrn Mod;;
 abyssal-decor;13450;abyssal_decor;Abyssal Decor;;AD
@@ -13206,7 +13186,7 @@ abyssal-decor;13450;abyssal_decor;Abyssal Decor;;AD
 reddens-stone-lanterns;13452;reddensstonelantern;Redden的石灯笼;Redden's Stone Lanterns;
 heaven-burns-red;13453;hbr_mc;红烧天堂;Heaven Burns Red;HBR
 ;13454;;Snowy Spirit - Doggo Compat;;
-apotheosis-modern-ragnarok;13455;apotheosis_modern_ragnarok;神化：现代诸神黄昏;Apotheosis Modern Ragnarok;
+apotheosis-modern-ragnarok;13455;apotheosis_modern_ragnarok;神化：现代诸神黄昏;Apotheosis Modern Ragnarok: Zero;
 ;13456;bedgoboom;BedGoBoom;;
 block-properties;13457;BlockProperties;方块属性;Block Properties;
 custom-chest-loot;13458;CustomChestLoot;自定义战利品箱;Custom Chest Loot;
@@ -13224,7 +13204,7 @@ leftist-potions;13469;leftistpotions;Leftist Potions;;
 more-delight-fabric;13470;moredelight;More Delight;;
 mceconomy3;13471;mceconomy3;MCEconomy3;;
 ;13472;antique-atlas;Antique Atlas 4;;
-;13473;pollution;污染;Pollution;PO
+pollution;13473;pollution;污染;Pollution;PO
 tinted-campfires;13474;tintedcampfires;Tinted Campfires;;
 additionalstatus;13475;AdditionalStatus;AdditionalStatus;;
 epic-knights-slavic-armory;13476;slavicarmory;Epic Knights: Slavic Armory;;
@@ -13232,7 +13212,7 @@ create-copies-cats;13477;copiescats;Create: Copies & Cats;;
 chat-signing-hider;13478;chatsigninghider;Chat Signing Hider;;
 gamma-creatures;13479;gamma_beasts;Gamma Creatures;;
 multipart-machines-mining;13480;mm_mining;Multipart Machines: Mining;;
-;13481;better_structure_block;更好的结构方块1.20.1;;BSB
+high-version-better-structure-block;13481;better_structure_block;更好的结构方块1.20.1;;BSB
 ;13482;drtech;Dr科技;DrTech;DRT
 ;13483;creepermultidrop;Creeper Multidrop;;
 the-man-from-the-fog;13484;man;雾中人;The Man From The Fog;
@@ -13248,10 +13228,10 @@ cit-resewn-jsonlagpatch;13493;citresewn;CIT Resewn JSONLagPatch;;
 geckoanimfix;13494;geckoanimfix;Iris/Oculus & GeckoLib Compat;;
 ;13495;dragonrealm;魔戒之龙;LOTR Dragon;
 mekanismecoenergistics;13496;mekanismecoenergistics;Mekanism EcoEnergistics;;
-waila-blacklist;13497;waila-blacklist;Waila黑名单;WAILA Blacklist;
+waila-blacklist;13497;waila-blacklist;Waila 黑名单;WAILA Blacklist;
 item-blacklist;13498;itemblacklist;物品黑名单;Item Blacklist;
 continue;13499;continue;Continue Button;;
-the-dawn-era;13500;dawnera;The Dawn Era;;TDE
+the-dawn-era;13500;dawnera;黎明纪元;The Dawn Era;TDE
 ;13501;bwb;更好的世界边界;Better World Border;BWB
 tridents-n-stuff;13502;tridents_n_stuff;Tridents 'n' Stuff;;TNS
 create-hand-crafting;13503;create_hc;Create Hand Crafting;;
@@ -13259,7 +13239,7 @@ create-hand-crafting;13503;create_hc;Create Hand Crafting;;
 ;13505;softerpastels;Softer Pastels;;
 ;13506;rainbethunder;RainBeThunder;;
 create-easy-structures;13507;create_easy_structures;Create: Easy Structures;;
-sound-overhaul;13508;sounds;Sound​s;;
+sound;13508;sounds;Sound​s;;
 skinshuffle;13509;skinshuffle;SkinShuffle;;
 reboot-lovelyrobot;13510;rlovelyr;萌化机器人：重启;Reboot LovelyRobot;
 ;13511;Suffuse;硝烟四起 枪械-拓展;Point Blank-Suffuse GunSmokePack;SGS
@@ -13269,7 +13249,7 @@ reboot-lovelyrobot;13510;rlovelyr;萌化机器人：重启;Reboot LovelyRobot;
 farmers-delight-tfc;13515;farmersdelight_tfc;Farmer's Delight TFC;;
 even-more-realistic-ore-veins;13516;realistic_ore_veins;Even More Realistic Ore Veins;;
 ad-astra-extra;13517;adastraextra;Ad Astra Extra;;
-underground-bunkers;13518;underground_bunkers;Underground Bunkers;;
+underground-bunkers;13518;underground_bunkers;Underground Bunkers;;UB
 minemath;13519;minemath;MineMath;;
 weapon-leveling;13520;weaponleveling;Lukas' Weapon Leveling;;
 rather-more-potions;13521;rather_more_potions;稍多药水;Rather More Potions;RMP
@@ -13277,7 +13257,7 @@ museum-curator;13522;museumcurator;琳琅满目;Museum Curator;
 pixel-hud;13523;pixelhud;Pixel-Hud;;
 ;13524;ImmibisMacroblocks;Immibis's Macroblocks;;
 ;13525;heater;Heater;;
-;13526;natures_melody;Nature's Melody;;
+natures-melody;13526;natures_melody;自然旋律;Nature's Melody;
 astemirlib;13527;astemirlib;AstemirLib;;
 create-unbreakable-tools;13528;create_unbreakable;Create: Unbreakable Tools;;
 timeless-heroes;13529;superhero;Timeless Heroes;;
@@ -13293,13 +13273,13 @@ tac-interact-key;13536;tacinteractkey;TAC交互优化;TAC Interact Key;
 ;13539;igfileeditor;In-Game File Editor;;
 tide;13540;tide;潮汐;Tide;
 taiga-replant-replant;13541;taiga;匠魂合金附加二次重栽版;TAIGA Replant Replant;TAIGARR
-salmons-genesis-reincarnation;13542;salmonsgenesisreincarnation;Salmon's Genesis Reincarnation;;
+salmons-genesis-reincarnation;13542;salmonsgenesisreincarnation;Salmon's Genesis Reincarnation;;SGR
 loot-bundles;13543;lootbundles;Loot Bundles;;
 optifine-check;13544;opticheck;Optifine Check;;
 tfc-ie-minerals;13545;tfc_ie_minerals;TFC IE Minerals;;
 looking-at;13546;lookingat;Looking At;;
 ;13547;Pistons;Pistons;;
-rftools-continuation;13548;;Rftools Continuation;;
+rftools-continuation;13548;rftools;Rftools Continuation;;
 better-with-everything;13549;betterwithmods,betterwithaddons;Better With Everything;;
 create-clockwork;13550;vs_clockwork;Clockwork: Create x Valkyrien Skies;;
 lomlib;13551;lomlib;LomLib;;
@@ -13325,14 +13305,14 @@ epic-knightsnmages-fabric;13570;knightsnmages;Epic Knights'n'Mages;;
 hotai;13571;hotai;绷带;Hotai;
 zeta;13572;zeta;Zeta;;
 taxtowncitizen;13573;taxtc;Tax' Town Citizen;;
-killer-rabbit-transformation;13574;killer_rabbit_transformation;转化杀手兔;Killer Rabbit Transformation;KRT
+killer-rabbit-transformation;13574;killer_rabbit_transformation;转化杀手兔;Killer Bunny Tweaks;
 bronze-viking;13575;bronze__vvikings;Bronze & Viking;;
 ;13576;mceconomy3compat;MCEconomy3Compat;;
 astikor-carts-redux;13577;astikorcarts;AstikorCarts Redux;;
-third-person-shooting;13578;tp_shooting;第三人称射击;Third Person Shooting;
+third-person-shooting;13578;tp_shooting;第三人称射击：零;Third Person Shooting: Zero;
 sight;13579;sight;视域;Sight;
 ;13580;mrbeastbossfight50k;The First City;;
-threetag-palladium;13581;palladium;Palladium;;
+threetag-palladium;13581;palladium;钯;Palladium;
 ;13582;vintagium;Vintagium;;
 ;13583;woodywe;伍德的工作扩展;Woody's Work Extend;
 ;13584;akatzumaworldedit;生存模式的创世神;AkatZumaWorldEdit;
@@ -13340,34 +13320,34 @@ permanent-status-effect;13585;permanent_status_effect;永久状态效果;Permane
 world-play-time;13587;worldplaytime;World Play Time;;
 ikwila-i-know-what-im-looking-at;13588;ikwila;I Know What I'm Looking At;;IKWILA
 experienced-crops;13589;experienced_crops;Experienced Crops;;
-medieval-seedbags;13590;medieval_seedbags;Medieval Seedbags;;
+medieval-seedbags;13590;medieval_seedbags,seedbags;Medieval Seedbags;;
 fusionutil;13591;fusionutil;FusionUtil;;
 ;13592;;无声无息;No Creatures;NC
 ;13593;compactmachinesinfinite;压缩空间：无限;Compact Machines: Infinite;
 thaumic-sanity;13594;thaumicstability;Thaumic Sanity;;
-tfc-thermal-deposits;13595;tfcthermaldeposits;TFC Thermal Deposits;;
+tfc-thermal-deposits;13595;tfcthermaldeposits;TFC Volcanoes;;
 animals-trap-for-tfc;13596;animaltraptfc;Animals Trap for TFC;;
 ;13597;ac;聊天工具;AutoChat;AC
 zzzzz-custom-configs;13598;zzzzzcustomconfigs;ZZZZZ Custom Configs;;
 weird-happenings;13599;weirdhappenings;Weird Happenings;;
 nbc-heroes;13600;heroes;NBC Heroes;;
 melody;13601;melody;Melody;;
-cut-through;13602;cutthrough;Cut Through;;
+cut-through;13602;cutthrough;Cut Through;;CT
 ;13603;intarray.beacon;Aesthetic Beacons;;
 anvilfixreborn;13604;anvil_fix;铁砧修复重生;Anvil Fix Reborn;
-;13605;celestial_weapon;星月武器;Celestial Weapon;CW
+;13605;celestial_weapon;星月武器;Celestial Weapon;
 apothic-curios;13606;apothiccurios;Apothic Curios;;
 hbm-ntm-lucky-blocks;13607;luckynuke;HBM NTM Lucky blocks;;
 thaumtweaks;13608;thaumtweaks;ThaumTweaks;;
 no-baby-zombies;13609;nobz;No Baby Zombies;;
-combat-nouveau;13610;combatnouveau;Combat Nouveau;;
+combat-nouveau;13610;combatnouveau;Combat Nouveau;;CN
 ;13611;hanging_on;Hanging On;;
 ;13612;igoa;游戏内离线登录;In-game Offline Auth;IGOA
 ;13613;lazymystical;神秘农业：懒人;Lazy Mystical;
 udlede;13614;udlede;港口;Udlede;
 hammer-time;13615;hammertime;Hammer Time;;
 hammerz;13616;hammerz;Hammerz;;
-;13617;pickup;Pickup;;
+;13617;pickup;物品框互交优化;Pickup;
 livingadventuretrails;13618;livingadventuretrails;Living Adventure: Trails;;
 suggestions-api;13619;suggestions-api,suggestionsapi;Suggestion API;;
 colorful-subtitles;13620;colorfulsubtitles;Colorful Subtitles;;
@@ -13383,13 +13363,13 @@ more-variants-and-biomes;13629;more_variants;more variants and biomes;;
 badoptimizations;13630;badoptimizations;BadOptimizations;;
 ;13631;PfaeffMod;Pfaeff's Mod;;
 genshinimpactmod;13632;genshin;Genshin;;
-diagonal-walls;13633;diagonalwindows;Diagonal Walls;;
+diagonal-walls;13633;diagonalwindows;Diagonal Walls;;DW
 gravestones-die-classy-updated;13634;gravestones;GraveStones - Die Classy Updated;;
 osog-city-cars;13635;osog-city-cars;City Cars;;
 immersive-vehicles-iav-parts-pack;13636;iav;IAV Parts pack;;
 tfmg-virtual-oil-deposit;13637;tfmgvod;工业长路：虚拟油田;TFMG: Virtual Oil Deposit;
 ;13638;alinlib;AlinLib;;
-croparia-if;13639;croparia;矿石作物/魔种之咏 IF版;Croparia-IF;
+croparia-if;13639;croparia;矿石魔种 (矿石作物/魔种之咏 IF版);Croparia-IF;
 ;13640;tetinker;科能工匠;Technical Engineering 3 Tinker;TEN3T
 ;13641;actionlib;ActionLib;;
 simple-close-button;13642;close-btn;Simple Close Button;;
@@ -13399,7 +13379,7 @@ godzilla-rising;13645;grising;Godzilla: Rising;;
 create-netherless;13646;create_netherless;Create: Netherless;;
 noguievolution;13647;noguievolution;沉浸进化;NoGuiEvolution;NGE
 baseball-bats;13648;bats;Bats;;
-tfc-weather;13649;tfcweather;TFC Weather;;
+tfc-weather;13649;tfcweather,weathertfc;TFC Weather;;
 ;13650;mup;EigenCraft Unofficial Patch;;
 conrad;13651;conrad;Conrad;;
 backpack-plus-addon;13652;bps;Backpack Plus;;
@@ -13407,15 +13387,15 @@ nendermoo;13653;nendermoo;Nendermoo;;
 forgedcarpet;13654;forgedcarpet;Forged Carpet;;
 framed;13655;framed;HELP! I'm being framed!;;
 gear-core;13656;gear_core;Gear Core;;
-hideasterisk;13657;hidemodded;隐藏“已修改”;HideModded;
+hideasterisk;13657;hidemodded;隐藏“已修改”;HideModded;HMD
 monster-eggs;13658;monstereggs;Monster Eggs;;
-rain-shield;13659;rainshield;Rain Shield;;
+rain-shield;13659;rainshield;驱雨盾;Rain Shield;
 cerbons-better-beacons;13660;better_beacons;CERBON's Better Beacons;;
 ;13661;funny-roulette;Funny Roulette;;
 ;13662;worldeditcui;WorldEdit CUI (Forge);;
 better-loot;13663;betterloot;Better Loot;;
 trique-api;13664;triqueapi;TriQue API;;
-lets-do-addon-structures;13665;letsdo_addon_structures;Let's Do Addon: Structures;;
+lets-do-addon-structures;13665;letsdo_addon_structures,letsdoaddon-structures;Let's Do Addon: Structures;;
 create-recycle-everything;13666;create_crush_everything;Create Recycle Everything;;
 tfc-ambiental-second-edition;13667;tfcambiental;TFC Ambiental: Second edition;;
 ;13668;somemusicdiscs;Some Music Discs;;
@@ -13441,7 +13421,7 @@ votemission;13687;votemission;VoteMission;;
 immersive-vehicles-automobilwerke-schwikau-veb;13688;auweschveb;VEB Automobilwerke Schwikau;;
 cheesemaking;13689;cheesemaking;Cheesemaking;;
 cardiac;13690;cardiac;Cardiac;;
-materialtweaker;13691;materialtweaker;MaterialTweaker;;
+materialtweaker;13691;materialtweaker;MaterialTweaker;;MT
 whirlwind;13692;whirlwind;WhirlWind;;
 warden-tools;13693;wardentools;Warden Tools;;
 royal-guard;13694;royal_guard;皇家守卫;Royal Guard;RG
@@ -13452,15 +13432,15 @@ elenai-dodge;13698;elenaidodge;Elenai Dodge;;
 xenon;13699;xenon;氙;Xenon;
 riftstorm-rpg;13700;riftstorm_rpg;Riftstorm RPG;;
 ;13701;data_api;Data API;;
-;13702;mr_better_babies;Better Babies;;
+better-babies;13702;mr_better_babies;Better Babies;;
 morecreativetabs-forge-fabric;13703;morecreativetabs;MoreCreativeTabs;;
 ;13704;mr_trade_villagerhats;Gen's Villager Hats;;
 ;13705;shove;Shove!;;
-sunflower-delight;13706;sunflower_delight;Sunflower Delight;;
+sunflower-delight;13706;sunflower_delight;向日葵乐事;Sunflower Delight;
 mystias-izakaya;13707;mystias_izakaya;夜雀乐事;Mystias Izakaya;MI
 carpet-everything;13708;carpeteverything;Carpet Everything!;;
 ;13709;nianyefan;黏液饭;Nian Ye Fan;
-lets-do-brewery;13710;brewery;盛节精酿;Let's Do Brewery;
+lets-do-brewery-farm-charm-compat;13710;brewery;盛节精酿;Let's Do Brewery;
 hephaestusplus;13711;hephaestusplus;Hephaestus Plus;;
 re-dimension-stages;13712;redimstages;维度阶段重制版;Re-Dimension Stages;
 lemoned;13713;lemoned;Lemoned;;
@@ -13473,7 +13453,7 @@ everymole;13719;every_mole;EveryMole - Alex Caves Addon;;
 mutant-iceologer;13720;mutant_iceologer,mi;Mutant Iceologer;;
 ;13721;days_gone;Days Gone;;
 ;13722;extra-loot;额外战利品;Extra Loot;EL
-relics-of-gaming-continued;13723;rogcontinued;Relics Of Gaming Continued;;
+relics-of-gaming-continued;13723;rogcontinued;游戏遗物：延续;Relics Of Gaming Continued;
 endermen-plus;13724;endermenplus;Endermen Plus;;
 tiptapshow;13725;tiptapshow;TipTapShow;;
 villager-gunners;13726;gunners;Villager Gunners;;
@@ -13482,8 +13462,8 @@ epic-fight-infernal-gainer;13728;infernal;Epic Fight - Infernal Gainer;;
 prodigy-mechanics;13729;prodigymechanics;Prodigy Mechanics;;
 just-an-end-anchor;13730;just_end_anchor;Just an End Anchor;;
 ;13731;MineFactory;MineFactory;;
-memory-usage-title;13732;memoryusagetitle;Memory Usage Title;;
-;13733;string-utilities;字符串工具;String Utilities;
+memory-usage-title;13732;memoryusagetitle;标题显示内存;Memory Usage Title;
+string-utilities;13733;string-utilities;字符串工具;String Utilities;
 ;13734;iis;无限物品;InfinityItems;IIS
 sweeper-maid;13735;sweeper_maid;清洁女仆;Sweeper Maid;SM
 more-enchantments_;13736;more_enchantments;更多附魔;More Enchantments;
@@ -13491,7 +13471,7 @@ bow-scope;13737;bowscope;BowScope;;
 ;13738;less_caves;更少的洞穴;less caves;LECA
 fpv20;13739;fpv20;FPV20;;
 molten-metal;13740;moltensteel;Molten Metal;;
-selling-bin;13741;selling-bin;Selling Bin;;
+selling-bin;13741;sellingbin;Joe's Selling Bin;;
 tomtarus-cobblemon-farmers-delight-tweaks;13742;tmtcd;Tomtaru's Cobblemon & Farmer's Delight Tweaks;;
 cobblemon-o-plenty;13743;tmtcop;Cobblemon O' Plenty;;
 tomtarus-cobblemon-immersive-engineering-tweaks;13744;tmtceic;Tomtaru's Cobblemon & Immersive Engineering Tweaks;;
@@ -13536,27 +13516,27 @@ totallybalancedcreativeflying;13781;tbcf;Totally Balanced Creative Flying;;
 heterorustichromia;13783;rustichromia;Heterorustichromia;;
 video-extension-for-fancymenu-forge;13784;fmextension_video;Video Extension for FancyMenu;;
 easy-npc;13785;easy_npc;Easy NPC;;
-;13786;mr_ns_fdrc;自然之灵-农夫乐事配方兼容;Nature's Spirit - Farmer's Delight Recipe Compat;
-the-dawn-era-delight;13787;dawnera_delight;The Dawn Era Delight;;
+;13786;mr_ns_fdrc,ns_fd_rc;自然之灵-农夫乐事配方兼容;Nature's Spirit - Farmer's Delight Recipe Compat;
+the-dawn-era-delight;13787;dawnera_delight;黎明纪元乐事;The Dawn Era Delight;
 dynamic-craft;13788;DynamicCraft;Dynamic Craft;;
 startinginventory;13789;StartingInventory;StartingInventory;;
 wireless-speakers;13790;speakermod;无线扬声器;Wireless Speakers;
-;13791;tgfx;科技枪特效;TechgunFX;TGFX
+;13791;safx;SA特效;SagerFX;SAFX
 ;13792;noteit;NoteIt;;
-jewelrycraft-2;13793;jewelrycraft2;Jewelrycraft 2;;
+jewelrycraft-2;13793;jewelrycraft2;珠宝工艺2;Jewelrycraft 2;
 fallflyinglib;13794;fallflyinglib;FallFlyingLib;;
 enchantable-spike;13795;enchantablespike;Enchantable Spike;;
 ;13796;crit;Crit Arrows From Mobs;;
 xaeros-map-chest-tracker-integration;13797;xaeros-map-chest-tracker-integration;Xaero's Map Chest Tracker Integration;;
 warden-horn;13798;wardenhorn;Warden Horn;;
 too-many-efficiency-losses;13799;tmel;Too Many Efficiency Losses;;TMEL
-srp-addon-cotesia-glomerata;13800;srpcotesia;Scape and Run Parasites Addon: Cotesia Glomerata;;
+srp-addon-cotesia-glomerata;13800;srpcotesia;SRP：寄生蜂;Scape and Run Parasites Addon: Cotesia Glomerata;SRPC
 ;13801;crf;Crash Pipe-Forge;;
 damage-lock;13802;damage_lock;磁场天锁;DamageLock;DL
 ;13803;whdf;狼受击伤害修正;WolfHitDamageFix;WHDF
 modular-materials;13804;modularmaterials;模块化材料;Modular Materials;
 minepal;13805;minepal;Minepal;;
-;13806;customportals;Custom Portals;;
+custom-portals;13806;customportals;自定义传送门;Custom Portals;
 dirty-lens;13807;dirty_lens;Dirty Lens;;
 ;13808;improved_anvils;Improved Anvils;;
 styled-player-list;13809;styledplayerlist;Styled Player List;;
@@ -13568,9 +13548,9 @@ abridged;13814;abridged;Abridged;;
 hexvr;13815;hex_vr;HexVR;;
 hearths;13816;hearths;Hearths;;
 prey-effect;13817;prey;Prey Effect;;
-;13818;venturer;Venturer;;
+venturer;13818;venturer;Venturer;;
 wheres-my-wither-storm;13819;wmws;Where's My Wither Storm?;;
-alexs-mobs-interaction;13820;alexsmobs;Alexs Mobs Interaction;;
+alexs-mobs-interaction;13820;alexsmobs;Alex 的生物：交互;Alexs Mobs Interaction;
 ;13821;to_neko;toNeko Forge重制版;toNeko Reforged;
 ;13822;cheesing_death;欺骗死亡;Cheesing Death;CD
 ;13823;isadd;物品堆叠上限突破;ItemStack++;ISADD
@@ -13579,7 +13559,7 @@ myworldgen;13825;MyWorldGen;MyWorldGen;;
 medieval-buildings-end-edition;13826;medievalend;Medieval Buildings [End Edition];;
 farmers-combat;13827;farmerscombat;Farmer's Combat;;
 orpheus;13828;orpheus;Orpheus;;
-;13829;createsweetsandtreets;Create: Sweets & Treats;;
+create-sweets-and-treats;13829;createsweetsandtreets;Create: Sweets & Treats;;
 klsts-beyond-netherite;13830;beyond;Klsts' Beyond Netherite;;
 ;13831;mcmodwiki;MC百科资料搜索：再重生;MCMOD Item Search Reborn Again;
 refined-polymorphism;13832;refinedpolymorph;Refined Polymorphism;;
@@ -13593,7 +13573,7 @@ simple-butchery;13839;butcherymod;Simple Butchery;;
 butchery;13840;butchery;Butchery;;
 ;13841;smr;平滑基岩层-Forge;Smoother Bedrock-Forge;SBF
 enchantment-reveal;13842;enchantment_reveal;Enchantment Reveal;;
-copycats;13844;copycats;Create: Copycats+;;
+copycats;13844;copycats;机械动力：伪装方块+;Create: Copycats+;
 the-great-alchemical-compendium;13845;the_great_alchemical_compendium;The Great Alchemical Compendium;;
 desperate-measures;13846;desperate_measures;Desperate Measures;;
 block-slabs-mod;13847;blockslabs;Block Slabs;;
@@ -13614,7 +13594,7 @@ piglin-army;13861;piglin_army;Piglin Army;;
 decorative-ladders;13862;decorative-ladders;Decorative Ladders;;
 more-foods;13863;morefood;More Foods;;
 ;13864;whousedrtpcommandmod;移跃当知;Who used RTP Command;WRC
-baking-delight;13865;bakingdelight;烘焙乐事;Baking Delight;BD
+modern-delight;13865;bakingdelight;现代乐事;Modern Delight;
 better-main-menu;13866;better_main_menu;Better Main Menu;;
 ;13867;airoverhaul;Drowning Overhaul / Air Overhaul;;
 more-wizards;13868;more_wizards;More Wizards;;
@@ -13637,19 +13617,19 @@ sandbox-bootstrap;13884;sandbox_bootstrap;Sandbox Bootstrap;;
 tetra-toolbooster;13885;toolbooster;Tetra Toolbooster;;
 ad-astra-proxima-plus;13886;proxima_plus;Ad Astra : Proxima Plus;;
 ad-astra-extra-additions;13887;ad_astra__extra_additions;Ad Astra: Extra Additions;;
-infinite-fluid-bucket;13888;infinite_fluid_bucket;无限流体桶;Infinite Fluid Bucket;
+infinite-fluid-bucket;13888;infinite_fluid_bucket;无限流体桶;Infinite Fluid Bucket;IFB
 ;13889;lcsmodpack;前期武器追加;;EWA
 ;13890;voxy;voxy;;
-;13891;vsource;VSource;;
+vmod;13891;valkyrien_mod;VMod;;
 minestuck;13892;minestuck;Minestuck;;
-;13893;vpbrecipe;VPB的配方;VPBR's Recipe;
+;13893;vpbrecipe;VPB的配方;VPB's Recipe;
 star-wars-planets-ad-astra;13894;swplanets;Star Wars Planets Ad Astra;;
 amethyst-equipment;13895;amethystequipment;Amethyst Equipment;;
 the-whisperer;13896;whisperer;The Whisperer;;
-;13897;lightningrod;格雷科技 0;GregTech 0 / Lightning Rod Addon;GT0
+;13897;lightningrod;格雷科技0;GregTech 0 / Lightning Rod Addon;GT0
 epic-vinland-saga;13898;epicvinlandsaga;Epic Vinland Saga;;
 cat_jam;13899;cat_jam;cat_jam;;
-remastered-structure;13900;milesplayz;Remastered Vanilla / Remastered Structure;;
+remastered-structure;13900;milesplayz;Fantastic Remastered Structures;;
 spacore;13901;spacore;SpACore;;
 fancyvideo-api;13902;fancyvideo-api;FancyVideo-API;;
 the-goatman-by-flamco4;13903;goatman;The Goatman;;
@@ -13670,7 +13650,7 @@ leaf-pile;13917;leafpile;落叶堆;Leaf Pile;
 uwufied;13918;uwufied;UwUfied;;
 sit-chill;13919;chillout;Sit & Chill;;
 blueprintvoid;13920;bpvoid;机械动力：蓝图空位;Create：Blueprint Void;
-;13921;quickonlinemod;快捷联机;;QOM
+;13921;quickonlinemod;快捷联机;QuickOnlineMod;QOM
 mo-creatures-legacy;13922;MoCreatures;Mo' Creatures Legacy;;
 sticky-hands;13923;stickyhands;Sticky Hands;;
 pandalib;13924;pandalib;PandaLib;;
@@ -13700,29 +13680,29 @@ sign-button;13947;signbutton;Sign Button;;
 startinv;13948;startinv;StartInv;;
 ;13949;server-replay;ServerReplay;;
 ftb-stoneblock-companion;13950;ftbsbc;FTB StoneBlock Companion;;
-ash-of-sin-custom-anti-enchantment-entity;13951;ash_of_sin_custom_anti_enchantment_entity;罪业余烬：自定义反附魔实体;Ash Of Sin:Custom Anti Enchantment Entity;
-ash-of-sin-anti-high-level-enchantment;13952;ash_of_sin_anti_high_level_enchantment;罪业余烬：反高级附魔;Ash Of Sin:Anti High Level Enchantment;
-ash-of-sin-custom-anti-item-entity;13953;ash_of_sin_custom_anti_item_entity;罪业余烬：自定义反物品实体;Ash Of Sin:Custom Anti Item Entity;
-ash-of-sin-custom-anti-seat-entity;13954;ash_of_sin_custom_anti_seat_entity;罪业余烬：自定义反坐垫实体;Ash Of Sin:Custom Anti Seat Entity;
-ash-of-sin-custom-entity-anti-effect;13955;ash_of_sin_custom_entity_anti_effect;罪业余烬：自定义实体反状态效果;Ash Of Sin:Custom Entity Anti Effect;
-ash-of-sin-custom-entity-effect;13956;ash_of_sin_custom_entity_effect;罪业余烬：自定义实体状态效果;Ash Of Sin:Custom Entity Effect;
-ash-of-sin-custom-entity-item;13957;ash_of_sin_custom_entity_item;罪业余烬：自定义实体装备;Ash Of Sin:Custom Entity Item;
-ash-of-sin-eternal-entity;13958;ash_of_sin_eternal_entity;罪业余烬：永恒实体;Ash Of Sin:Eternal Entity;
+ash-of-sin-custom-anti-enchantment-entity;13951;ash_of_sin_custom_anti_enchantment_entity;罪业余烬：自定义反附魔实体;Ash Of Sin: Custom Anti Enchantment Entity;
+ash-of-sin-anti-high-level-enchantment;13952;ash_of_sin_anti_high_level_enchantment;罪业余烬：反高级附魔;Ash Of Sin: Anti High Level Enchantment;
+ash-of-sin-custom-anti-item-entity;13953;ash_of_sin_custom_anti_item_entity;罪业余烬：自定义反物品实体;Ash Of Sin: Custom Anti Item Entity;
+ash-of-sin-custom-anti-seat-entity;13954;ash_of_sin_custom_anti_seat_entity;罪业余烬：自定义反坐垫实体;Ash Of Sin: Custom Anti Seat Entity;
+ash-of-sin-custom-entity-anti-effect;13955;ash_of_sin_custom_entity_anti_effect;罪业余烬：自定义实体反状态效果;Ash Of Sin: Custom Entity Anti Effect;
+ash-of-sin-custom-entity-effect;13956;ash_of_sin_custom_entity_effect;罪业余烬：自定义实体状态效果;Ash Of Sin: Custom Entity Effect;
+ash-of-sin-custom-entity-item;13957;ash_of_sin_custom_entity_item;罪业余烬：自定义实体装备;Ash Of Sin: Custom Entity Item;
+ash-of-sin-eternal-entity;13958;ash_of_sin_eternal_entity;罪业余烬：永恒实体;Ash Of Sin: Eternal Entity;
 ;13959;ct;运算变速;CustomTimer;CT
 fundamental;13960;fundamental;Fundamental;;
 wendigo;13961;skin_stalker;The Skinstalker;;
-;13962;TheSuperGodRoad;超神之路;TheSuperGodRoad;SGR
+the-super-god-road;13962;TheSuperGodRoad;超神之路;TheSuperGodRoad;SGR
 ;13963;backrooms;The Backrooms;;
 ;13964;cad2t;区块加成;ChunkAddition;CAD2t
 ;13965;exblades;ExBlades;;
 storage-delight-forge;13966;storagedelight;存储乐事;Storage Delight;
-;13967;lightshield;光之护盾;LightShield;LShield
-sophisticated-core-unofficial-fabric-port;13968;sophisticatedcore;精妙核心（非官方 Fabric 移植）;Sophisticated Core (Unofficial Fabric port);
-sophisticated-backpacks-unofficial-fabric-port;13969;sophisticatedbackpacks;精致背包（非官方 Fabric 分支）;Sophisticated Backpacks (Unofficial Fabric port);
+lightshield;13967;lightshield;光之护盾;LightShield;LShield
+sophisticated-core-unofficial-fabric-port;13968;;精妙核心（非官方 Fabric 移植）;Sophisticated Core (Unofficial Fabric port);
+sophisticated-backpacks-unofficial-fabric-port;13969;;精妙背包（非官方 Fabric 分支）;Sophisticated Backpacks (Unofficial Fabric port);
 red-power;13970;red_power;Red Power;;
 ;13971;hdykwd;你怎么知道我做了什么;How do you know what I done;HDYKWD
 ;13972;minihudextra;MiniHUD Extra;;MHEx
-sophisticated-storage-unofficial-fabric-port;13973;sophisticatedstorage;精妙存储（非官方 Fabric 分支）;Sophisticated Storage (Unofficial Fabric port);
+sophisticated-storage-unofficial-fabric-port;13973;;精妙存储（非官方 Fabric 分支）;Sophisticated Storage (Unofficial Fabric port);
 ;13974;oldblockdrops,oldoredropsforge;Old Ore Drops;;
 rage-mod;13975;rage;兴怒;Rage Mod;
 ;13976;disableallstructers;Disable All Structures;;
@@ -13734,13 +13714,13 @@ trajectory-estimation;13980;trajectory_estimation;弹道估计;Trajectory Estima
 ;13982;interconnectionfabric,interconnectionneoforge,interconnectionpaper;互联核心;Interconnection;
 ;13983;interconnectionplayerpaper,interconnectionplayerneoforge,interconnectionplayerfabric;互联玩家同步;InterconnectionPlayer;
 ;13984;twelve_talismans;十二符咒;TwelveTalismans;
-;13985;dragicland;老猎人;Dragicland;
-;13986;mr_ns_crrc;自然之灵-机械动力配方兼容;Nature's Spirit - Create Recipe Compat;
-;13987;yecorn;田野核心;Ye Corn;YC
-dices-repair-kits;13988;repair_kits;Dice's Repair Kits;;
+;13985;dragicland;老猎人;The Elder Hunter;
+ns-cr-rc;13986;mr_ns_crrc;自然之灵-机械动力配方兼容;Nature's Spirit - Create Recipe Compat;
+;13987;yecorn,ye_corn;田野核心;Ye Corn;YC
+iron-repair-kits;13988;repair_kits;Iron Repair Kits;;
 ;13989;susinsert;SusInsert;;
 critters-n-crawlers;13990;cnc;Critters n' Crawlers;;CN'C
-;13991;FishModLoader;FishModLoader;;FML
+;13991;FishModLoader;FishModLoader;;
 epic-stats;13992;epic_stats;Epic Stats;;
 brew-chew;13993;brewchew;Brew'n Chew;;
 ;13994;lummobs;Lummobs!;;
@@ -13750,18 +13730,18 @@ jains-desserts;13996;jains_desserts;Jain's Desserts;;
 ;13998;thief_tweaks;Thief Tweaks;;
 the-long-story;13999;thelongstory;The Long Story;;TLS
 simple-hud-enhanced;14000;simplehudenhanced;Simple HUD Enhanced;;
-;14001;vocalized_ayachi_nene;Vocalized 绫地宁宁语音包;VocalizedAyachiNeneVoicePack;
+vocalized-ayachinene-voice-pack;14001;vocalized_ayachi_nene;Vocalized 绫地宁宁语音包;VocalizedAyachiNeneVoicePack;
 the-between-awakens;14002;shitty_enchants;The Between Awakens;;
 emc-interface;14003;emc_interface;EMC Interface;;
 csgo-box;14004;csgobox;Csgo 箱子;CsgoBox;
 create-oppenheimered;14005;create-oppenheimered;机械动力：原子计划;Create: Oppenheimered;
 dimension-update-fixer;14006;dimensionupdatefixer;Dimension Update Fixer;;DUF
 dont-keep-vanishing-items;14007;dontkeepvanishingitems;Don't Keep Vanishing Items;;
-ore-processing-for-tfc;14008;tfcoreprocessing;群峦冶炼;Ore Processing for TFC;
+ore-processing-for-tfc;14008;tfcoreprocessing;Ore Processing for TFC;;
 creativepagejump;14009;creativepagejump;创造物品栏页码跳转;CreativePageJump;CPJ
 april-fools;14010;aprilfools;April Fools;;
 exmoxl;14011;exmoxl;极墨核心;exmoxl;
-;14012;when_the_parasite;寄染之时;When The Parasite;SRP:WTP
+;14012;parasite_era;寄染之时;The Parasite Era;SRP:TPE
 armortip;14013;armortip;Armortip;;
 true-herobrine;14014;true_herobrine;True Herobrine;;
 oam-by-choupiclou2007;14015;oreandmore,ore;Ore And More;;OAM
@@ -13773,8 +13753,8 @@ deeper-caves;14020;cavesanddepths;Deeper Caves;;
 ;14021;Aviancraft_Seriemas;鸟语星球_叫鹤目;Aviancraft: Seriemas (Terror birds & their relatives);
 ;14022;tinkers;匠魂3基岩版;Tinkers' Construct 3 Addon / Tinkers' Awakening;
 ;14023;modularwarfare;逃离我的世界;EscapeFromMinecraft;EFMC
-arborfirmacraft;14024;afc;ArborFirmaCraft;;AFC
-enchanting-with-tfc;14025;enchdesc;Enchanting With TFC;;
+arborfirmacraft;14024;afc;林海传说;ArborFirmaCraft;AFC
+enchanting-with-tfc;14025;enchanting_with_tfc;Enchanting With TFC;;
 tfc-vessel-tooltip;14026;tfcvesseltooltip;TFC Vessel Tooltip;;
 nether-gold-ore;14027;nethergoldore;Nether Gold Ore;;
 natural-nether-portals;14028;naturalnetherportals;Natural Nether Portals;;
@@ -13792,7 +13772,7 @@ hunger-plus;14039;hunger_plus;饥饿+;Hunger Plus;
 melee-ex-machina-meexma;14040;melee_ex_machina;Melee Ex Machina;;
 ;14041;swdheftpywaedf;对不起，我们没有充足的资金为您提供一只末影龙-1.18;Sorry We Don't Have Enough Funds To Provide You With An Ender Dragon in 1.18;swdheftpywaedf
 arc;14042;arc;Arc Lib;;
-amlib;14043;anmao.mc.amlib;AMLib;;
+cores;14043;cores,nws.mc.cores;Cores;;
 ;14044;jkvb;消失的方块;Vanishing Blocks;
 ;14045;citymod;我的城市;City Mod;CM
 too-hard-to-dig;14046;h2d;隐岩砥凿;Too Hard to Dig;
@@ -13807,26 +13787,4080 @@ crystalline-ender-eye;14054;c_ender_eye;晶化末影之眼;Crystalline Ender Eye
 ars-caelum;14055;ars_caelum;Ars Caelum;;
 elytra-chestplates;14056;elytra-chestplates;鞘翅之甲;Elytra Chestplates;
 variants-and-ventures;14057;variantsandventures;Variants & Ventures;;
-horseshoes;14058;;Horseshoes;;
+horseshoes;14058;horseshoes;马掌;Horseshoes;
 questlines;14059;questlines;Questlines;;
 endofherobrine;14060;endofherobrine;The End of Herobrine;;
 thirstcanteen;14061;thirstcanteen;口渴-水壶;ThirstCanteen;
-thaumic-energistics-extended-life-fork;14062;thaumicenergistics;Thaumic Energistics Extended Life Fork;;
+thaumic-energistics-extended-life-fork;14062;thaumicenergistics;神秘能源延续版分支;Thaumic Energistics Extended Life Fork;
 ;14063;SkillsSwitch;职业开关;Skills Switch;SS
-;14064;ymjb_login;界面登录;ymjblogin;
+;14064;ymjb_login;登录;ymjblogin;
 prehistoric-nature-decorations;14065;lepidodendron;Prehistoric Nature Decorations;;
 tinyfoes;14066;tinytabs;Tiny Foes;;
-pyradium;14067;lithium;Pyradium;;
-anvilcraft;14068;anvilcraft;铁砧工艺：原版科技;AnvilCraft;ANC
-tiny-mob-farm-remastered;14069;tinymobfarm;Tiny Mob Farm Remastered;;
-;14070;create_aquatic_ambitions;Create: Aquatic Ambitions;;
+pyradium;14067;;Pyradium;;
+anvilcraft;14068;anvilcraft;铁砧工艺：重力科技;AnvilCraft;ANC
+tiny-mob-farm-remastered;14069;tinymobfarm;迷你刷怪场：重制;Tiny Mob Farm Remastered;
+create-aquatic-ambitions;14070;create_aquatic_ambitions;Create: Aquatic Ambitions;;
 ffl-trinkets-compat;14071;ffl-trinkets-compat;FFL Trinkets Compat;;
 kaleidios-guns;14072;kaleidiosguns;Kaleidio's Guns;;
 mc-vr-playground;14073;mc_vr_playground;MC VR Playground;;
 cosmopolis-mod;14074;cosmopolis;Cosmopolis Mod;;
 caveopolis-mod;14075;caveopolis;Caveopolis;;
 flexipause;14076;flexipause;FlexiPause;;
-geysers;14077;geysers;Geysers;;
-;14078;;MOAR Enchantments;;
-;14079;;Lose Your Touch;;
+geysers;14077;geysers;间歇泉;Geysers;
+;14078;moar_enchantments;MOAR Enchantments;;
+;14079;lose_your_touch;Lose Your Touch;;LYT
 man-of-many-planes;14080;man_of_many_planes;Man of Many Planes;;
+caliber-lib;14081;caliberlib;Caliber Lib;;
+;14082;kriforfab;Kriforfab;;
+multiscoreboard;14083;multiscoreboard;MultiScoreboard;;
+;14084;minerally_me;Minerally Me!;;
+;14085;cover_them_in_armor;Cover Them In Armor;;CTIA
+jerotes-village;14086;jerotesvillage;Jerotes村庄;Jerotes Village;
+;14087;acd_nether;A Cold Day In The Nether;;
+;14088;translucencyfix;Translucency Fix;;
+create-ponder;14089;createponder;机械动力: 思索;Create Ponder;CP
+mopeds;14090;moped;Mopeds;;
+;14091;dr;药水注入;Drugged;DR
+advanced-shulkerboxes;14092;advanced-shulkerboxes;Advanced Shulkerboxes;;
+;14093;;Noodle World Generation Experiment;;
+;14094;mr_vanilla_stoneblock;Vanilla Stoneblock;;
+visible-shield-cooldown;14095;visible_shield_cd;可视化盾牌冷却;Visible Shield Cooldown;VSC
+mns-moogs-nether-structures;14096;mns;Moog's Nether Structures;;MNS
+bunker-down;14097;bunker_down;Bunker Down;;
+just-enough-guns;14098;jeg;Just Enough Guns;;JEG
+buildify;14099;buildify;Buildify;;
+;14100;bigglobe;Big Globe;;
+dragon-finder;14101;dragon-finder;Ice and Fire: Dragon Finder;;
+respackopts;14102;respackopts;Respackopts;;
+fortuitous-feasts;14103;dffeasts;Fortuitous Feasts;;
+monazite;14104;monazite;独居石;Monazite;
+music-control;14105;music_control;音乐控制;Music Control;
+stellarcore;14106;stellar_core;星核;StellarCore;
+;14107;cp;自定义Ping;CustomPing;CP
+ash-of-sin-custom-entity-attack-effect;14108;ash_of_sin_custom_entity_attack_effect;罪业余烬：自定义实体攻击状态效果;Ash Of Sin: Custom Entity Attack Effect;
+ash-of-sin-soul-like-boss-battle;14109;ash_of_sin_soul_like_boss_battle;罪业余烬：类魂BOSS战;Ash Of Sin: Soul Like Boss Battle;
+wh40kmc-project;14110;warhammer40kmod;Hammercraft 40k;;
+;14111;snowwaifu;雪の嫁;Snow Waifu;
+pixelmon-bank;14112;pixelmonbank;Pixelmon 银行;Pixelmon Bank;
+;14113;loose-litematica;Loosen Litematica;;
+wsmc;14114;wsmc;WSMC;;
+no-gui-chest;14115;noguichest;沉浸箱子;No Gui Chest;NGC
+;14116;mr_warden_withloot;Warden With Loot;;
+filedirector;14117;moddirector;File Director;;
+extra-compat;14118;extra-compat;Extra Compat;;
+eu-converter;14119;euconverter;EU Converter;;
+royal-variations;14120;royalvariations;Royal Variations;;
+;14121;probezs;ProbeZS;;
+temporal-api;14122;temporal-api;Temporal API;;
+;14123;defender,underworld_magic_craftsmanship;幽法工艺;Underworld Magic Craftsmanship;UMC
+;14124;mrblade;技术革新;TRblade;
+callable-horse-unofficial-fabric-port;14125;callablehorsefabric;召之马来 Fabric版;CallableHorse Unofficial Fabric port;
+;14126;bce;更好的战斗体验;Better Combat Experience;BCE
+shiny-horses-forge-enchantable-horse-armor;14127;shiny-horses-forge-enchantable-horse-armor;Shiny Horses Forge - Enchantable Horse Armor;;
+spartan-weaponry-simpleores;14128;spartansimpleores;斯巴达的武器：简单矿石;Spartan Weaponry: SimpleOres;
+;14129;jbplus;JointBlockPlus;;
+dye-depot;14130;dye_depot;Dye Depot;;
+;14131;pixelradar;宝可梦雷达;PixelRader;
+;14132;autoharvest;自动收获-重制;AutoHarvest-RE;
+;14133;nyan_cat_loading;Nyan Cat Loading;;
+homeward-bound;14134;homeward-bound;Homeward Bound;;
+sword-blocking-mechanics;14135;sword-blocking-mechanics;Sword Blocking Mechanics;;SB
+electric-mace;14136;electric-mace;Electric Mace;;
+mace-backport;14137;mace_backport;Mace Port;;
+;14138;steveeatstew;Steve Eat Stew;;
+imaginary;14139;imaginary;Imaginary;;
+kuvalich;14140;kuvalich;赤毒玄骸;KuvaLich;KL
+ae2-import-export-card;14141;ae2insertexportcard,ae2importexportcard;AE2 Import Export Card;;
+;14142;magick_experience;Magick Experience;;
+;14143;sz;超级变焦;SuperZoom;SZ
+;14144;repairable_disc_11;Repairable Disc 11;;
+;14145;structure_export;结构渲染导出;Structure Export;SE
+;14146;fabric-permissions-api-v0;Fabric Permissions API;;
+;14147;khinkalimod;Khinkali;;
+configured-defaults;14148;configured-defaults;Configured Defaults;;CD
+bens-sharks;14149;sharks,benssharks;Ben's Sharks;;
+;14150;equipset;装备预设;EquipSet;EQS
+torches-in-water;14151;torches_in_water;水中火把;Torches in Water;TiW
+;14152;olderskins;还原旧皮肤;OlderSkins;ODS
+;14153;cllb;区块渲染距离突破;ChunkLoadingLimitBreached;CLLB
+pigs-with-fireworks;14154;pigs_with_fireworks;Pigs with Fireworks;;
+infinityspell;14155;infinityspell;无限魔咒;InfinitySpell;IS
+multipart-machines-grinding;14156;mm_grinding;Multipart Machines: Grinding;;
+ash-of-sin-custom-anti-high-atk-entity;14157;ash_of_sin_custom_anti_high_atk_entity;罪业余烬：自定义反高攻击力实体;Ash Of Sin: Custom Anti High ATK Entity;
+;14158;;基洛的植物大战僵尸模组;Gero's Plants vs. Zombies Add-On;GPVZA
+;14159;bioforge;BioForge;;
+quad;14160;quad;Quad;;
+;14161;another;Another;;At
+;14162;rws;移除欢迎界面;RemoveWelcomeScreen;RWS
+;14163;badd;Boom++;;BA
+;14164;custom_boss_bar;自定义BOSS血条;Custom BOSS Bar;CBB
+;14165;cgmfix;CGM修复;CGMFix;
+makit-better;14166;makit_better;Makit Better;;MKB
+macaws-for-terrafirmacraft;14167;mcw_tfc_aio;All-In-One, Macaw's Mods for TerraFirmaCraft;;
+;14168;;考古幸运方块;;
+;14169;;史蒂夫在红白机;;
+;14170;muit;MusicIt;;
+;14171;blahaj-totem;Blåhaj of Undying;;
+corals-tfc;14172;coralstfc;Corals TFC;;
+tfc-aged-alcohol;14173;tfcagedalcohol;TFC Aged Alcohol;;
+tfc-improved-badlands;14174;tfcimprovedbadlands;TFC Improved Badlands;;
+;14175;russianmetro;Russian Metro Addon;;RMA
+winter-massacre;14176;winter-massacre;Winter Massacre;;
+ghostlys;14177;ghostly;幽灵;Ghostly;
+tectonic-tweak;14178;tectonic_tweak;Tectonic-Tweak;;
+forge-essentials-client;14179;forgeessentialsclient;Forge Essentials Client;;
+;14180;world-host;World Host;;
+;14181;letsimaginate;纸袋剧场！;Let's Imaginate!;
+spit-splat;14182;splat;唾溅兽;Spit Splat;
+maced;14183;maced;重锤一击;Maced;
+nether-villager-trader;14184;nether-villager-trader;Nether Villager Trader;;
+;14185;no-exp-enchanting-reimagined;NoExpEnchantingReimagined;;
+cadmus;14186;cadmus;Cadmus;;
+argonauts;14187;argonauts;Argonauts;;
+giacomos-travelogue;14188;giacomostravelogue;Giacomo's Travelogue;;
+giacomos-maps;14189;giacomos_maps;Giacomo's Maps;;
+descension;14190;descension;Descension;;
+;14191;treasure;财宝;Treasure;
+;14192;startup-time;启动时间;Startup Time;
+;14193;orikingcraft;未知之境:装饰品;OrikingCraft;sudeco
+;14194;littermanagement;掉落物管理;LitterManagement;LM
+toggledpickup;14195;toggledpickup;拾取控制;Toggled Pickup;
+farmers-delight-refabricated;14196;farmersdelight;农夫乐事：重织;Farmer's Delight Refabricated;
+village-nullifier-terralith-mod;14197;mr_village_nullifierterralith;Village Nullifier: Terralith;;
+village-nullifier-mod;14198;mr_village_nullifier;Village Nullifier;;
+structure-credits-fabric-version;14199;structurecredits;Structure Credits;;
+i-wanna-travel;14200;i_wanna_travel;i Wanna Travel;;IWT
+simple-unbreakable-tools;14201;gk_unbreakable;Simple Unbreakable Tools;;
+cat-loaf;14202;catloaf;Cat Loaf;;
+copper-tuff-backport-fabric;14203;copperandtuffbackport;Copper & Tuff Backport;;
+;14204;f3scale;F3Scale;;
+giacomos-teleport;14205;giacomos_teleport;Giacomo's Teleport;;
+giacomos-farmland;14206;giacomos_farmland;Giacomo's Farmland;;
+back-weapon-slot;14207;curiosbackslot;Back Weapon Slot;;
+chested-companions;14208;chestedcompanions;Chested Companions;;
+create-train-perspective-fix;14209;trainperspectivefix;Create: Train Perspective Fix;;
+create-metalwork-fabric;14210;createmetalwork;Create: Metalwork;;
+tragicmc;14212;TragicMC;悲惨世界1;TragicMC;
+auditory-continued;14213;auditory;Auditory Continued;;
+;14214;elb;附魔等级上限突破;EnchantmentLevelBreakthrough;ELB
+create-more-copycats;14215;create_more_copycats;Create: More Copycats;;
+farlands-reborn;14216;farlandsreborn;Farlands Reborn;;
+;14217;mangrove_ruins;Mangrove Ruins;;
+;14218;royge;Royge: Rainbow Dimension;;
+momento;14219;momento;Momento;;
+prometheus;14220;prometheus;Prometheus;;
+;14221;xb;喜报--;XiBao--;XB
+waystones-jawsawn-fork;14222;;传送石碑：Jawsawn版;Waystones Jawsawn Fork;
+nautilium-spirits;14223;nautilium_spirits;鹦鹉螺重置版;Nautilium Spirits;NS
+;14225;telluriumforge;TelluriumForge;;
+aquatweaks;14226;AquaTweaks;水下微调;AquaTweaks;
+aquatweaks-compat;14227;aquatweakscompat;水下微调：兼容;AquaTweaks Compat;
+;14228;potionsreglint;Potions Re-Glint;;
+simpletextoverlay;14229;simpletextoverlay;Simple Text Overlay;;
+bountiful-fares;14230;bountifulfares;丰饶食记;Bountiful Fares;
+;14231;ancient_debris_tweak;远古残骸微调;Ancient Debris Tweak;ADT
+;14232;milk-bottle;牛奶瓶;Milk Bottle;
+;14233;wauslt;？话说好好能不能;shiT ekiL gnikaepS U erA yhW;WAUSLT
+crydolph;14234;crydolph;Crydolph;;
+anti-id-conflict;14235;antiidconflict;反ID冲突;Anti Id Conflict;AIC
+confighelper;14236;confighelper;配置助手;config helper;
+better-boat;14237;betterboat;更好的船;Better Boat;
+weighted-inventories;14238;weighted_inventories;物品栏重量;Weighted Inventories;
+detected-setblock-be-gone;14239;dsbg;Detected setBlock Be Gone;;DSBG
+;14240;Hexical;Hexical;;
+tabula-minecraft-modeler;14241;tabula;Tabula;;
+glow-sticks;14242;glow_sticks;荧光棒;Glow Sticks;
+alt-hud;14243;althud;Alt HUD;;
+;14244;lmrebellion;LittleMaidRebellion;;
+furniture-expanded;14245;furnitureexpanded;Furniture Expanded;;
+celestora;14246;celestora;Celestora;;
+geckolib-unofficial-1-7-10;14247;;Geckolib：非官方版;Geckolib-Unofficial;
+cnpc-custom-model-addon;14248;npcgecko;自定义NPC+： Gecko 附属;CNPC+ Gecko Addon;
+cnpc-armorers-workshop-addon;14249;npcaw;自定义NPC+ ：时装工坊附属;CNPC+ Armorer's Workshop Addon;
+;14250;mr_bearedit;BearEdit;;
+fusion-smithing;14251;fusion-smithing;融锻;Fusion Smithing;FS
+leos-loot-bag;14252;loot-bag;战利品袋;Loot Bag;LB
+adventure-dimensions;14253;advdims;冒险维度;Adventure Dimensions;
+simple-dimensions;14254;simpledimensions;简单维度;Simple Dimensions;
+portals-gui;14255;portalsgui;传送门GUI;Portals Gui;
+interworlds-splashscreens;14256;template;进入维度加载界面;Interworlds Splashscreens;
+;14257;creativemenutweaks;Creative Menu Tweaks;;
+vampires-delight;14258;vampiresdelight;Vampire's Delight;;
+thats-my-bed;14259;thatismybed;That's My Bed!;;
+caligo;14260;caligo;Caligo;;
+;14261;sharpened_swords;Sharpened Swords;;
+;14262;yuzukitools;YuzukiTools;;
+donut-and-mochi;14263;donutmod;Donut and Mochi;;
+ducky;14264;ducky;Ducky;;
+lost-idols;14265;lost-idols;Lost Idols;;
+simple-trashcan;14266;simple_trashcan;Simple Trashcan;;
+darwin-water-ambience;14267;watermod;Darwin Water Ambience;;
+decorative-wooden-lattices;14268;decorativewoodenlattices;Decorative Wooden Lattices;;
+apotheotic-additions;14269;apotheotic_additions;Apotheotic Additions;;
+lithosphere;14270;welded_;Lithosphere;;
+;14271;futurecommands;未来指令;Future Commands;
+build-your-campfire;14272;better_campfires;Build Your Campfire;;
+biome-decoration-fix;14273;alreadydecoratingfix;Biome Decoration Fix;;
+simply-tools;14274;simplytools;Simply Tools;;
+immersive-snowgen;14275;immersivesnow;沉浸式雪生成;Immersive Snowgen;ISg
+the-wandering-gambler;14276;the_wandering_gambler_ii;The Wandering Gambler;;
+cheatdetector;14277;cheatdetector;作弊检测器;CheatDetector;CD
+just-another-spawner;14278;JustAnotherSpawner;Just Another Spawner;;JAS
+stack-size-edit-fabric;14279;stacksizeedit;Stack Size Edit;;
+;14280;remoteresourcepack;远程资源包;Remote Resource Pack;RRP
+;14281;luckydraw;幸运彩券;Lucky Draw;
+battery-shield;14282;battery_shield;电池护盾;Battery Shield;
+giacomos-chat-fix;14283;giacomos_chat_fix;Giacomo's Chat Fix;;
+giacomos-compass;14284;giacomoscompass;Giacomo's Compass;;
+giacomos-experience-drainer;14285;giacomos_experience_bottler;Giacomo's Experience Bottler;;
+;14286;frank;Frank;;
+load-my-resources-forge;14287;loadmyresources;Load My Resources;;LMR
+apotheotic-creation;14288;apotheoticcreation;Apotheotic Creation;;
+;14289;seared_furnace_calculator;匠魂计算器;Seared Furnace Calculator;
+;14290;nature;Nature's Spirit Addon;;
+eiorecipesteinductionsmelter;14291;eiorteis;EIORecipesTEInductionSmelter;;
+;14292;rit;随机物品名称;RandomItemText;RIT
+ash-of-sin-better-ai;14293;ash_of_sin_better_ai;罪业余烬：更好的AI;Ash Of Sin: Better AI;
+dimensional-cake-rebuilt;14294;dimensionalcake;Dimensional Cake Rebaked;;
+medieval-village-dimension;14295;lostworldsmpmod;Medieval Village Dimension;;
+create-big-contraptions;14296;bigcontraptions;Create: Big Contraptions;;
+;14297;forgelin;GTNH's Forgelin;;
+rose-gold-equipment;14298;rosegoldequipment;Rose Gold Equipment;;
+;14299;mr_qraftys_mangrovevillages;qrafty's Mangrove Villages;;
+pantheonsent;14300;pantheonsent;PantheonSent;;
+;14301;yukkuri;Touhou Yukkuri;;
+;14302;asrp;反服务器资源包加载;AntiServerResourcesPack;ASRP
+;14303;icc;无限聊天字符长度;InfinityChat;IC
+;14304;moddetectionpreventer;Mod Detection Preventer;;
+dramatic-spawning;14305;dramatic_spawning;Dramatic Spawning;;
+all-mobs-attack-villagers;14306;allmobsattackvillagers;All Mobs Attack Villagers;;
+cicada;14307;cicada;CICADA;;
+;14308;yxxq;圆形星球;yxxq;
+immersive-cvm;14309;immersive_cvm;Immersive CVM;;
+no-gui-fd;14310;noguifd;沉浸乐事;No Gui FD;NGFD
+custom-credits;14311;customcredits;Custom Credits;;
+fishing-life;14312;fishinglife;钓鱼生活;FishingLife;
+;14313;vanilla_craft;Zyx的随意之作;Zyx's Random Creation;ZRC
+;14314;cca;Crystal Carpet Addition;;CCA
+hoes-are-scythes;14315;hoes-are-scythes;Hoes Are Scythes;;
+;14316;pehkuirandomsize;PehkuiRandomSize;;
+chat-ping;14317;chatping;Ping!;;
+;14318;lance;骑枪;Lance Mod;
+damage-number;14319;damage_number;伤害数字显示;Damage Number;
+;14320;jkat;关于传送;About Teleport;jkat
+mineshot-reforged;14321;mineshotreforged;高清截图Forge;Mineshot Reforged;
+krysztal-language-scala;14322;krysztal-language-scala;Krysztal's Language Scala;;KLS
+filters-api;14323;filters;Filters API;;
+;14324;ibs;虫蚀方块;InfestedBlocks;IBS
+flavored;14325;flavored;Flavored;;
+huesodewiki;14326;huesodewiki;HuesoDeWiki / Wiki Bone;;
+platos-transporters;14327;platos;Plato's Transporters;;
+plushie-reeker-mod;14328;lil_reeker_mod;Plushie Reeker;;
+semi-hardcore;14329;semihardcore;Semi-Hardcore;;
+placeables;14330;placeables;Placeables;;
+bigbanana;14331;bigbanana;🍌大香蕉🍌;BigBanana;BB
+;14332;dabaosword;大宝刀;DabaoSword;
+look-eye-of-cthulhu;14333;look;Look;;
+;14334;salmonberryaddition;Salmonberry Addition;;
+pet-collecting;14335;petcollecting;Pet Collecting;;
+;14336;yummyglass;Yummy Glass;;
+repurposed-structures-biome-makeover-compat;14337;;结构变体：生物群系改造兼容数据包;Repurposed Structures - Biome Makeover Compat Datapack;
+totallybalancedfallflying;14338;tbff;Totally Balanced Fall Flying;;
+giacomos-experience-seedling;14339;giacomos_exp;Giacomo's Experience Seedling;;
+;14340;server-notify;Server Notify;;
+config-api;14341;configapi;Config API;;
+nethers-delight-refabricated;14342;nethersdelight;下界乐事：重织;Nethers Delight Refabricated;
+;14343;pumpkin_pie;Pumpkin Pie Delight;;
+tipsylib;14344;tipsylib;TipsyLib;;
+dragon-mounts-more-dragons;14345;moredragons;龙骑士附属：更多龙;Dragon Mounts: More Dragons;
+repurposed-structures-sawmill-compat;14346;;结构变体：锯木机兼容数据包;Repurposed Structures - Sawmill Compat Datapack;
+repurposed-structures-irons-spells-n-spellbooks;14347;;结构变体：Iron's Spells 'n Spellbooks 兼容数据包;Repurposed Structures - Iron's Spells 'n Spellbooks Compat;
+hey-wiki;14348;heywiki;嘿Wiki;Hey Wiki;
+turf;14349;turf;Turf;;
+ad-extendra;14350;ad_extendra;Ad Extendra;;
+smava;14351;smava;Smava Creepers;;
+zwieback;14352;zwieback;Zwieback;;
+random-respawn;14353;randomrespawn;Random Respawn;;
+;14354;telluriumsrandomstuff;Tellurium's Random Stuff;;
+per-aspera;14355;per_aspera;Per Aspera;;
+spice-of-life-valheim-edition;14356;sol_valheim;Spice of Life: Valheim Edition;;
+tfc-paths;14357;tfcpaths;TFC Paths;;
+binkers-bonstruct;14358;tconstruct;Binkers' Bonstruct for TFC;;
+ranged-weapon-api;14359;ranged_weapon_api;Ranged Weapon API;;
+numismatics;14360;numismatics;Create: Numismatics;;
+;14362;sleepatease;安心睡觉;SleepAtEase;SAE
+canned-foods-and-drinks;14363;cannedfoodanddrinks;Canned Foods and Drinks;;
+alexs-caves-dimension;14364;alexscavesdimension;Alex's Caves Dimension;;
+villager-contracts;14365;villagercontracts;Villager Contracts;;
+better-agriculture;14366;betteragriculture;Better Agriculture;;
+soul-shards-respawn-patched;14367;soulshardsrespawn;Soul Shards Respawn Patched;;
+tfc-finger-in-the-wind;14368;fitw;TFC Finger In The Wind;;
+immersive-craft-patched;14369;immcraft;Immersive Craft Patched;;
+jockeys;14370;jockeys;Spooky Scary Jockeys;;
+disguiselib;14371;disguiselib;DisguiseLib;;
+;14372;mrp;MTR 资源包保护工具;MTR Resource Protector;MRP
+station-architecture;14373;project_xena;Station Architecture / Project Xena;;
+;14374;jqcity;界秋城建;Jie Qiu Urban construction;JQUC
+enchantmentrequirements;14375;enchantmentrequirements;Enchantment Requirements;;
+enchantment-enhancements;14376;enchantment_enhancements;Enchantment Enhancements;;
+mo-enchantments;14377;enchantments_plus;Mo' Enchantments;;
+soul-like-enchantment;14378;soullike_enchantment;soul-like enchantment: new weapon enchants;;
+;14379;gravityfix;Gravity Fix;;
+;14380;blockbench-import-library;Blockbench Import Library;;
+mrcrayfish-furniture-mod-legacy;14381;cfm;MrCrayfish's Furniture Mod Legacy;;
+btfixes;14382;btfixes;Battle Towers Fixes;;
+vmfixes;14383;vmfixes;VM Fixes / VoxelMap Fixes;;
+pillar-patched;14384;pillar;Pillar Patched;;
+novalogin;14385;novalogin;新星登录;Nova Login;NL
+tfc-desire-paths;14386;tfcdesirepaths;TFC Desire Paths;;
+tfc-ore-washing;14387;tfcorewashing;TFC Ore Washing;;
+tfc-canes;14389;tfccanes;TFC Canes;;
+lhmob-difficulty-increase;14390;lhmobdifficultyincrease;变强的怪物;LH Mob Difficulty Increase;
+;14391;zombiesarereal;Zombies Are Real Reforged;;
+from-the-shadow-reborn;14392;fromtheshadows;From The Shadows Reborn;;
+;14393;life-crystals;Life Crystals;;
+;14394;awakened_creeper;苦力怕觉醒了;AwakenedCreeper;
+the-slumbering-omen;14395;the_slumbering_omen;沉睡的预兆;The Slumbering Omen;
+;14396;advanced_equip;进阶刀剑;AdvancedEquip;AE
+;14397;more_weapons;武器多样化;More Weapons;
+ftb-guides-forge;14398;ftbguides;FTB Guides;;
+;14399;titanium;钛;Titanium;
+caelum;14400;caelum;Caelum;;
+clearspam;14401;clearspam;ClearSpam;;
+ad-astra-rocketed;14402;ad_astra_rocketed;Ad Astra: Rocketed;;
+soulbound-quilt;14403;soulbound;Soulbound;;
+tinyinv;14404;tinyinv;TinyInv;;
+animationjs;14405;animationjs;AnimationJS;;
+raids-backport;14406;raids;Raids Backport;;
+crossbows-backport;14407;crossbows;Crossbows Backport;;
+tfc-caelum;14408;tfccaelum;TFC Caelum;;
+epic-compat-parcool;14409;epiccompat_parcool;Epic Compat: ParCool;;
+loqui;14410;loqui;Loqui;;
+real-worlds;14411;real_worlds;Real Worlds;;
+;14412;ba;Bilibili音频;BilibiliAudio;BA
+dragonlib;14413;dragonlib;DragonLib;;
+andromeda;14414;andromeda;群星;Andromeda;AM
+;14415;awakened_phantom;幻翼觉醒了;AwakenedPhantom;
+;14416;superauth;超级授权;SuperAuth;
+mobdisguises;14417;mobdisguises;MobDisguises;;
+inventory-generators;14418;inventorygenerators;Inventory Generators;;
+creating-space-gravity-addon;14419;creating_space_gravity_addon;Creating space gravity addon;;
+alexs-caves-torpedoes;14420;alexs_caves_torpedoes;Alex 的洞穴：物品 & 鱼雷;Alex's Caves: Stuff & Torpedoes;
+;14421;passivesystemskill;被动熟练度系统;Passive System Skill;PSS
+;14422;pillow;枕头模组加载器;Pillow Mod Loader;
+;14423;slaviccuisine;Slavic Cuisine;;
+tfc-tumbleweed;14424;tfc_tumbleweed;TFC Tumbleweed;;
+tfc-barrens;14425;tfcbarrens;TFC Barrens;;
+chiselse-bits-for-tfc;14426;chiselsandbits_tfc;Chisels & Bits for TFC;;
+tfc-fresh-water-everywhere;14427;tfcfreshwatereverywhere;TFC Fresh Water Everywhere;;
+tfc-more-swords;14428;tfckatana;TFC More swords;;
+galleria;14429;galleria;Galleria;;
+constructs-casting;14430;constructs_casting;Construct's Casting;;
+tinkers-innovation;14431;tinkersinnovation;工匠创新;Tinkers' Innovation;TI
+;14432;weirdoenchantmaster;古怪附魔师;;
+delicious-delights;14433;deliciousdelights;Delicious Delights;;
+;14434;vietnamsdelight;Vietnam's Delight;;
+harvest-tweaks;14435;harvesttweaks;Harvest Tweaks;;
+decay-2012;14436;decay_2012;Decay 2012;;
+tfc-grooming-station;14437;tfcgroomer;TFC Grooming Station;;
+terrafirmagregtech-ores;14438;tfg_ores;TerraFirmaGregTech - Ores;;
+blaze-map;14439;blazemap;Blaze Map;;
+epic-knights-japanese-armory;14440;epic_knights__japanese_armory;Epic Knights : Japanese Armory;;
+tfcpyros-adjustedgen;14441;tfcpyros_adjustedgen;TFCPyros-AdjustedGen;;
+astikor-carts-tfc-florae;14442;astikorcartstfcf;Astikor Carts TFC Florae;;
+exp-counter-fabric-forge-neoforge;14443;expcounter;EXP Counter;;
+lightwithin;14444;lightwithin;LightWithin;;
+the-slenderman-mod;14445;slendermod;The Slenderman Mod;;
+flanchanmod;14446;flanchanmod;Cute Flanchan !!;;
+;14447;awakened_spider;蜘蛛觉醒了;Awakened Spider;
+cartography;14448;cartography;Cartography;;
+laser-bridges-doors;14449;laserbridges;Laser Bridges & Doors;;
+lukis-grand-capitals;14450;l_g_c;Luki's Grand Capitals;;
+fabric-create-netherless;14451;create_netherless;Create: Netherless (Fabric);;
+create-connected-fabric-experimental;14452;create_connected;Create: Connected Fabric;;
+;14453;antiquecities;Antique Cities;;
+wastify;14454;wastify;Wastify;;
+starter-structure;14455;starterstructure;初始建筑;Starter Structure;
+;14456;safety_backpack;安全背包;Safety Backpack;
+mobblocker;14457;mobblocker;MobBlocker;;
+giacomos-foundry;14458;giacomos_foundry;Giacomo's Foundry;;
+;14459;blocky_bass;Blocky Bass;;
+;14460;toms_mobs;Tom's Mobs;;
+;14461;homoium;Homoium;;
+alex-cave-addon;14462;alex_cave_addon;Alex Cave Addon;;
+;14463;enchanting;妙手偶得;Enchanting;
+;14464;awakened_enderman;末影人觉醒了;AwakenedEnderman;
+iced-lava;14465;iced_lava;Iced Lava;;
+fabric-core-mods;14466;gud_fcm;Fabric Core Mods;;FCM
+the-tropics-telepastry;14467;tropics_telepastry;The Tropics TelePastry;;
+carrot-apple;14468;carrotapple;胡萝卜苹果;Carrot Apple;
+baked-delight;14469;bakeddelight;烘烤乐事;Baked Delight;
+create-basic-additions;14470;create_basic_additions;Create Basic Additions;;
+horse-stats-and-more;14471;giacomos_horse_stats;Horse Stats and More / Giacomo's Horse Stats Mod;;
+giacomos-hud-overlays-configurator;14472;giacomos_hud_conf;Giacomo's HUD Overlays Configurator;;
+giacomos-map-coloring;14473;giacomos_map_coloring;Giacomo's Map Coloring;;
+ec-epic-fight-compat;14474;ec_ef_plugin;EC Epic Fight Compat;;
+easy-npc-epic-fight;14475;easy_npc_epic_fight;Easy NPC - Epic Fight;;
+puffish-attributes;14476;puffish_attributes;Pufferfish's Attributes;;
+pufferfishs-unofficial-additions;14477;pufferfish_unofficial_additions;Pufferfish's Unofficial Additions;;
+smart-completion;14478;smartcompletion;Smart Completion;;
+additional-attributes;14479;additional_attributes;Additional Attributes;;
+;14480;hexed;Hexed;;
+;14481;mordenwindows;现代窗户;;MW
+;14482;elainalike;魔女之绘：重生;ElainalikeReborn;
+;14483;exnihilodraconicextendo;无中生有：传承 - 龙之研究扩展;ExNihilo-Draconic-Extend;ENDE
+suicide-key;14484;suicide_key;Suicide Key;;
+;14485;tfcaf;群峦自动锻造;TFCAutoForging;TFCAF
+uranus;14486;uranus;Uranus;;
+annotationlib;14487;annotation_lib;AnnotationLib;;
+;14488;waxed;Waxed;;
+nether-overload;14489;netheroverload;Nether Overload;;
+ender-relay;14490;ender_relay;Ender Relay;;
+enchanted-effects;14491;enchantedeffects;Enchanted Effects;;
+emi-create-schematics;14492;emi_create_schematics;EMI: Create Schematics;;
+the-silence;14493;the_silence;The Silence;;
+infinite-music-fabric;14494;infinite-music;Music Delay Remover (Infinite Music);;
+kakapos;14495;kakapos;Kakapos;;
+;14496;tomereader;Tome Reader;;
+scary-creepers;14497;scary-creepers;Scary Creepers;;
+;14498;show-my-skin-parts;Show My Skin Parts;;
+sn0wfrogs-capybaras;14499;sn0wfrogs_capybaras;Sn0wfrog's Capybaras;;
+enemybanner;14500;enemybanner;敌怪旗;EnemyBanner;
+;14501;obitoblade;拟态;Mimetic;
+souls-egg;14502;soulsegg;Souls Egg;;
+barely-enough-enchantments;14503;barelyenoughenchantments;Barely Enough Enchantments;;BEE
+tool-kit;14504;toolkit;Tool Kit;;
+;14505;filament;Filament;;
+lijms-armory;14506;lijms_armory;Lijm's Armory;;
+tinker-delight;14507;tinkersdelight;Tinkers Delight;;
+barbeques-delight;14508;barbequesdelight;烧烤乐事;Barbeque's Delight;
+coffeecraft-by-blockbrothers;14509;coffeecraft;CoffeeCraft;;
+hearty-meals;14510;heartymeals;Hearty Meals;;
+;14511;mincar_drill;Minecar Drill;;
+;14512;;放置器、破坏器与旋转器;Placer, Breaker and Rotator;PBR
+enderfake;14513;enderban;Enderfake;;
+;14514;always-online;Always Online;;
+;14515;guide_to_afterlife;蝶火燎原;Guide to Afterlife;
+;14516;awakened_silverfish;蠹虫觉醒了;AwakenedSilverfish;
+rawore-on-1-12-2;14517;suikerawore;1.12.2的粗矿;rawOre_on_1.12.2;
+entityjs;14518;entityjs;EntityJS;;
+poem-of-star-wars;14519;poemofstarwars;Poem o' Star Wars;;PoSW
+;14520;portalhexaddon;Hex Ways;;
+vanity-aesthetic-armory;14521;vanity_aesthetic_armory;Vanity: Aesthetic Armory;;
+;14522;muffins_thaidelight;Muffin's Thai's Delight;;
+;14523;more-useful-copper;更有用的铜;MoreUsefulCopper;MUC
+;14524;did;迷宫饭;Delicious In Dungeon;DID
+animals-plus;14525;animals_plus;Animals Plus;;
+giacomos-map-merging;14526;giacomos_map_merging;Giacomo's Map Merging;;
+giacomos-spyglass-10-90x15;14527;giacomos_spyglass;Giacomos Spyglass 10-90x15;;
+exquisite-packing;14528;exquisite_packing;精致包装;Exquisite Packing;
+;14529;la_cucaracha;La Cucaracha;;
+grieflogger;14530;grieflogger;GriefLogger;;
+;14531;BGD;贝爷数据包;BearGryllsDatapack;BGD
+the-quest-of-entity-303;14532;entity_303;The Quest of Entity 303;;
+pineapple-mending;14533;mending;经验修补：凤梨版;Pineapple Mending;
+;14534;quick_chat;快捷聊天;Quick Chat;
+magic-vibe-decorations;14535;magic_vibe_decorations;Magic Vibe Decorations;;
+valentines-blessing;14536;valentines_blessing;Valentine's Blessing;;
+decent-biomes;14537;decent_biomes;Decent Biomes;;
+d-placeable-food-fabric-forge;14538;placeable_food;3D Placeable Food;;
+fan-shaped-cake;14539;fanshapecake,fan_cake;Fan-shaped cake;;FSC
+bitter-brews;14540;bitter_brews;Bitter Brews;;
+richards-coffee-tea-mod;14541;teamod;Richard's Coffee and Tea Mod;;
+ribes-adventures;14542;ribes_adventures;Ribes Adventures;;
+;14543;invisiblekeybinding;隐藏按键绑定;Invisible Key Binding;
+;14544;cell;Cell (Vanilla+);;
+packed-up;14545;packedup;Packed Up;;
+hexcircus;14546;hex_circus;HexCircus;;
+diamond-chest-shops;14547;diamondchestshop;Diamond Chest Shops;;
+armor-stand-poses-datapack;14548;armor_stand;Armor Stand Poses;;
+better-clouds-reforged;14549;betterclouds;Better Clouds Reforged;;
+excessive-building;14550;excessive_building;Excessive Building;;
+modchu_modchulib;14551;modchulib;ModchuLib;;
+;14552;samhackers_command_gui;SamHacker's Command GUI;;
+no-slime-in-flat-world;14553;noslime_inflat_world;No Slime In Flat World;;
+icarae-origin;14554;icarae_origin;Icarae Origin;;
+;14555;pokecycles;Pokecycles;;
+;14556;consoles;Gaming Consoles;;
+;14557;clkx;翠翎恐蕈;Jadeplume Terrorshroom;JT
+fsit;14558;fsit;FSit;;
+carbon-config;14559;carbonconfig;Carbon Config;;
+productivetrees;14560;productivetrees;Productive Trees;;
+;14561;tsa-concrete;Toms Server Additions: Concrete!;;
+;14562;tsa-planks;Toms Server Additions: Planks!;;
+;14563;tsa-stone;Toms Server Additions: Stone!;;
+stellarview;14564;stellarview;Stellar View;;
+biome-cows;14565;biome_cows_;Biome Cows;;
+simple-stopwatch;14566;giacomos_stopwatch;Simple Stopwatch / Giacomos Stopwatch Mod;;
+liolib;14567;liolib;LioLib;;
+giacomos-better-dye;14568;giacomos_better_dye;Giacomo's Better Dye;;
+ash-of-sin-custom-anti-trap-cage-entity;14569;ash_of_sin_custom_anti_trap_cage_entity;罪业余烬：自定义反捕捉笼实体;Ash Of Sin: Custom Anti Trap Cage Entity;
+elementus;14570;elementus;Elementus;;
+dedicated-bud;14571;budchevsky;Dedicated BUD;;
+;14572;barrierfree;巧渡障碍;Barrier Free;
+vanity-twilight-zone;14573;vanity_twilight_zone;Vanity：晨昏线;Vanity: Twilight Zone;
+tfc-barrels;14574;tfcbarrels;TFC Barrels;;
+melter;14575;melter;Melter;;
+armour;14576;armorplusplus;Armour++;;
+speedometer-and-more;14577;giacomos_speedometer;Speedometer and More / Giacomos Speedometer Mod;;
+ash-of-sin-anti-same-modifier;14578;ash_of_sin_anti_same_modifier;罪业余烬：反重复修饰符;Ash Of Sin: Anti Same Modifier;
+giacomos-automatable-cauldrons;14579;giacomos_automatable_cauldrons;Giacomo's Automatable Cauldrons;;
+giacomos-bookshelf;14580;giacomos_bookshelf;Giacomo's Bookshelf;;
+no-outbreaks;14581;no_outbreaks;No Outbreaks!;;
+nemos-woodcutter;14582;nemos-woodcutter;Nemo's Woodcutter;;
+command-button;14583;commandbutton;Command Button;;
+;14584;vmr;Vape管理器：重生;VapeManagerReborn;VMR
+;14585;paleozoic;是你先开的;You cheated first;
+;14586;hallelugw;哈利路大旋风;Hallelu the Grand Whirlwind;
+exp-ore;14587;expore;经验矿石;Exp Ore;
+;14588;hexpigmentplus;Hex Pigment Plus;;
+starcrop;14589;starcrop;Star Crop;;
+the-social;14590;thesocial;The Social;;
+;14591;;炼狱模式;Infernum Mode;
+goety-mythical-addon;14592;goety_ut;Goety Mythical Addon;;
+huge-structure-blocks;14593;hugestructureblocks;Huge Structure Blocks;;HSB
+;14594;mr_calamity_mc;Calamity MC;;
+bodyhygiene;14595;bodyhygiene;BodyHygiene;;
+cafes-birding;14596;cafesbirding;Café's Birding;;
+kafs-valentine-special;14597;kafvalentine;Kaf's Valentine Special;;
+create-deepfried;14598;create_deepfried;机械动力：油炸;Create: Deepfried;
+sleepable-create;14599;sleepable_create;Sleepable Create;;
+create-railways-navigator;14600;createrailwaysnavigator;机械动力：铁路导航;Create Railways Navigator;CRN
+speed-drifter;14601;mcspeed;MC飞车;MCSpeed;MCS
+;14602;donothitme;好好挖矿，不要给我一镐子;DoNotHitMe;
+rearmour;14603;rearmour;REArmour++;;
+lionfish-api;14604;lionfishapi;Lionfish API;;
+;14605;thinker;沉思者;Thinker;
+avaritia-universal;14606;avaritia;Avaritia Universal;;
+slash-blade-tweaker;14607;slashbladetweaker;Slash Blade Tweaker;;
+guns-without-roses-additions;14608;gunswithoutrosesadditions;Guns Without Roses Additions;;
+cleanview;14609;cleanview;CleanView;;
+built;14610;built;Built;;
+diyotweaks;14611;DiyoTweaks;DiyoTweaks;;
+extra-spell-attributes;14612;extraspellattributes;Extra RPG Attributes;;
+;14613;createcontraptioncreatures;Create : Contraption Creatures;;
+immersive-vehicles-iv-mts-texel-arsenal-pack;14614;ma_c,ma_d,ma_m,ma_p;SMZ TexelWorks;;
+creature-whisperer;14615;cw;Creature Whisperer;;CW
+;14616;spelling_and_crafting;魔法字母;Spelling and Crafting;
+;14617;fn;FullBright;;FB
+create-molten-metals;14618;molten_metals;Create: Molten Metals;;
+create-optical;14619;create_optical;机械动力：光学;Create Optical;
+;14620;farmersdelightplus;Farmer's Delight: Plus;;
+;14621;flintloader;Flint Loader / Punch;;
+;14622;autorespawn;自动重生;AutoReSpawn;
+;14623;more_difficult_diving;更困难的潜水;More Difficult Diving;
+mob-battle-music;14624;mobbattlemusic;战斗音乐;Mob Battle Music;
+concerto;14625;concerto;协奏曲/一起听;Concerto;
+;14626;loadingtipsfixer;LoadingTipsFixer;;
+;14627;iff;Invisible Frames for Forge;;IFF
+factions-and-curiosities;14628;fnc;派系与奇遇;Factions And Curiosities;FNC
+;14629;anyfps;anyfps;;
+create-amazing-trading;14630;amazingtrading;Create: Amazing Trading;;
+;14631;release_these_fish;放生;Release These Fish!!!;
+;14632;inficraft;InfiCraft;;
+westeroscraft-worldeditcui;14633;worldeditcui;WesterosCraft WorldEditCUI;;
+;14634;ef;ElytraFly;;EF
+durability-display;14635;duradisplay;Durability Display;;
+hardrock-samples-tfc;14636;hardrock_samples;Samples TFC;;
+;14637;invhud_configurable;物品栏HUD+ 药水显示支持;InvHUD_Configurable;
+;14638;viaforgeplus;ViaForgePlus;;
+modern-multitools;14639;mr_modern_multitools;现代化多功能工具;Modern Multitools;
+treps-cars;14640;trepscars;Trep's Cars;;
+;14641;rs;重生！;Respawn!;RS
+back-up-beds;14642;backupbeds;Back Up Beds;;
+;14643;fc;FreeCam;;FC
+;14644;walksycrystaloptimizer;WalksyCrystalOptimizer;;
+;14645;supersnail;知乎蜗牛の奇妙冒险;Super_Snail;
+;14646;dc;简单交互性装饰模型支持库;Deco Creater kit;dc
+;14647;hc_enchanted_food;附魔食物;Enchanted Food;
+mountain-sea-and-continent-two;14648;shanhaicontinent;山海大陆2;Mountain Sea and Continent Two;SeaM
+;14649;lmxxc;雷鸣修仙录;;
+vinery-tfc;14650;vinery_tfc;Vinery TFC;;
+tkbs-campfires;14651;tkbscampfires;TKBS-CampFires;;
+;14652;symbiogen;共生基因;symbiogen;sbg
+whispers-of-the-wendigo;14654;whispers_of_the_wendigo;Whispers of the Wendigo;;
+quartz-elevator;14655;quartzelv;Quartz Elevator;;
+elytra-utilities;14656;elytrautilities;Elytra Utilities;;
+davids-furniture;14657;davids_furniture;大卫的家具;David's Furniture;DF
+kubejs-natures-aura;14658;kubejs_naturesaura;KubeJS Nature's Aura;;
+fancymenu-system-interactions-addon;14659;fmsia;FancyMenu System Interactions Addon;;FMSIA
+control-engineering;14660;controlengineering;Control Engineering;;
+wooden-furnace-fabric;14661;woodenfurnace;Wooden Furnace;;
+jjthunder-to-the-max;14662;jjthunder_to_the_max;JJThunder To The Max;;
+telepass;14663;telepass;Telepass;;
+offhandbanning;14664;offhandbanning;禁手令;Off Hand Banning;
+fantasy-craft;14665;fantasycraft;幻想工艺;FantasyCraft;FC2
+breeding-potion;14666;breedingpotion;繁殖药水;Breeding Potion;BP
+;14667;servux;ServuxForged;;
+loading-tips;14668;tips;加载提示;Loading Tips / Pineapple Tips;
+;14669;higher_nether;更高的下界;Higher Nether;
+better-one-block;14670;oneblock;更好的单方块;Better One Block;
+the-fletching-table-mod;14671;the_fletching_table_mod;The Fletching Table Mod;;
+;14672;create_militarized;Create Militarized;;
+customemoji;14674;customemoji;自定义表情;CustomEmoji;CEMO
+sword-soaring;14675;sword_soaring;史诗战斗：御剑飞行;Epic Fight - Sword Soaring;
+bigger-ae2;14676;bigger_ae2;Bigger AE2;;
+scalar;14677;scalar;Scalar;;
+trials-towers;14678;trails;Trials Chambers;;
+blus-sign-pack-mts-iv;14679;blussignpack;Blu's Sign Pack [MTS/IV];;
+alexs-mediumcore;14680;mediumcore;Mediumcore;;
+sherdsapi;14681;sherdsapi;Sherds API;;
+;14682;kontraption;Kontraption;;
+musketeer-illager;14683;musketeer_illager;Musketeer Illager;;
+;14684;hyjg_bag_extend_system;超大容量背包;;
+daker-acg;14685;daker_acg;Daker ACG工艺;DakerACG;
+bananarangs;14686;bananarangs;Bananarangs;;
+remorphed;14687;remorphed;Remorphed;;
+particle-core;14688;particle_core;Particle Core;;
+fermiumbooter;14689;fermiumbooter;FermiumBooter;;
+ytech;14690;ytech;YTech;;
+;14691;betterbiomeblend;Better Biome Reblend;;
+mcterra;14692;mcterra;MCTerra;;
+siren-head-the-arrival;14693;siren_head;Siren Head: The Arrival (Beta);;
+classic-musical-discs;14694;classic_musical_discs;Classic musical discs;;
+music-notification;14695;musicnotification;Music Notification;;
+orechidendium;14696;orechidendium;影矿兰;Orechid Endium;
+bones;14697;bones;Bones;;
+my-nethers-delight;14698;mynethersdelight;My Nether's Delight;;
+localizator;14699;localizator;Localizator;;
+scorchful;14700;scorchful;焦土;Scorchful;
+marbleds-api-mapi;14701;marbledsapi;Marbled's API;;MAPI
+;14702;better_enchantment;更好的附魔;Better Enchantments;BE
+magma-bucket;14703;magmabucket;岩浆桶;Magma Bucket;
+ropes;14704;AS_Ropes;Ropes+;;
+paniclecraft;14705;paniclecraft;PanicleCraft;;
+cpmpvc;14706;cpmpvc;自定义玩家模型Plasmo语音兼容;Customizable Player Models Plasmo Voice compat;
+ydms-gunblades-mod;14707;gunblades;YDM's Gunblades;;
+warp-pads;14708;warppads;Warp Pads;;
+marbleds-arsenal;14709;marbledsarsenal;Marbled's Arsenal;;MA
+;14710;inventory-tabs;Inventory Tabs 4;;
+mob-spawning-fix;14711;mobspawningfix;生物生成修复;Mob Spawning Fix;
+lh-miracle-road;14712;lhmiracleroad;奇迹之路之魂系加点;LH Miracle Road;LHMR
+;14713;optifinechange;Optifine Change;;
+compatskills-fork;14714;compactskills;CompatSkills(Fork);;
+reskillable-fork;14715;reskillable;Reskillable(Fork);;
+;14716;tcc;TCCEnchantments;;TcE
+;14717;subtick;SubTick;;
+electroblobs-wizardry-continuation;14718;wizardry;巫术学：延续;Electroblob's Wizardry Continuation;
+agricraft-continuation;14719;AgriCraft;农业工艺：延续;Agricraft Continuation;
+create-nuke;14720;create_nuke;Create: Nuke;;
+egg-particle-fix;14721;eggparticlefix;鸡蛋粒子修复;Egg Particle Fix;
+chicken-chunk-patcher;14722;cpg;Chicken Chunk Patcher;;
+achievement-detection-fix;14723;achievementdetection;成就检测修复;Achievement Detection Fix;
+;14724;autonightvision;自动夜视;Auto Night Vision;ANV
+;14725;chais-inventory-sorter;Chai's Inventory Sorter;;
+;14726;friendlypenetration;魔戒友军穿透;LOTR Friendly Penetration;
+;14727;lotrcallablehorse;召之马来：魔戒版;LOTRHorseCall;
+;14728;mysteriumlib;菌丝;Mycelium Lib;ML
+;14729;xpf;经验公式;Xp Formula;XPF
+witcherypatch;14731;witcherypatch;巫术补丁;WitcheryPatch;
+pin;14732;pin;Pin;;
+simple-pings;14733;simplepings;Simple Pings;;
+great-scrollable-tooltips;14734;great-scrollable-tooltips,great_scrollable_tooltips;Great Scrollable Tooltips;;
+waterframes;14735;waterframes;WATERFrAMES: Multimedia Displays;;
+eugenes-whistle-spur;14736;eugenes-whistle-spur;友止殷的马哨和马刺;Eugene's Whistle & Spur;
+quickquark;14737;quickquark;畅启速始/夸克疾速启动;QuickQuark;
+minecraft-mineralogy;14738;mineralogy;Minecraft Mineralogy;;
+seed-delight;14739;seeddelight,seedsdelight;种子乐事;Seed Delight;
+transmog;14740;transmog;幻化;Transmog;
+nuclear-guitars;14741;ng;Nuclear Guitars;;
+cubic-racers;14742;cubicracers;Cubic Racers;;
+;14743;LOTR-UCP;魔戒非官方兼容性补丁;LOTR UCP;
+delightful-sandwiches;14744;delightfulsandwich;Delightful Sandwiches;;
+shader-fixer;14745;shadersfixer;光影修复;Shader fixer;
+resiever;14746;resiever;ReSiever;;
+cartload;14747;cartload;CartLoad;;
+stewing-baking;14748;stewing-baking;炖与烤;Stewing & Baking;
+am2playground;14749;am2pg;AM2PlayGround;;
+;14750;astrocraft;Astrocraft;;
+;14751;ats;AutoTools;;ATS
+neat-shaders-fix;14752;Neat;极简血量显示 - 光影修复版;Neat - Shaders-Fix;
+worldtooltips-shadersfix;14753;worldtooltips;掉落物信息显示 - 光影修复版;WorldTooltips - ShadersFix;
+;14754;ars_repairing;新生魔艺：修复纤维强化;Ars Repairing;
+options-enforcer;14755;optionsenforcer;Options Enforcer;;OE
+macaws-bridges-biome-o-plenty;14756;macawsbridgesbop;Macaw的桥梁：超多生物群系附属;Macaw's Bridges - Biomes O' Plenty;
+renhider;14757;renhider;RenHider;;
+itemframeremover;14758;itemframeremover;物品展示框移除器;ItemFrameRemover;
+;14759;legacy-debug-pause;Legacy Debug Pause;;
+trick-or-treat;14760;trickortreat;Trick or Treat;;
+ninjin-entities-by-hedaox;14761;ninjinentities;Ninjin Entities;;
+dangerrpg-continuation;14762;dangerrpg;危险RPG：延续;DangerRPG Continuation;
+zelda-sword-skills-continuation;14763;zeldaswordskills;塞尔达剑技：延续;Zelda Sword Skills Continuation;
+;14764;ForgottenRelics;失落遗物学：非官方版;Forgotten Relics Unofficial;
+screenshots-enhanced;14765;screenshots;截图增强;Screenshots Enhanced;
+the-rings-of-power;14766;trop;力量之戒/魔戒众戒;The Rings of Power;TRoP
+;14767;voxelcam;体素相机;VoxelCam;
+;14768;fancydelight;Fancy Delight;;
+;14769;salt;Salt for Fabric;;
+suspicious-zombification;14770;suszombification;Suspicious Zombification;;
+;14771;wmis;Where Is My Stuff-Forge;;WIMSF
+ivtoolkit-arcana-rpg-continuation-edition;14772;IvToolkit;IvToolkit：延续;IvToolkit Arcana Rpg Continuation Edition;
+;14773;FarmersDelightBedrockUnofficial;农夫乐事基岩版（Unofficial）;Farmer's Delight Bedrock (Unofficial);
+;14774;byzh-picgen;byzh's 麦块画图;BYZH's Picgen;
+tropicraft-continuation;14775;tropicraft;热带世界：延续;Tropicraft Continuation;
+battle-tower-continuation;14776;AS_BattleTowers;战斗高塔：延续;Battle Tower Continuation;
+kswitch;14777;kswitch;KSwitch;;
+tfc-lumberjack;14778;tfc_lumberjack;TFC LumberJack;;
+tfc-better-stone-tools;14779;tfc_stone_tools;TFC Better Stone Tools;;
+protons-additions;14780;protonsadditions;Proton's Create Additions;;
+kinetic-anti-cheat;14781;kinetic anti-cheat;Kinetic Anti-Cheat;;
+where-are-the-ores;14782;wherearetheores;Where Are The Ores?;;
+underp-hangables;14783;underphangables;Underp Hangables;;
+doggy-talent-continuation;14784;doggytalents;小狗天才：延续;Doggy Talents Continuation;
+mod-observer;14785;mod_observer;Mod Observer;;
+mineralogy-continuation;14786;mineralogy_continuation;Mineralogy Continuation;;
+ubc-ore-registrar;14787;UBCOres;科学地质：矿石注册;UBC Ore Registrar;
+genesis-2d;14788;genesis;创世纪;Genesis;
+;14789;nonupdate_reloaded;不再有更新重制版;NonUpdate Reloaded;NUR
+radiation-zone;14790;radiation_zone;辐辽地带;Radiation Zone;RZ
+;14791;ZeroClitedAPI;ZeroClitedAPI;;ZCLib
+adventure-backpacks-patched;14792;adventurebackpack;探索者背包：延续;Adventure Backpacks Patched;
+;14793;tcaltarcull;ThaumcraftAltarCull;;
+bhops;14795;bhops;BHops;;
+from-spores;14796;fromspores;From Spores;;
+just-dire-things;14797;justdirethings;Just Dire Things;;
+hit-feedback;14798;hit_feedback;攻击反馈;Hit Feedback;
+;14799;hasoook;Hasoook;;
+middle-earth;14800;me;中洲;Middle-earth;ME
+windows-keyboard-fixes-fixes-sticky-keys;14801;win_kb_fix;Windows 键盘修复 - 粘滞键;Windows Keyboard Fixes - Fixes sticky keys;
+statuesmod-fix;14802;statuesmodfix;雕像模组-修复;StatuesMod Fix;
+;14803;numericaltabping;NumericalTabPing;;
+ninjinentities-unofficial;14804;ninjinentities-Unofficial;Ninjin Entities-非官方版;ninjinentities-Unofficial;
+sanguine-arsenal-reforged;14805;sanguinearsenal;血染武装重铸版;Sanguine Arsenal Reforged;
+respawn-obelisks;14806;respawnobelisks;Respawn Obelisks;;
+flintandsteel-improve;14807;biologyfire;FlintAndSteel Improve;;
+forge-zombie-plague-mod-2-wip;14808;zombieplague2;僵尸瘟疫2;Zombie Plague 2;
+colored-grasses;14809;coloredgrasses;Colored Grasses;;
+more-default-options;14810;moredefaultoptions;More Default Options;;
+;14811;lively_danmaku;缤纷弹幕;;
+;14812;kanake;简明魔法;;KNK
+treecapitator-updated;14813;TreeCapitator;砍树更新版;Treecapitator Updated;
+;14814;offhandlights;副手光源;Offhand Lights;OL
+keep-your-mouth-healthy;14815;keepyourmouthhealthy;保持口腔健康;Keep Your Mouth Healthy;
+prehistoric-nature-jurassic-dimension;14816;pnjurassic;Prehistoric Nature Jurassic Dimension;;
+tfcify-tfc-explorify;14817;;TFCify;;
+many-more-structures;14818;morestructuresmodreforged,morestructuresmod;Many More Structures;;
+mobs-are-friends;14819;mobs_are_friends;Mobs are Friends;;
+polytone;14820;polytone;Polytone;;
+;14821;calcium;钙;Calcium;
+delightful-burgers;14822;delightful-burgers;Delightful Burgers;;
+cinderloe-project;14823;cinder_loe;CinderLoE Project;;
+lotweakr;14824;lotweakr;魔戒微调;LOTweakR;
+lotr-renewed-extended;14825;lotrextended;魔戒：复兴-拓展;LOTR: Renewed Extended;
+lotr-companions-renewed-addon;14826;lotrcompanions;魔戒：同伴;LOTR: Companions;
+dvs;14827;dvs;自定义魔戒小建筑;DVS;
+mffs;14828;mffs;Modular Force Field Systems;;MFFS
+lotr-extended;14829;lotre;魔戒大陆拓展;LOTR Extended;
+bitcrafting;14830;bcm;BitCrafting;;BCM
+fart-shit-pee;14831;fart_shit_pee;Fart Shit Pee;;
+statuseffecthud-updated;14832;StatusEffectHUD;状态信息显示更新版;StatusEffectHUD Updated;
+capejs;14833;capejs;CapeJS;;
+advanced-machines-patcher;14834;advmachinespatch;高级机械补丁;Advanced Machines Patcher;
+;14835;immersive-tooltip;沉浸式的工具提示;Immersive:Tooltip;
+;14836;legacyfixes;LegacyFixes;;
+sound-controller;14837;soundcontroller;Sound Controller;;
+cagerium;14838;cagerium;Cagerium;;
+advanced-inventory-mod;14839;advancedinventory;Advanced Upgradable Inventory;;
+rolling-down-in-the-deep;14840;rolling_down_in_the_deep;Rolling Down in the Deep;;
+dwarven-realm;14841;drealm;矮人诸国;Dwarven Realm;
+renewed-eras-of-arda-addon;14842;eoa;阿尔达纪元：复兴;Eras of Arda: Renewed Addon (First and Second Age);EoA
+legendary-item;14843;legendarium;魔戒传说物品;Legendary Item;
+lotr-middleearth-tweaks;14844;metweaks;中洲微调;MiddleEarth Tweaks;
+thaumcraft-integration;14845;tc_integraton;Thaumcraft Integration;;
+reach-display;14846;reach_display;Reach Display;;
+gravitation-suite-patcher;14847;gravisuitepatch;Gravitation Suite Patcher;;
+anti-rat-dungeon;14848;anti_rat_dungeon;Anti Rat Dungeon;;
+modchu_defaultmodelset;14849;modchumodel;DefaultModelSet;;
+create-storage;14850;fxntstorage;Create: Storage;;
+avaritia-item;14851;avaritiaitem;无尽特效物品;Avaritia Item;
+kingdom-of-rin-regions;14852;kingdomregions;Kingdom of RIN | Regions;;
+durability-speed-legacy-backport;14853;durabilityspeed;Durability Speed (Legacy Backport);;
+inventory-on-death-mod;14854;inventoryondeath;Inventory on death Mod;;IOD
+berries-cherries-delight;14855;berries_and_cherries;Berries & Cherries Delight;;
+silents-delight;14856;silentsdelight;幽匿乐事;Silent's Delight;
+darwin-sprinting-system;14857;dss;达尔文疾跑系统;Darwin Sprinting System;DSS
+camera-overhaul-reforged;14858;cameraoverhaul;Camera Overhaul Reforged;;
+monolib;14859;monolib;MonoLib;;
+;14860;pyrofrost;Pyrofrost;;
+animal-armor-trims;14861;animal-armor-trims;Animal Armor Trims - Horse & Wolf;;
+;14862;beetech;狼群：群蜂工艺;Wolves：SwarmBeeTech;SBT
+better-safe-bed;14863;bettersafebed;Better Safe Bed;;
+modchu_models;14864;multimodel;Modchu Model;;
+ice-and-fire-spellbooks;14865;ice_and_fire_spellbooks;Ice and Fire: Spellbooks;;
+exlines-fishing;14866;exlinefishing;Exline's Fishing;;
+cavernous-delight;14867;cavernousdelight;Cavernous Delight;;
+;14868;steep-surface-fix;Steep Surface Fix;;
+;14869;fluffyalien_itemducts;Itemducts;;
+arthropocolypse;14870;arthropocolypse;Arthropocolypse;;
+;14871;kaleido;Kaleido;;
+;14872;tab_ppd;TABPlayerPositionDisplay;;
+;14873;igmun;模组隐藏器;ModHider;MH
+combat-skill;14874;combat_skill;战斗技巧;Combat Skill;CS
+life-is-precious;14875;lip;生命是宝贵的;Life is precious;LIP
+;14876;rdfim;随机难度;Random Difficulties For Improved Mobs;RDFIM
+advanced-skills;14877;advanced_skills;进阶技能;Advanced Skills;AS
+nuts-delight;14878;cavernousdelight;Nuts Delight;;
+vegetables-delight;14879;vegetablesdelight;Vegetables Delight;;
+enderpack;14880;enderpack;EnderPack - New Backpack;;
+ingame-mod-configs;14881;InGameModConfigs;游戏内模组配置;InGame Mod Configs;
+playertag;14882;playertag;玩家标签;PlayerTag;
+hide-names;14883;hidenames;隐藏名称;Hide Names;
+camo-suits;14884;camosuits;迷彩套装;Camo Suits;
+vtubruh-lotr-mobs-new;14885;vtubruhlotrmobs;Vtubruh的魔戒生物;vtubruh LOTR Mobs;
+;14886;;Awaken Dreams;;AD
+;14887;fluffyalien_asn;Advanced Storage Network;;
+;14888;create_more_features;Create: More Features;;
+armadillo-scute-armor;14889;armadillo-scute-armor;Armadillo Scute Armor;;
+new-shield-variants;14890;new-shield-variants;New Shield Variants;;
+;14891;fantasycraftcomplements;幻想工艺：扩充;FantasyCraft Complements;FCC
+;14892;;What Am I Looking At?;;WAILA
+way-much-faster-oxidize-reborn;14893;way_much_faster_oxidize_reborn;Way Much Faster Oxidize Reborn;;
+bn-blood-particles;14894;bnbloodparticles;BN Blood Particles;;
+bn-weapons;14895;bn_weapons;BN Weapons;;
+ecotones;14896;ecotones;Ecotones;;
+froglins;14897;froglins;Froglins;;
+create-armor-trim;14898;create_armor_trims;Create: Armor Trim;;
+slashblade-resharped;14899;slashblade;拔刀剑：重锋;SlashBlade: Resharped;
+spawn-mod;14900;spawn;Spawn;;
+;14901;smooth_swapping;Smooth Swapping 1.20.4 Port;;
+;14902;create_tab_fix;Create Tab Fix;;
+scape-and-run-origins;14903;srp_origins;Scape and Run: Origins;;SR:O
+origins-extra-keybinds;14904;extrakeybinds;Origins Extra Keybinds;;
+epic-knights-addon;14905;magistuarmoryaddon;Epic Knights: Addon;;
+;14906;silverlighting;未尽之事;SilverLighting;
+;14907;arknights-skadi-orca-plushie;【明日方舟】斯卡蒂的虎鲸抱枕;[Arknights] Skadi Orca Plushie;
+sona-survival-101;14908;sona;唢呐生存指南;Sona Survival 101;
+;14909;more_villargers;More Villargers;;
+cult-of-the-wither;14910;cotw;Cult of the Wither;;
+clochetweaks;14911;clochetweaks;ClocheTweaks;;
+;14912;;ReplayCraft;;
+;14913;flintapi;Flint API;;
+;14914;multiproto;Multiproto;;
+frostbytes-improved-inventory;14915;inventory;Frostbyte's Improved Inventory;;
+mekanism-extras;14916;mekanism_extras;通用机械：扩展;Mekanism Extras;MekE
+leaf-beds;14917;leafbeds;Leaf Beds;;
+unidentified-enchantments;14918;unidentifiedenchantments;Unidentified Enchantments;;
+protection-pixel;14919;protection_pixel;机素防护;Protection Pixel;
+;14920;;More Camera Perspectives;;
+;14921;hcml_launch;HMCL_Launch;;
+createdpcompat;14922;createdpcompat;CreateDPCompat;;
+;14923;nbs;NonBlind;;NBS
+lava-waterblock;14924;lavaandwaterblock;Lava and Water Block;;
+;14925;im_tired;我很疲倦;I'm Tired;IT
+constant-music;14926;constantmusic;Constant Music;;
+supercore;14927;supercore;SuperCore;;
+extreme-reactors-create-compat;14928;er2create;Extreme Reactors Create Compat;;
+modchu_playerformlittlemaid;14929;pflm;PlayerFormLittleMaid;;PFLM
+totally-lit;14930;totally-lit;Totally Lit;;
+mo-shiz-mod;14931;ms;Mo' Shiz;;
+aetheric-tetranomicon;14932;aetheric_tetranomicon;Aetheric Tetranomicon;;
+arda-addon;14934;arda;阿尔达拓展;Arda Addon;
+;14935;potion-warning;PotionWarning;;
+a-good-place;14936;a_good_place;A Good Place;;
+aether-protect-your-moa;14937;aether_protect_your_moa;Protect Your Moa;;
+advanced-rocketry-2;14938;advancedrocketry;Advanced Rocketry - Reworked/Advanced Rocketry - fixed;;
+compostimprove;14939;compostimprove;Compost Improve;;
+superb-steeds;14940;superb-steeds;Superb Steeds;;
+coal-piece;14941;coal_piece;Coal Piece;;
+;14942;zoom;变焦;Zoom;
+;14943;GlobalShop;全球商店3;GlobalShop_v3;
+;14944;mechmonstrosity;机械巨兽;MechMonstrosity;
+slash-illager;14945;slash_illager;Slash Illager;;
+;14946;create-spawnerboxer;Create: SpawnerBoxer;;
+skeletalband;14947;skeletalband;骷髅乐队乐谱;SkeletalBand;
+alexs-caves-entropy;14948;entropy;Alex 的洞穴：熵;Alex's Caves:Entropy;ACE
+mekanism-explosives;14949;mekanismexplosives;通用机械：炸药;Mekanism Explosives;
+;14950;minimalcoordshud;Minimal Coords HUD;;
+;14951;;存储乐事基岩版（Unofficial）;Storage Delight Bedrock (Unofficial);
+;14952;;蟹农乐事基岩版（Unofficial）;Crabber's Delight Bedrock (Unofficial);
+;14953;;末地乐事基岩版（Unofficial）;End's Delight Bedrock (Unofficial);
+avaritiareborn;14954;avaritia;无尽贪婪：复兴;AvaritiaReborn;
+cherry-shrimp;14955;cherry_shrimp;Cherry Shrimp;;
+pick-command;14956;pickcommand;俺拾的指令;Pick Command;PiC
+regalliv;14957;regalliv;regalliV;;
+extra-addition-s;14958;extra_additions;Extra Additions;;
+;14959;allmusic_server,allmusic_client;AllMusic;;
+;14960;amethyst-shield;紫水晶盾;Amethyst Shield;
+;14961;plateplate;板板;PlatePlate;
+;14962;pb;保护方块;Protect Block;
+;14963;mirrordim;镜像维度;MirrorDim;
+;14964;difficultytweak;难度调整;Difficulty Tweak;
+;14965;customitemprojectile;自定义简单物品投掷物;CustomItemProjectileForKubejs;CIPjs
+;14966;herbal-delight;Herbal Delight;;
+;14967;;迅捷冲刺;Ctrl Sprint;CS
+;14968;randgradle;随机合成;randgradle;
+;14969;compatlib;旧版本兼容工具;LegacyCompatibilityUtils / CompatLib;
+warriors-of-past-epoch;14970;warriorsofpastepoch;Warriors of Past Epoch;;
+the-ghast-cow;14971;ghastcow;The Ghast Cow;;
+;14972;alternatecurrent;Alternate Current Unofficial;;
+birds-on-a-wire;14973;bow;Birds On A Wire;;
+no-hurt-animation;14974;no_hurt_animation;No Hurt Animation;;
+incense;14975;Incense;Incense;;
+wild-lands-2;14976;wl;Wild Lands 2;;
+hullabaloo;14977;hullabaloo;Hullabaloo;;
+invinci-dogs-ssp;14978;;Invinci-Dogs;;
+;14979;noglow;禁止发光;noglow;
+timeless-and-classics-zero;14980;tacz;永恒枪械工坊：零;Timeless and Classics Zero;TaCZ
+;14981;sufyf;Would You Shut Up-Forge;;STFUF
+;14982;concentration;专注;Concentration;
+terra-curio;14983;confluence,terra_curio;泰拉饰品;Terra Curio;TC
+;14984;additionallatherecipes;车床配方追加;Additional Lathe Recipes;
+cobblemon-counter;14985;cobbled_counter,cobblemon_counter;Cobblemon Counter;;
+cobblemon-move-inspector;14986;cobblemon_move_inspector;Cobblemon Move Inspector;;
+cobblemon-spawn-notification;14987;cobblemon_spawn_notification,spawn_notification;Cobblemon Spawn Notification;;
+cobblemon-pokenav;14988;cobblenav;Cobblemon Pokenav;;
+cobblemontrainers;14989;cobblemontrainers;CobblemonTrainers;;
+the-ink-arena;14990;the-ink-arena,theinkarena;The Ink Arena;;
+;14991;spd;SimplePositionDisplay;;SPD
+epicfight-integration;14992;efi_mod;史诗战斗·集成;EpicFight Integration;EFI
+;14993;stopspidersfromclimbing;Stop Spiders From Climbing!;;
+kubejs-enderio;14994;kubejs_enderio;KubeJS EnderIO;;
+polymorphic-energistics;14995;polyeng;Polymorphic Energistics;;
+war-of-the-ring-mc;14996;wotrmc;魔戒大战;The War of the Ring MC;WotR
+redstone-clock-mod;14997;redstoneclock;红石钟;Redstone Clock;RC
+create-cobblestone;14998;createcobblestone;Create Cobblestone;;
+;14999;another_pickaxe;Another Pickaxe;;
+selfexpression;15000;selfexpression;Selfexpression;;
+electricalcraft;15001;electricalcraft;ElectricalCraft;;
+;15002;elecfurn_mod;ElecFurn;;
+what-is-stone-colorful-caves;15003;what_is_stone;What is 'Stone'? (Colorful Caves);;
+vtones;15004;vtones;Vtones;;
+heavy-inventories;15005;heavyinventories;物品负重;Heavy Inventories;
+vs-addition;15006;vs_addition;VS Addition;;VSA
+gravity-torch;15007;gravitytorch;Gravity Torch;;
+lifesteal-forge-fabric;15008;lifesteal;Lifesteal;;
+mores-by-its-infinite;15009;mores;mOres Reloaded;;
+dragonite-gear;15010;dragonitegear;Dragonite Gear;;
+lets-do-addon-fluids;15011;lets-do-addon-fluids;[Let's Do Addon] Fluids;;
+;15012;strscan;结构扫描解锁器;STR Scan Unlocker;
+;15013;no-blocked-servers;禁用Mojang服务器封禁;No Blocked Servers;
+;15014;just_glowing_buttons_forge,just_glowing_buttons_neoforge;Just Glowing Buttons;;JGB
+rats-hats;15015;rats-hats;Rats' Hats;;
+biome-reactors;15016;biomereactors;Biome Reactors;;
+mystical-agriculture-tiered-crystals;15017;matc;Mystical Agriculture Tiered Crystals;;MATC
+tpaplusplus;15018;tpaplusplus;TPA++;;
+warlerys-hq;15019;warleryshq;WARLERY'S HQ;;
+call-of-yucutan;15020;call-of-yucutan;尤卡坦的呼唤;Call of Yucatán;
+redman;15021;redman;红超人;;RM
+lets-do-addon-compat;15022;lets-do-addon-compat,letsdoaddon-compat;[Let's Do Addon] Compat;;
+;15023;af;AttackFix;;AF
+worldeditcui-forge-edition;15024;WorldEditCuiFe;WorldEditCUI Forge Edition;;
+slime-delight;15025;slime_delight;粘液乐事;Slime Delight;
+darkcap;15026;darkcap;DarkCap - Cap Your XP!;;
+;15027;ryoamium;Ryoamium;;
+quality-equipment;15028;quality_equipment;Quality Equipment;;
+seals;15029;seals;Seals;;
+nocubes-better-smoker;15030;nocubes_better_smoker;NoCube's Better Smoker;;
+;15031;shutdownondeath;Shutdown On Death;;
+mekanism-energistics;15032;mekeng;Mekanism Energistics;;
+ae2-network-visualiser;15033;aenetvistool;AE2 Network Visualiser;;
+ahznb-sword-plus;15034;ahznbswordsplus;AHZNB sword plus;;
+anbu-bingo-book-for-ahznbs-shinobicraft;15035;anbubingobook;Anbu Bingo Book for AHZNB's ShinobiCraft;;
+ahznbs-naruto-mod-reroll;15036;rerollthingy;AHZNB's Naruto Mod Reroll;;
+xycraft-override;15037;xycraft_override;XyCraft: Override;;
+xycraft-machines;15038;xycraft_machines;XyCraft: Machines;;
+xycraft-world;15039;xycraft_world;XyCraft: World;;
+battlemusic;15040;battlemusic;Battle Music;;
+;15041;hwite;Hwite;Here's What Is Too Easy;Hwite
+;15042;embyui;EmbeddiumUI;;
+engineered-golems;15043;EngineeredGolems;Engineered Golems;;
+axifier;15044;axifier;Axifier;;
+renderjs;15045;renderjs;RenderJS;;
+;15046;enchantmentcompat;Enchantment Compatibility;;
+dehand;15047;dehand;Dehand;;
+jadecolonies;15048;jadecolonies;JadeColonies;;
+;15049;cobblemonmikeskills;Cobblemon Mike Skills;;
+diamond-star-combat;15050;dscombat;Diamond Star Combat;;
+modern-ae2-additions;15051;mae2;Modern AE2 Additions;;MAE2
+create-metallurgy;15052;createmetallurgy;机械动力：冶金学;Create: Metallurgy;
+;15053;clientinfofix;Client Info Fix;;
+the-shy-guy;15054;shy_guy;SCP-096, The Shy Guy;;
+;15055;teatime;Tea Time;;
+;15056;cobbreeding;Cobbreeding;;
+mythsandlegends-datapack;15057;mythsandlegends;Cobblemon Myths and Legends Addon;Myths and Legends [Cobblemon Sidemod];
+;15058;rctmod;Radical Cobblemon Trainers;;RCT
+create-klinks-n-klangs;15059;create_klinks_n_klangs;Create: Klinks n' Klangs;;
+mo-than-enough-guns;15060;mteg;Mo'Than Enough Guns;;M'TEG
+;15061;killcup;KillCup;;
+forge-creeper-heal;15062;forgecreeperheal;Forge 苦力怕坑修复;Forge Creeper Heal;
+;15063;;玉米乐事基岩版 (Unofficial);Corn Delight Bedrock (Unofficial);
+;15064;;种子乐事基岩版 (Unofficial);Seed Delight Bedrock (Unofficial);
+;15065;skiphand;莫莫的折跃之手;Momo's SkipHand;MoSH
+curse-of-disintegration;15066;curseofdisintegration;Curse of Disintegration;;
+adventure-backport;15067;adventure_backport;冒险模式向后移植;Adventure Backport;
+;15068;oreganized;井然有矿：重织;Oreganized Refabricated;
+yosby;15069;yosby;Your Options Shall Be Yours;;YOSBY
+;15070;zundamod;ZundaMod;;
+common-network;15071;commonnetworking;Common Network;;
+addurdisc;15072;addurdisc;自定义唱片;AddurDisc/Add your disc;
+enigmatic-addons;15073;enigmaticaddons;神秘遗物扩展;Enigmatic Addons;
+;15074;MITEIsTooFalse;MITE Is Too False;;MITF
+;15075;bloodscythe;BloodScythe;;
+dungeons-delight;15076;dungeons_delight_gourmet_battles;Dungeon's Delight;;
+stronger-potions;15077;stronger_potions;更强的药水;Stronger Potions;
+;15078;accountsx;游戏内账号切换 X;Accounts X;
+villager-knights;15079;villagerknights;Villager Knights;;
+;15080;particular;Particular ✨;;
+;15081;sgb;Say Goodbye;;SGB
+reforgedplay-mod;15082;replaymod;ReForgedPlay;;
+sqript;15083;sqript;Sqript;;
+natures-delight;15084;natures_delight;生灵乐事;Nature's Delight;
+reimagining-potatoes;15085;reimagining-potatoes;Poisonous Potato Update;;
+;15086;rpa;Legacy Resource Pack Adapter;;
+insane-stamina;15087;stamina;Stamina;;
+bren;15088;bren;Bren;;
+;15089;power-hud;Power HUD;;
+plushables;15090;plushables;毛绒玩偶;Plushables;
+;15091;craftguide;G键合成表-MITE;CraftGuide-MITE;
+;15092;mlc;我的世界启动器核心;MinecraftLauncherCore;MLC
+;15093;ass;自动拿取;AutoSteal;ASS
+;15094;moddev;SpeedBuilders;;RBG
+;15095;staff_of_the_king_orange;橙王的权杖;Staff of the King Orange;
+;15096;ef_irp;史诗战斗：渲染调整;EpicFight:ItemRenderPatcher;EFIRP
+path-under-gates;15097;pathundergates;Path Under Gates;;
+ojs-guilds;15098;guild_mod;OJ's Guilds;;
+command-macro-key;15099;;命令宏键;Command Macro Key;
+realm-rpg-quests-rewards;15100;realmrpg_quests;Realm RPG: Quests & Rewards;;
+;15101;roadworks;Roadworks;;
+unlucky-tnt;15102;unluckytnt;Unlucky TNT;;
+fastboot;15103;fastboot;FastBoot;;
+;15104;oceania;Oceania;;
+tardis-refined;15105;tardis_refined;改良的TARDIS;TARDIS Refined;
+ocean-villager-trader;15106;ls_ocean_trader,oceanvillagertrader;Leon's Ocean Trader;;
+;15107;prma;机械动力：精制工艺;Create: Precise Manufacturing;PrMa
+;15108;newagealexscaves;Create: New Age / Alex's Caves Integration;;
+create-kryeit;15109;kryeit;Create: Kryeit;;
+animationoverhaul;15110;animation_overhaul;Animation Overhaul;;
+starbunclemania;15111;starbunclemania;StarbuncleMania;;
+;15112;mclogin;RE:MCLogin;;
+;15113;ep;实体保护;EntityProtection;EP
+display-qien;15114;display-qien;Display-Qien;;
+;15115;villagehealthcare;Village Healthcare;;
+cubic-villager;15116;cubicvillager;Cubic Villager;;
+;15117;morecursors;更多光标;MoreCursors;
+true-infinity;15118;fourinchknife-trueinfinity;True Infinity;;
+nukateams-gun-lib;15119;ntgl;NukaTeam's Gun Lib;;NTGL
+fantastic-biomes-cave;15120;cavernous;Fantastic Biomes Cave;;
+nukacraft;15121;nukacraft;Nukacraft;;
+enchantment-limiter;15122;enchantlimiter;Enchantment Limiter;;
+emi-ores;15123;emi_ores;EMI Ores;;
+;15124;bread_skin;面包皮;Bread Skin;BS
+extra-gore;15125;extragore;Extra Gore;;
+chassiscore;15126;chassis_core;ChassisCore;;
+;15127;spit_splat;Spit Splat [Fabric];;
+;15128;less_hurt_particle;LessHurtParticle;;
+normalcore;15129;normalcore;NormalCore;;
+appliede;15130;appliede;AppliedE;;
+waystones-teleport-pets;15131;w2pets;Waystones Teleport Pets;;
+;15132;sneaky_link;Sneaky Link;;
+create-mortar;15133;create_mortar;Create: Mortar;;
+forgelin-continuous;15134;forgelin_continuous,forgelin;Forgelin-Continuous;;
+;15135;jojo;RotP：杀手皇后附属;Ripples of the Past: Killer Queen Addon;
+ninjin-knockback-dbc-by-hedaox;15136;ninjinkb;Ninjin Knockback;;
+wings-3;15137;wings;Wings Reborn / Wings 3;;
+dstathud;15138;dstathud;DStatHud;;
+opticmanager;15139;opticmanager;OpticManager;;
+ribbits;15140;ribbits;Ribbits;;
+;15141;actually-camel;Actually Camel;;
+;15142;pm;图片信息;PictureMessage;PM
+;15143;raml;REAgainMCLogin;;
+;15144;large_number;卡儿的数学库;Large Number;
+raws-visual-keybinder;15145;visual_keybinder;Raw's Visual Keybinder;;
+;15146;synthetic_products;合成配方;Synthetic Products;SP
+;15147;fastlang;Fast Lang;;
+;15148;scoreboardtweaks;Scoreboard Tweaks;;
+rsinfinitewireless;15149;rsinfinitewireless;RSInfiniteWireless;;
+rustic-engineer;15150;rustic_engineer;Rustic Engineer;;
+artsandcrafts;15151;arts_and_crafts;Arts & Crafts;;
+mermaid-legend;15152;mermaidlegend;人鱼传说;Mermaid Legend;
+endcake;15153;endcake;末影蛋糕;EndCake;
+;15154;bettertropical;更好的热带鱼;BetterTropical;BT
+;15155;sudo;mcsudo;;
+;15156;stz;简易缩放;SimplestZoom;STZ
+scp-remake;15157;scp_foundation;SCP - REMAKE;;
+;15158;scpff;SCP Fallen Foundation;;
+;15159;anytag;天使命名牌;Anytag;
+create-heat-js;15160;create_heat_js;Create Heat JS;;
+createaddoncompatibility;15161;createaddoncompatibility;Create: Addon Compatibility;;
+more-difficulty-levels;15162;iiz_mdl;More Difficulty Levels;;
+alternacraft;15163;alternacraft;Alterna Craft;;
+sheep-squeak;15164;sheepsqueak;Sheep Squeak;;
+fabric-simple-animated-guns;15165;animated_guns;Simple Animated Guns;;
+a-v-a-in-minecraft;15166;ava;Alliance of Valiant Arms Guns;;A.V.A
+coordinates-display;15167;coordinatesdisplay;坐标显示;Coordinates Display;
+;15168;acrylic;亚克力窗口;AcryliCraft;
+towelette;15169;towelette;Towelette;;
+shc-pvz-zengarden;15170;pvz_zengarden;SHC PVZ ZenGarden;;
+unusual-foods-delight;15171;unusualfoodsdelight;奇食乐事;Unusual food's Delight;
+re-fruitful;15172;refruitful;RE-Fruitful;;
+dark-rites-2;15173;darkrites;Dark Rites 2;;
+advitam-addon-for-requiem;15174;advitam;Ad Vitam: Addon for Requiem;;
+potheads;15175;potheads;PotHeads;;
+;15176;objection;异议！;Objection!;
+skyfall-meteorites;15177;skyfall;Skyfall: Meteorites;;
+fancyclear;15178;fancyclear;FancyClear;;
+pathfinders-spade;15179;pathfinder;Pathfinder's Spade;;
+legacy-minecraft;15180;legacy;Legacy4J;;
+festive-creepers;15181;festive_creepers;Festive Creepers;;
+essential-features;15182;essentialfeatures;Essential Features;;
+piston-control-forge;15183;pistoncontrol;Piston Control;;
+blahaj-restitched;15185;blahaj;布罗艾重制版;Blahaj Restitched;
+;15186;tabbychat2;TabbyChat 2 Reforged;;
+lithostitched;15187;lithostitched;Lithostitched;;
+pogfish;15188;pogfish;Pogfish;;
+launch-time;15189;launch_time;启动耗时;Launch Time;
+killer-table;15190;killer_table;Killer Table;;
+trading-table;15191;trading_table;Trading Table;;
+winter-decorations;15192;winterdecorations;Winter Decorations;;
+fancy-snowy-weather;15193;fancy_snowy_weather;Fancy Snowy Weather;;
+winter-ambience;15194;winterambience;Winter Ambience;;
+dralards-rock-candy-mod;15195;rockcandy;Dralard's Rock Candy Mod;;
+;15197;testbooks;可食用课本;Testbooks;
+;15198;vines_and_copy;生蔓聚解;Vines and Copy;V&C
+;15199;explosionbreaksnoblock;爆炸不破坏方块;Explosion Breaks No Block;EBNB
+via-romana;15200;via_romana;Via Romana: Infrastructure-Driven Fast Travel;;
+lithic-coins;15201;lithiccoins;Lithic Coins;;
+dynamic-trees-for-natures-spirit;15202;dtnatures_spirit;动态的树：自然之灵附属;Dynamic Trees for Nature's Spirit;
+gore-edition;15203;gore;Gore Edition;;
+christmas-wish-in-a-bottle;15204;christmas_wish_in_a_bottle;Christmas Wish in a Bottle;;
+chiseled-bricks;15205;chiseled-bricks;Chiseled Bricks;;
+unethly-origin;15206;untetly;Unethly Origin;;
+dimensional-totem;15207;dimtotem;Dimensional Totem;;
+placeable-gunpowder;15208;gunpowder;Placeable Gunpowder;;
+library-for-ar-reworked;15209;libVulpes;ARLib;;
+;15210;mr_better_caveworlds;Better Cave Worlds;;
+;15211;;E.M.I 特遣队武器;;E.M.I
+;15213;aquaculture_delight;水产乐事：早产;Pre Aquaculture Delight;PAD
+craftdev-core;15214;craftdevcore;CraftDev Core;;
+costume;15215;costume;Costume;;
+borzoi-dogs;15217;borzoi_dogs;Borzoi Dogs;;
+;15218;scg;SimpleClickGui;;SCG
+nether-exorcism;15219;nethers_exorcism;Nether Exorcism;;
+integrated-villages;15220;integrated_villages;Integrated Villages;;
+taxdeepvillager;15221;taxdv;Tax' Deep Villager;;
+;15222;rxey_bd;Voxelprint's Desert;;
+music-on-demand;15223;musicondemand;Music on Demand;;
+leadable-bats;15224;leadbats;Leadable Bats;;
+canes-wonderful-spiders;15225;caneswonderfulspidersoverhaul;Canes Wonderful Spiders;;
+;15226;optifine;OptiKai;;
+;15227;mr_idlefreeze;Idle Freeze;;
+scribble;15228;scribble;Scribble;;
+;15229;anvil-formatting-fix;Text Formatting Everywhere;;
+extended-item-information;15230;eii;Extended Item Information;;
+mod-sound-volume-options;15231;mvo76;Mod Sound Volume Options;;
+;15232;olo;OldLoadingOverlay;;OLO
+teams-hud;15233;teams;Teams HUD;;
+;15234;tpm;传送管理器;TeleportManager;TPM
+;15235;cameraobscura;Camera Obscura;;
+wzorescanner;15236;wzorescanner;WzOreScanner;;
+;15237;potion_recipes;Potion Recipes;;
+wither-totem;15238;totemmod;Wither Skeleton Totem;;
+;15239;rxey_bone;Player Bones;;
+;15240;malmomod;Project Malmö / Microsoft Malmo Mod;;
+more-apples-hyj;15241;more_tools_hyj;更多苹果;More Apples;
+fancy-enchantments;15242;fancyenchantments;奇异附魔;Fancy Enchantments;FE
+ash-of-sin-adventure-dimension;15243;ash_of_sin_adventure_dimension;罪业余烬：冒险维度;Ash Of Sin: Adventure Dimension;
+push-forward;15244;push_forward;猪突猛进;Push Forward;
+ymn;15245;ymn;你现在是我的了！;You're Mine Now!;
+thermal-endergy;15246;thermalendergy;Thermal Endergy;;
+mekanism-turrets-fences;15247;mekanism_turrets;Mekanism Turrets & Fences;;
+nuka-cola-classic;15248;nuka_cola_classic;Create: Nuka Cola Classic;;
+draconic-machinery;15249;draconicmachinery;Draconic Machinery;;
+;15250;rxey_hw;Voxelprint's Halloween;;
+iap-gobber;15251;iapg;IAP [Gobber];;
+iap-botania;15252;iapb;IAP [Botania];;
+iap-industrial-foregoing;15253;iapif;IAP [Industrial Foregoing];;
+iap-silents-gems;15254;iapsg;IAP [Silent's Gems];;
+iap-silents-gems;15255;iapp;IAP [Powah];;
+iap-omega-craft;15256;iapoc;IAP [Omega Craft];;
+iap-mekanism;15257;iapm;IAP [Mekanism];;
+industrial-agriculture-plugin-silents-mechanisms;15258;iapsm;IAP [Silent's Mechanisms];;
+tfc-grander-canopies;15259;;TFC Grander Canopies;;
+roads-and-roofs-tfc;15260;rnr;Roads and Roofs TFC;;
+taxvillagearchitect;15261;taxva;Tax' Village Architect;;
+taxoceanarchitect;15262;taxoa;Tax' Ocean Architect;;
+nethers-flora;15263;nether_flora;The Nether's Flora🌸;;
+;15264;plasma_tech;Plasma Tech;;
+microcosm;15265;microcosm;Microcosm;;
+chinese-flying-island-tower;15266;chineseflyingislandtower;Chinese Flying Island Tower;;
+;15267;cwsm_ncbt;Netherite tools for Crackers witherstorm mod;;
+better-maces;15268;mr_mace,mace;Better Mace;;
+jack-o-launcher;15269;jack_o_launcher;Jack-O'-Launcher;;
+the-otherworld-mod;15270;otherworld;The Otherworld - Reborn;;
+craftingxp;15271;craftingxp;CraftingXP;;
+dmmttba;15273;dmmttba;Don't Make Me Turn This Boat Around;;DMMTTBA
+fzzy-config;15274;fzzy_config;Fzzy Config;;
+no-shield-delay;15275;no-shield-delay;No Shield Delay;;
+musicpower;15276;musicpower;音乐之力;MusicPower;
+macrocraft;15277;macrocraft;MacroCraft;;
+camerapture;15278;camerapture;Camerapture;;
+simple-voice-radio;15279;simpleradio;Simple Voice Radio;;
+;15280;focal-engine,focalengine;Focal Engine;;
+adorned;15281;curios;Adorned (Curios);;
+fence-on-slab;15282;fence_on_slab;Fence On Slab!;;
+monochromatic-blocks;15283;monochromatic_blocks;Monochromatic Blocks;;
+;15284;forbid_sprinting_while_sneaking;禁止蹲跑;forbid sprinting while sneaking;Fsws
+;15285;followtheheart;随心起意;FollowTheHeart;
+;15286;mr_unbreakapack;无法破坏数据包;Unbreakapack;
+;15287;archaicfix;ArchaicFixFork;;
+;15288;inventive_inventory;Inventive Inventory;;
+boxlib;15289;boxlib;BoxLib;;
+the-shattered-goddess-mokels-bossfight-saphyra;15290;mokels_bossfight_saphyra;Mokels The Shattered Goddess;;
+resource-explorer;15291;resource_explorer;Resource Explorer;;
+;15292;patcher;PolyPatcher;;
+autoreconnectrf;15293;autoreconnectrf;Auto Reconnect Reforged;;
+disable-accessibility-screen;15294;disableaccessibilityscreen;Disable Accessibility Screen;;
+;15295;fly_high;Fly High;;
+;15296;tc4helper;神秘4研究助手;TC4Helper;
+;15297;fly_apple;飞苹果;Fly Apple;flyap
+;15298;;自然之灵-植树盆栽配方兼容;Nature's Spirit - Botany Trees Recipe Compat;
+;15299;hoyoi;HoYoI;;
+rogues-and-warriors;15300;rogues_and_warriors,rogues;Rogues & Warriors (RPG Series);;
+;15301;mr_trashapack;垃圾桶数据包;Trashapack;
+;15302;lryx;猎人游戏数据包/极限追杀数据包;;
+;15303;formulae;配方数据包/原版配方优化;;
+;15304;tfc_support_indicator;TFC Support Indicator;;
+tfc-poisoned-drinks;15305;poisoned_drinks;TFC Poisoned Drinks;;
+smartercontraptionstorage;15306;smartercontraptionstorage;智能动态结构存储;SmarterContraptionStorage;SCS
+lexiconfig;15307;lexiconfig;Lexiconfig;;
+;15308;mr_no_caves;No Caves;;
+;15309;advancementsfullscreen;AdvancementsFullscreen;;
+luckys-wardrobe;15310;wardrobe;Lucky's Wardrobe;;
+;15311;fukkit;Forkkit;;
+more-affordable-than-ever-never-too-expensive;15312;affordable;More Affordable Than Ever - Never Too Expensive;;
+what-am-i;15313;inventity;What am I?;;
+;15314;boi;更好的配置选项;BetterOptionInstance;BOI
+;15315;camoverlay;CamOverlay;;
+autoplant;15316;autoplant;AutoPlant;;
+;15317;skipbackupscreen;Skip backup screen;;
+;15318;polysprint;PolySprint;;
+;15319;crashpatch;CrashPatch;;
+;15320;vanillahud;VanillaHUD;;
+;15321;damagetint;Damage Tint;;
+;15322;polyblur;PolyBlur;;
+;15323;colorsaturation;ColorSaturation;;
+;15324;polyhitbox;PolyHitbox;;
+lains-random-creation;15325;lain;LAIN的随意创作;Lain's random creation;LRC
+autochefs-delight;15326;autochefs-delight,autochefsdelight;Autochef's Delight;;
+;15327;waif;What am I Forge;;
+bindcommands;15328;bindcommands;BindCommands;;
+short-grass;15329;short_grass;Short Grass;;
+stairs-but-chairs;15330;stairsbutchairs;Stairs But Chairs;;
+yumo-compactmachines-por;15331;yumo_cmp;压缩空间:产量推演;yumo compactmachines por;CMP
+dynamic-trees-for-fruit-trees;15332;dtfruitfulfun;动态的树：妙趣果园 🍊附属;Dynamic Trees for Fruitful Fun 🍊;
+dynamic-trees-for-better-end;15333;dtbetterend;动态的树：更好的末地附属;Dynamic Trees for BetterEnd;
+dynamic-trees-autumnity;15334;dtautumnity;动态的树：秋原附属;Dynamic Trees - Autumnity;
+dynamic-trees-for-bloomingnature;15335;dtbloomingnature;动态的树：BloomingNature附属;Dynamic Trees for BloomingNature;
+dynamic-trees-terralith;15336;dtterralith;动态的树：Terralith附属;Dynamic Trees - Terralith;
+dynamic-trees-for-meadow;15337;dtmeadow;动态的树：青青草甸附属;Dynamic Trees for Meadow;
+dynamic-trees-for-beachparty;15338;dtbeachparty;动态的树：沙滩派对附属;Dynamic Trees for Beachparty;
+dynamic-trees-for-vinery;15339;dtvinery;动态的树：葡园酒香附属;Dynamic Trees for Vinery;
+tfc-aesthetics;15340;tfc-plus-aesthetics;TFC+ Aesthetics;;
+smooth-gui;15341;smoothgui;Smooth Gui;;
+offershud;15342;offershud;OffersHUD;;
+perspektive;15343;perspektive;Perspektive;;
+ore-harvester;15344;oreharvester;Ore Harvester;;
+flightassistant;15345;flightassistant;FlightAssistant;;
+biomefog;15346;biome-fog;Biome Fog;;
+edgeless-chat-screen;15347;edgelesschatscreen;无边界聊天框;Edgeless Chat Screen;
+villager-death-messages;15348;villagerdeathmessages;Villager Death Messages;;
+;15349;smoothskies;Smooth Skies;;
+clist;15350;coordinatelist;CList;;
+tothestarsremake;15351;tothestarsremake;ToTheStarsRemake;;
+galacticraft-gravity;15352;gcg;Galacticraft Gravity;;
+dragon-mounts-even-more-dragons;15353;evenmoredragons;龙骑士附属：附加龙;Dragon Mounts: Even More Dragons;
+xplus-contingameime;15354;ingameime;游戏内输入法 XPlus 版;XPlus ContingameIME;
+;15355;watersource;水源 2;Water Source 2;
+radomraidspawn;15356;randomraid;随机袭击生成;Random Raid Spawn;
+enigmatic-legacy-legacy;15357;enigmaticlegacy;神秘²遗物;Enigmatic Legacy Legacy;
+tschipcrafts-dynamic-lights;15358;dynamiclights;动态光源 [数据包版];Dynamic Lights [Data Pack];
+nco-java-legacy-lib;15359;nclegacy;NCO Java Legacy Lib;;
+forge-souls-like-universe;15360;soulslikeuniverse;souls-like universe: epic fight;;
+;15361;rts;渲染工具;RenderTools;RTS
+;15362;GTNHModify;万宁NH;GTNH Modify;
+;15363;dream_core_decoration;梦核装饰;Dream core decoration;DCD
+neutral-animals;15364;neutral-animals;Neutral Animals;;
+create-upgraded-armor;15365;create_upgraded_armor;Create: Upgraded Armor;;
+fbp-renewed;15366;fbp;Fancy Block Particles - Renewed;;FBPR
+chat-impressive-animation;15367;chatimpressiveanimation;聊动魅影;Chat Impressive Animation;CIA
+;15368;pianoplayer;钢琴块;;
+pianocraft;15369;pianocraft;PianoCraft;;
+jazzymusicality;15370;musicality_legacy;Musicality;;
+;15371;boids;Boids;;
+buckshotroulette;15372;buckshotroulette;恶魔轮盘赌;BuckshotRoulette;BR
+customnpcs-unofficial;15373;customnpcs;CustomNPCs Unofficial;;
+;15374;fasttrading;Fast Trading;;
+simple-wooden-pipes;15375;simplewoodenpipes;Simple Wooden Pipes;;
+simplywalk;15376;simplywalk;SimplyWalk;;
+persistent-stuff;15377;persistent-stuff;Persistent Stuff;;
+lan-operators;15378;lanoperators;LAN Operators;;
+compatdatapacks;15379;compatdatapacks76;CompatDatapacks;;
+the-luminous-mod;15380;luminousworld;The LUMINOUS Mod;;
+;15381;mpwl;整合包模组白名单;ModPackWhiteList;MPWL
+;15382;mwb;MouseWheelButton;;MWB
+burst-door-open;15383;bdo;破门而入;Burst Door Open;BDO
+;15384;sheng_xi;笙汐;;
+;15385;hyperdimensionaltech;超维度科技;Hyperdimensional Tech;HT
+chain-suspension-forge;15386;chainsuspension;Chain Suspension;;
+cui;15387;cui;Colorful ui;;CUI
+emi-enchanting;15388;emi_enchanting;EMI Enchanting;;
+clientsort;15389;clientsort;Client Sort;;
+immersive-ui;15390;immersiveui;Immersive UI;;
+;15391;customportalapi;自定义传送门 API;Custom Portal Api;
+curios-continuation;15392;curios;Curios API Continuation;;
+;15393;minekimi;MineKimi;;
+blind-accessibility;15394;minecraft_access;Blind Accessibility/Minecraft Access;;
+enchanting-tree;15395;enchantingtree;Enchanting Tree;;
+dragon-enchants;15396;dragon_enchants;Dragon Enchants;;
+item-placer;15397;itemplacer;Item placer;;
+expandedworld;15398;expandedworld;Expanded World;;
+monster-hunter-villager;15399;monster_hunter_villager;Monster Hunter Villager;;
+jcraft-eyes-of-ender;15400;jcraft;JCraft: Eyes of Ender;;
+;15401;return_dirt_background;Return Dirt Background;;
+;15402;nmn;NotifyMe-NeoForge;;
+;15403;reset-keys-confirmation-screen;Reset Keys Confirmation Screen;;
+idle-boost;15404;idle_boost;Idle Boost;;
+bettergrassify;15405;bettergrass;更好的草地;BetterGrassify;
+;15406;lightweight-inventory-sorting;Lightweight Inventory Sorting;;
+;15407;loom-remastered;Stonecutter GUI Remastered;;
+;15408;loom-remastered;Loom GUI Remastered;;
+unseaworthy;15409;unseaworthy;Unseaworthy;;
+;15410;chromaanvils;ChromaAnvils;;
+thermal-and-space;15411;thermal_and_space;Thermal And Space;;
+create-curios-jetpack;15412;create-curios-jetpack;Create: Curios Jetpack;;
+epic-knights-antique-legacy;15413;antiquelegacy;Epic Knights: Antique Legacy;;
+viking-samurai-knight-items;15414;ryans_vsk;Viking / Samurai / Knight Items;;
+barely-simple-staffs;15415;barely_simple_staffs;Barely Simple Staffs;;
+;15416;;Better Vanilla Mobs;;
+;15417;;Gorify;;
+alexs-caves-delight;15418;alexscavesdelight;Alex's Caves Delight;;
+alexs-caves-adventure;15419;alexscaves_adventure;Alex's Caves: Adventure;;
+divine-weaponry;15420;divine_weaponry;Divine Weaponry;;
+;15421;fj;FluidJump;;FJ
+hook;15422;hook;抓钩;Hook;
+fix-guard;15423;fixguard;格挡修复;FixGuard;
+;15424;gregcaves;格雷的洞穴;Greg Caves;GC
+better-mob-combat;15425;bettermobcombat;Better Mob Combat;;
+mob-player-animator;15426;mobplayeranimator;Mob Player Animator;;
+depression;15427;depression;抑郁症;Depression;
+more-rpg-classes;15428;more_rpg_classes;More RPG Library;;
+minimalism-leaf-decay;15429;minimalism_leaf_decay;极简快速落叶;Minimalism Leaf Decay;MLD
+biome-modifier-for-fabric;15430;biome_modifier;Fabric版群系编辑器;Biome Modifier for Fabric;BM
+chunkloader-simple;15431;mychunkloader;Chunkloader;;
+apollyon;15432;apollyon;Apollyon;;
+worldweaver;15433;wover;WorldWeaver;;WoVer
+netherite-compass;15434;netherite_compass;Netherite Compass;;
+the-darkness-will-find-you;15435;the_darkness_will_find_you;The Darkness Will Find You;;
+silent-screenshots;15436;silentscreenshots;Silent Screenshots;;
+cr3stal-updatet;15437;cr3stal;Cr³stal;;
+toggle-subtitles;15438;togglesubtitles;Toggle Subtitles;;
+ok-boomer-zoom;15439;ok-boomer;Ok Boomer;;
+;15440;flattened_dimensions;Flattened Dimensions;;
+;15441;forcegl20;ForceGL2.0-Remapped;;
+;15442;dragon_survival_fix;龙之生存综合修复;;
+rendi;15443;rendi;重生：伤害免疫机制移除;ReNDI;
+create-questing;15444;create_questing;Create Questing;;
+;15445;create_train_perspective;Create Train Perspective;;
+elainalike;15446;elainalike;魔女之绘 重生：重生;ElainaLike Reborn:Reborn;
+take-back-your-sword;15447;tbys;收回你的剑！;Take Back Your Sword;TBYS
+;15448;sk;SameKeyBind;;SK
+;15449;eww;边缘行走;EdgeWalk;EW
+;15450;reciperenderer;配方渲染;Recipe Render;RR
+travel-friendly-food-fabric-forge;15451;travel_friendly_food;Travel Friendly Food;;
+stardew-valley-food;15452;stardewvalley_food,sdvf;Stardew Valley Food;;
+minecolonies-compatibility;15453;minecolonies_compatibility;MineColonies: Compatibility;;
+bettergamma;15454;bettergamma;BetterGamma;;
+more-lectern-variants;15455;lolmlv;More Lectern Variants;;
+;15456;ase;AnotherSimpleElevator;;ASE
+lush-cave-trader;15457;lushcavetrader;Lush Cave Trader;;
+oceans-enhancements;15458;oceans_enhancements;Ocean's Enhancements;;
+xp-jellies;15459;xp_jellies;Xp Jellies;;
+aromatic;15460;aromatic;Aromatic;;
+onekeyminerforge;15461;onekeyminer;一键连锁Forge版;OneKeyMinerForge;OKMFo
+;15462;cuf;ChatUpForge;;
+retargetato;15463;retargetato;约谊敌众;ReTargetato;
+iceandfire-ce;15464;iceandfire;冰火传说社区版;IceAndFire Community Edition;IAFCE
+tomanos-vehicle-mod;15465;vehiclemod;Tomano's Vehicle Mod;;
+ancient-sands;15466;ancientsand;Ancient Sands;;
+hs-bosses;15467;hs_bosses;H's bosses;;
+chubby-mobs;15468;chubby_mobs;Chubby Mobs;;
+repair-gem;15469;repairgem;修复宝石;Repair Gem;
+better-weaponry-compatible-with-better-combat;15470;better_weaponry;Better Weaponry;;
+disable-front-perspective;15471;disablefrontperspective;disable front perspective;;
+;15472;ntt;NetherTweaker;;NT
+;15473;lastserver;LastServer;;
+thaumcraft-6-aspects-for-jei;15474;thaumcraft-6-aspects-for-jei;Thaumcraft 6 Aspects for JEI;;
+;15475;up_and_away;Up and Away;;
+;15477;rotp_zhp;RotP：紫色隐者附属;Ripples of the Past: Hermit Purple Addon;
+nc-steam-additions;15478;ncsteamadditions;NuclearCraft Steam Additions;;
+aura-cascade;15479;Aura;气场流注;Aura Cascade;
+rac-compat;15480;raccompat;Relics: Alex's Caves Compat;;
+spartan-weaponry-addon-toolkit;15481;spartantoolkit;Spartan Weaponry Addon Toolkit;;
+smsn;15482;smsn;Save My Shaky Network;;SMSN
+sneaky-tree-growing-forge;15483;sneaky_tree_growing;Sneaky Tree Growing;;
+hungry-zombies;15484;hungryZombies;Hungry Zombies;;
+;15485;gravity_gourds;Gravity, Gourds, & You;;
+usa-delight;15486;usadelight;USA Delight;;
+experience-farm;15487;xp_farm;Experience Farm;;
+ad-extendra-dandi2k8-version;15488;ad_extendra;Dandi2k8's Ad Extendra;;
+nebulus-juice-trader;15489;nebulus_juce_trader;Nebulus Juice Trader;;
+cthulhu-fishing;15490;cthulhufishing;Cthulhu Fishing;;
+large-super-potato;15491;largesuperpotato;大型超级马铃薯;Large Super Potato;LSP
+;15492;crafttime;Craft Time;;
+the-orcs;15493;theorcs;The Orcs!;;
+made-in-abyss-shroombears;15494;shroombear;Made in Abyss: Shroombears;;
+squinkers;15495;squinkers;Squinkers;;
+mokels-bossfight-kinora;15496;mokels_boss_mantyd;Mokels Bossfight: Kinora;;
+;15497;create_high_pressure;Create High Pressure;;
+create-framed;15498;createframed;机械动力：多彩边框;Create: Framed;
+trackwork;15499;trackwork;Trackwork;;
+oritech;15500;oritech;Oritech;;
+the-impossible-library;15501;the-impossible-library;The Impossible Library;;
+perspective-mod-redux;15502;perspectivemod;Perspective Mod Redux;;
+more-cartography-tables;15503;lolmcgt;More Cartography Tables;;
+more-barrel-variants;15504;lolmblv;More Barrel Variants;;
+wheelbarrow;15505;wheelbarrow;Wheelbarrow;;
+simple-automation;15506;simple_automation;Simple Automation;;
+better-paragliders;15507;betterparagliders;Better Paragliders;;
+fallen-wizards-more-magic-series;15508;fallenwizardsmod;Fallen Wizards;;
+;15509;lootreplacer;LootReplacer;;
+;15510;whiffowisp;Whiff O' Wisp;;
+mango-cats;15511;mango_cars;Mango Cats;;
+tax-tree-giant;15512;taxtg;Tax' Tree Giant;;
+taxskyvillager;15513;taxsv;Tax' Sky Villager;;
+compostable-rotten-flesh;15514;compostable-rottenflesh;Compostable Rotten Flesh (Fabric);;
+villager-in-a-bucket;15515;villagerinabucket;Villager In A Bucket;;
+nebulus-trader-for-the-desert;15516;nebulus_desert_trader;Nebulus Trader for the Desert;;
+nebulus-jungle-trader;15517;nebulus_jungle_trader;Nebulus Trader for the Jungle;;
+mushroom-villager-trader;15518;mushroom_villager_trader;Mushroom Villager Trader;;
+nebulus-better-portals;15519;nebulusbetterportals;Nebulus Better Portals;;
+resource-ghouls;15520;resource_ghouls;Resource Ghouls;;
+avaritianeo;15521;avaritia;无尽贪婪Neo;AvaritiaNeo;
+create-legacy;15522;;Create Legacy;;
+;15523;bronze_age;Create: Bronze Age;;
+wind-bottle;15524;wind_bottle;风瓶;wind bottle;WindB
+lc-tech;15525;lightmanscurrency;LC Tech;;
+minecolonies-tweaks;15526;minecolonies_tweaks;Tweaks addon for MineColonies;;
+text-placeholder-api;15527;placeholder-api;文本占位符 API;Text Placeholder API;
+;15528;gravity_changer_q;Gravity Changer (qouteall fork);;
+;15529;btt;更好的游戏标题;BetterTitle;
+;15530;tt20;TT20;;
+kasugalib;15531;kasuga_lib;KasugaLib;;Ksglib
+;15532;etshtinker;乙硫基匠魂;C2H6S Tinker;EtST
+;15533;encounter;遭遇/长驱速弑;Encounter;
+kubejs-mekanism-unofficial;15534;kubejs_mekanism;KubeJS Mekanism UNOFFICIAL;;
+;15535;mediaplayer;媒体播放器;MediaPlayer;MP
+bakery-villager-trader;15536;bakery_villager_trader;Bakery Villager Trader;;
+nebulus-trader-for-the-plains;15537;nebulus_plains_trader;Nebulus Trader for the Plains;;
+mokels-more-spiders;15538;mokels_spider_extension;Mokels more Spiders;;
+;15539;villagerstocker;村民补货器;VillagerStocker;
+exposure-catalog;15540;exposure_catalog;Exposure Catalog;;
+skinchanger;15541;skin_changer;SkinChanger;;
+;15543;halflifemenu;Half-Life Menu;;
+sitting;15544;sitmod;Sitting+;;
+forgotten-east;15545;forgotteneast;Forgotten East;;
+brazil-legends;15546;brazil_legends;Brazil Legends;;
+;15547;bettertp;更好的TP指令;BetterTP;
+custom-item-despawn-duration;15548;custom-item-despawn-duration;自定义掉落物消失时间;Custom Item Despawn Duration;
+your-items-to-new-worlds;15549;your_items_to_new_worlds;Your Items to New Worlds;;
+enhanced-boss-bars;15550;enhanced_boss_bars;更好的Boss血条;Enhanced Boss Bars;
+cutetrade;15551;cutetrade;CuteTrade;;
+;15552;rtb;随机标题：重生;RandomTitleReborn;
+smoothmenu-refabricated;15553;smoothmenu;平滑菜单：重制版;SmoothMenu Refabricated;
+;15554;mr_minibossbars;Miniboss Bars;;
+toexistingstacks;15555;existing_stacks;添加到现有堆叠;ToExistingStacks;
+;15556;postmortalparticles;Postmortal Particles;;
+;15557;give-me-a-new-splash-text;Give me a new splash text!;;
+;15558;lessannoyingfire;Less Annoying Fire;;
+treasuredistance;15559;treasuredistance;Better Treasure Map;;
+affinity;15560;affinity;Affinity;;
+chaos-moon;15561;chaosmoon;Chaos Moon;;
+;15562;healthindicator;HealthIndicator;;
+;15563;small_chisel;小凿子;Small chisel;SCL
+;15564;autosprintfix;Auto Sprint Fix;;
+lets-do-emi-compat;15565;emi_letsdo_compat;[Let's Do Addon] EMI Compat;;
+health-indicator;15566;healthindicators;Health Indicators;;
+aiming-fix;15567;aimingfix;Aiming Fix;;
+compasshud;15568;compasshud;指南针HUD;CompassHUD;
+mini-boss-boss-bars;15569;miniboss_boss_bars;Mini-boss Boss Bars;;
+berserker-rpg-class;15570;berserker-rpg;Berserker (More RPG Classes);;
+fromanotherlibrary;15571;fromanotherlibrary;FromAnotherLibrary;;
+mounted-pearl-bring-your-mount-along-when-you;15572;mountedpearl;Mounted Pearl;;
+biome-id-fixer;15573;biomeidfixer;Biome Id Fixer;;
+immortal-coral;15574;immortalcoral;Immortal Coral;;
+immersive-guns;15575;immersive_guns;Immersive Guns;;
+;15576;mr_guns;Guns++;;
+additional-rpg-jewelry;15577;additional_rpg_jewelry;Additional RPG Jewelry (More RPG Content);;
+mekanism-ad-astra-ores;15578;mekanismaaa;Mekanism: Ad Astra Ores;;
+question-ducks-ambient-fireflies;15579;ambiance;Question Duck's Ambient Fireflies;;
+travelerz;15580;travelerz;TravelerZ;;
+the-rise-of-minerals;15581;trom;矿石崛起;The Rise Of Minerals;TRoM
+gregtech-steam-additions;15582;steamadditions;Gregtech Steam Additions;;
+gregtech-nomifactory-edition;15583;gregtech;GregTech Nomifactory Edition;;
+create-ethium;15584;ethuim;Create: Ethium;;
+create-contraption-terminals;15585;createcontraptionterminals;机械动力：动态终端;Create Contraption Terminals;
+;15586;;天域初始维度;SkyOverDimension;
+strata-recipes;15587;stratarecipes;Strata Recipes;;
+strayed-fates-forsaken;15588;mr_strayed_fatesforsaken,forsaken;STRAYED FATES: Forsaken;;
+snowyleavesplus;15589;snowyleavesplus;SnowyLeavesPlus;;
+shield-overhaul;15590;shield_overhaul;Shield Overhaul;;
+g-weapons-mod-gargantuan-weapons-mods;15591;gweapons;G武器;G-Weapons;
+backtools;15592;backtools;工具后置/后背工具展示：重制版;BackTools;
+epic-fight-guandao-moveset;15593;falchionmoveset;史诗战斗：关刀;Epic Fight - Guandao Moveset;
+epicfight-dual-greatsword;15594;efdg;Epicfight - Dual GreatSword;;
+spell-checker;15595;spellchecker;Spell Checker;;
+sparkle;15596;sparkle;Sparkle;;
+;15597;visibletraders;Visible Traders;;
+villagers-inventory;15598;villagers_inventory;Villagers' Inventory;;
+removehud;15599;removehud;RemoveHUD;;
+;15600;orthocamera;OrthoCamera;;
+third-person-crosshair-fabric;15601;tpcrosshair;Third Person Crosshair (Fabric);;
+;15602;hitrange;HitRange;;
+black-moon;15603;blackmoon;Black Moon;;
+dynamic-fire-overlay;15604;dynamic-fire-overlay;Dynamic Fire Overlay;;
+firorize;15605;oscimate_soulflame;Firorize / Improved Fire Overlay;;
+smoke-extender;15606;smokeextender;Smoke Extender;;
+;15607;nohotbarlooping;No Hotbar Looping;;
+;15608;higher-chat;Higher Chat (chat above armor bar);;
+mekanism-cardboard-tooltip;15609;mekanismcardboardtooltip;Mekanism Cardboard Tooltip;;
+durability-notifier;15610;durabilitynotifier;Durability Notifier;;
+gregtech-extended-chemistry;15611;gtec;Gregtech: Extended Chemistry;;
+centrifuge-tiers;15612;ctiers;Centrifuge Tiers;;
+distant-friends;15613;distantfriends;Distant Friends;;
+the-world-of-herobrine;15614;the_world_of_herobrine;The World Of Herobrine;;
+primal-storage;15615;primalstorage;Primal Storage;;
+;15616;potioncore;药水核心重制;PotionCoreReloaded;PCR
+yamazakura-reforked;15617;yamazakura;山樱之刃重置版;Yamazakura reforked;
+;15618;bad_omen_potion_reborn;不祥之兆药水：重生;Bad Omen Potion:Reborn;BOPR
+;15619;;随机名字生成数据包;Name Generator Datapack;NGD
+apothic-spawners;15620;apothic_spawners;Apothic Spawners;;
+;15621;dbcmobends;龙珠更多弯曲;DBCMoBends;
+sinocore;15622;sinocore;华夏核心;SinoCore;SC
+tinted-dyes;15623;tinted_dyes;Tinted Dyes;;
+dynamic-trees-ecologics;15624;dtecologics;动态的树：丰富的生态附属;Dynamic Trees - Ecologics;
+craftablecapes;15625;craftablecapes;可合成的披风;Craftable Capes;
+tamago;15626;tamago;Tamago;;
+;15627;clickthrough;Clickthrough 2.0;;
+cat-jammies-fabric;15628;catjammies;Cat Jammies;;
+open-computer-resurrected;15629;;Open Computer: Resurrected;;
+advancements-reloaded;15630;advancementinforeloaded;AdvancementInfo Reloaded;;
+oc2r;15631;oc2r;OpenComputers II: Reimagined;;
+eu-p2p-tunnel;15632;eup2p;EU能源P2P通道;EU P2P Tunnel;
+;15633;hold_onto_everything;Hold Onto Everything;;
+ardagrass;15634;ardagrass;ArdaGrass;;
+geocluster;15635;geocluster;Geocluster;;
+;15636;;Tinker's Masonry;;
+;15637;knives_construct;Knives Construct;;
+;15638;;Tinker's Woodworks;;
+updating-world-icon;15639;updatingworldicon;Updating World Icon;;
+shared-resources;15640;shared-resources;Shared Resources;;
+tech-dimension;15641;techdimension;Tech Dimension;;
+tilt-break;15642;tiltbreak;Tilt Break (Old Damage Tilting);;
+item-frament;15643;itemframent;Item Framen't;;
+water-vision;15644;water_vision;Water Vision;;
+randomized-default-fireworks;15645;randomized_default_fireworks;Randomized Default Fireworks;;
+glowing-torchflower;15646;glowing-torchflower;Glowing Torchflower;;
+;15647;clock-hud;Clock Hud Renew;;
+cameranoclip;15648;cameranoclip;CameraNoClip;;
+barriers-dont-block-rain;15649;barriers-dont-block-rain;Barriers Don't Block Rain;;BDBR
+no-render;15650;no_render;No Render;;
+;15651;ncf;不诅咒-Forge;NoCurseForge;NCF
+runningshoes;15652;runningshoes;跑鞋;Running Shoes;
+fluid-void-fading;15653;fluidvoidfading;Fluid Void Fading;;
+;15654;movement-in-gui;Movement In GUI;;
+glowing-eyes;15655;glowingeyes;Glowing Eyes;;
+youarch;15656;litematica;YouArch;;
+true-darkness-fabric;15657;darkness;True Darkness Refabricated;;
+esf-entity-sound-features;15658;entity_sound_features;实体声音特性;Entity Sound Features;ESF
+nomoreglowingpots;15659;nomoreglowingpots;No More Glowing Potions;;
+smooth-particles;15660;smoothparticles;Smooth Particles;;
+;15661;aowf;始终开放水域-Forge;AlwaysOpenWaterForge;AOWF
+unloaded-activity;15662;unloadedactivity;Unloaded Activity;;
+;15663;improperui;ImproperUI;;
+neverenoughanimation;15664;neverenoughanimations;NeverEnoughAnimation;;NEA
+reds-stagger-parry;15665;staggered;Redxzy's Parry & Stagger;;
+additional-placements;15666;additionalplacements;Additional Placements;;
+akicaters-shelves;15667;aki;Akicater's Shelves;;
+refurbished-furniture;15668;refurbished_furniture;MrCrayfish 的家具：重制;MrCrayfish's Furniture Mod: Refurbished;CFMR
+improved-stations-forge;15669;improved-stations;Improved Stations;;
+elemental-wizards-rpg-class;15670;elemental_wizards_rpg;Elemental Wizards (More RPG Classes);;
+pov-that-one-short-friend;15671;short_friend;POV: That one short friend;;
+onward-and-upward;15672;onward_upward;Onward and Upward!;;
+weapon-case-loot;15673;weaponcaseloot;武器箱战利品;Weapon Case Loot;
+mace-but-3d;15674;macebut3d;Mace but 3D;;
+;15675;healthindicators;Player Health Indicators;;
+smoothcoasters;15676;smoothcoasters;SmoothCoasters;;
+do-a-flip;15677;doaflip;Do a Flip;;
+;15678;nodeathanimation;No Death Animation;;
+veindigging;15679;veindigging;VeinDigging;;
+too-many-entities;15680;too-many-entities;Too Many Entities;;
+;15681;cscore;CScore;;
+;15682;otf;万能翻译-Forge;OmniTranslationForge;OTF
+;15683;mes;更多附魔;MoreEnchantments;MES
+;15684;banitem;不准用！;BanItem;
+datapack-breakpoint;15685;datapack-breakpoint;断点调试;Datapack Debugger;
+;15686;nuclealloy;核金;Nuclealloy;NA
+endlessluckblock;15687;endless;无尽幸运方块;Endless Luck Block;
+frosted-heart;15688;frostedheart;冬季救援：寒霜之心;The Winter Rescue: Frosted Heart;FH
+create-planetary-tweaks;15689;cp_tweaks;Create Planetary Tweaks;;
+entris;15690;entris;Entris: Enchanting Tetris;;
+;15691;sushi_bar;Sushi Bar;;
+lumi;15692;lumi;Lumi;;
+pet-the-frog;15693;frog_petting;Pet the Frog;;
+ex-nihilo-extras;15694;exnihiloextras;Ex Nihilo Extras;;
+cycle-title-screen-splash;15695;cycletitlescreensplash;Cycle Title Screen Splash;;
+hide-invisible-armor;15696;hideinvisiblearmor;Hide Invisible Armor;;
+inventory-tweaks-refoxed;15697;invtweaks;Inventory Tweaks - ReFoxed;;
+bigshot;15698;bigshot;BigShot;;
+more-immersive-aircraft;15699;moreimmersiveaircaft;More Immersive Aircraft;;
+legendary-survival-overhaul;15700;legendarysurvivaloverhaul;传说生存;Legendary Survival Overhaul;LSO
+mineral-delight;15701;mineraldelight;Mineral Delight;;
+not-just-sandwich;15702;refurbished_furniture;Not Just Sandwich;;
+fantasyfood;15703;fantasyfood;幻想食物;FantasyFood;FF
+allthefood;15704;allthefood;AllTheFood;;
+villager-names-fabric;15705;villagernames;Villager Names;;
+trial-vault-restock;15706;trialrestock;Trial Vault Restock;;
+hot-green-fire;15707;hotgreenfire;Hot Green Fire;;
+phantom-flames;15708;phantom_flame;Phantom Flames;;
+darktitlebar;15709;dark_title_bar;DarkTitleBar;;
+cubes-without-borders;15710;cubes-without-borders;Cubes Without Borders;;
+block-parry-dodge;15711;block_parry_dodge;Block, Parry, Dodge;;
+fargos-enchantments;15712;fargos;Fargo's Enchantments;;
+toostrongmonster;15713;toostrongmonster;TooStrongMonster;;
+simplystronger;15714;simplystronger;SimplyStronger;;
+tacz-durability;15715;gundurability;TACZ: Durability;;
+bigger-lightning-storms;15716;lightningstorms;Bigger Lightning Storms;;
+eternal-limbo;15717;eternallimbo;Eternal Limbo;;
+legoman;15718;LegoMan;LegoMan;;
+petcreepers-mod;15719;littletinyme;PetCreepers mod;;
+tugkandemans-weaponry;15720;twm;TugkanDeMan's Weaponry;;TWM
+;15721;;玩家头颅;Player skull;
+;15722;bk;老板键;BossKey;BK
+;15723;cg;运算变速;ChangeGear;CG
+;15724;osf;还原旧皮肤-Forge;OlderSkinsForge;OSF
+;15725;fisher;渔者的奇迹之肝;Fisher;
+;15726;more_cd;更多命令;;MCD
+;15727;betternether;崇祯五年的下界;Chongzhen's Nether;CZN
+;15728;noanysus;NoAnySUS;;
+rekusaeater;15729;rekusaeater;Re艹;ReKusaEater;
+jsg;15730;jsg;Just Stargate Mod;;JSG
+;15731;potion_mixing;药水混合;Potion Mixing;PM
+sandfilter;15732;sandfilter;砂滤器;Sand Filter;
+resaplingslayer;15733;resaplingslayer;雁雅得枝;ReSaplingslayer;
+cerberu;15734;restarks;狱牙抵战;Cerberus;
+remoreloyaltrident;15735;moreloyaltrident;远亦得珍;ReMoreloyaltrident;
+potionlevelfix;15736;potion_level_fix;药水等级修复/药引对注;PotionLevelFix;
+reunmending;15737;unmending;以验垫砧;ReUnmending;
+reghostjump;15738;ghostjump;引殃髑至;ReGhostJump;
+rebroken-blade;15739;broken_blade;隐影刀珍;Mowzie's Mobs: ReBroken Blade;
+attackagain;15740;attackagain;又御刀追/追击;AttackAgain;
+;15741;sectionsign;SectionSign§;;
+;15742;allowchat;Allow Chat;;
+retro-damage-indicators;15743;retrodamageindicators;Retro Damage Indicators;;
+;15744;Fabric API;Improper's 3D Minimap;;
+beddium;15745;beddium;Beddium;;
+create-thermal-compat;15746;create_thermal;Create Thermal Compat;;
+create-lagless;15747;createlagless;Create: Lagless;;
+create-ironworks;15748;create_ironworks;Create: Ironworks;;
+;15749;create_vibrant_vaults;Create: Vibrant Vaults;;
+steam-power;15750;steam_powered;Steam Powered;;
+kevs-library;15751;kevslibrary;Kev's Library;;
+remove-purpleprison-ads;15752;removepurpleprison;Remove PurplePrison Ads;;
+timeoutfixes;15753;timeout_fixes;Timeout Fixes;;
+forgeskyboxes;15754;forgeskyboxes;ForgeSkyboxes;;
+customfishing;15755;customfishing;随液钓趣;CustomFishing;CF
+metr0polis;15756;metropolis;Métropolis.;;MET
+crust;15757;crust;Crust;;
+;15758;aebusblacklist;AE存储总线黑名单;AE StorageBus Blacklist;
+sc-structurecraft;15759;structurecraft;StructureCraft;;SC
+minehop;15760;minehop;Minehop;;
+placeabletools;15761;PlaceableTools;PlaceableTools;;
+rlfoliage;15762;betterfoliage;RLFoliage;;
+bc-remastered;15763;;BC Remastered;;
+;15764;deepdrilling;Deep Drilling;;
+copperworks;15765;copperworks;Copperworks;;CW
+;15766;;Real Hero of the Village;;HOV
+;15767;mr_village_heroplus;Village Hero+;;
+miner-villager;15768;minervillager;Miner Villager;;
+villager-venture;15769;villager_venture;Villager Venture;;
+alekiships;15770;alekiships;aleki's Nifty Ships;;
+alekishipsbop;15771;alekishipsbop;Nifty Ships + Biomes O'Plenty Compat;;
+antique-trading-ship;15772;antique_trading_ship;Antique Trading Ship;;
+small-horse-stable;15773;smallhorsestable;Small Horse Stable;;
+shrek-the-ogre;15774;shrek;Shrek;;
+the-anomaly;15776;the_anomaly;The Anomaly;;
+desert-behemoths-sandworms;15777;sandworm_mod;Desert Behemoths: Sandworms!;;
+vermintide-rising;15779;vermintide_rising;Vermintide: Rising;;
+armor-of-the-ages;15780;armoroftheages;时代铠甲;Armor of the Ages;
+;15781;hungrycolonies;饥饿殖民地;;HC
+;15782;ci;引雷物品;ChannelingItem;CI
+;15783;mot;Mxpea's Multiplayer Motion API;;MMMAPI
+;15784;betterf3;BetterF3 StationAPI;;
+ftb-quest-localizer;15785;ftbquestlocalizer;FTB Quest 本地化;FTB Quest Localizer;FTBQL
+modpack-update-checker;15786;modpack-update-checker;Modpack Update Checker;;MPUC
+minimotd-fabric;15787;minimotd-fabric,minimotd;MiniMOTD;;
+effecttimerplus;15788;effecttimerplus;Effect Timer Plus;;
+thaumic-concilium;15789;ThaumicConcilium;神秘议会;Thaumic Concilium;
+equivalentexchange;15790;equivalentexchange;Equivalent Exchange / Equivalent Exchange 4;;
+;15791;gm4_apple_trees;苹果树;Apple Trees;
+coral-up;15792;coralup;Coral Up;;
+plushie-buddies;15793;plushie_buddies;Plushie Buddies;;
+;15794;aethersdelight;Aether's Delight;;
+;15795;wheelchairs;Wheelchairs;;
+dnt-pillager-outpost-overhaul;15796;mr_dungeons_andtavernspillageroutpostoverhaul;DnT Pillager Outpost Overhaul;;
+mage-flame;15797;mageflame;Mage Flame;;
+;15798;totem-party;Totem Party Popper;;
+;15799;powerless_refinedstorage;Refined Storage: Powerless Addon;;
+forgotten-graves;15800;forgottengraves;Forgotten Graves;;
+day-zombies;15801;dayzombies;DayZombie;;
+morecoal;15802;morecoal;更多煤炭;;
+jjku;15803;jujutsucraftaddon;Jujutsu Kaisen Ultimate Rework;;JJKU
+ice-and-steel;15804;sunrise;Ice and Steel;;
+immersive-combat-feathers;15805;bettercombat;Immersive Combat Feathers;;
+ghosties-monocle;15806;monocle;Ghostie's Monocle!;;
+ender-dragon-loot;15807;ender_dragon_loot_;Ender Dragon Loot;;
+;15808;mr_epicterrain,mr_epic_terrain_compatible;史诗地形;Epic Terrain;ETN
+oh-the-trees-youll-grow;15809;ohthetreesyoullgrow;Oh The Trees You'll Grow;;
+oh-the-biomes-weve-gone;15810;biomeswevegone;我们走过的生物群系;Oh The Biomes We've Gone;BWG
+dblockbusterdisplays;15811;webdisplays;DBlockbusterDisplays;;
+;15812;wac;自动重连;W-AutoReconnect;WAC
+;15813;scbc;SimpleClientBaseCore;;SCBC
+;15814;waygl;WayGL;;
+no-sneaking-over-magma;15815;no_sneaking_over_magma;No Sneaking Over Magma!;;
+harmonia;15816;harmonia;Harmonia;;
+configurable-head-drop;15817;configurableheaddrop;Configurable Head Drop;;
+;15818;c3me;C^3M 引擎;Connectored Concurrent Chunk Management Engine;C3ME
+structure-expansion;15819;structureexpansion;Structure Expansion;;
+armored-doggo;15820;armoreddoggo;Armored Doggo;;
+the-newest-goatman;15821;goatman;The Newest Goatman;;
+epic-mob-siege-nightmare;15822;nightmareesm;Epic Mob Siege: Nightmare;;EMSN
+jupiter;15823;jupiter;Jupiter;;
+airport;15824;mass_island_airfields;Airport Lighting;;
+just-dandy;15825;just_dandy;Just Dandy;;
+;15826;uk_roads;UK Roads;;
+my-totem-doll;15827;my-totem-doll;My Totem Doll;;
+;15828;void_power;虚空动力;Void Power;
+;15829;expansion_of_building_materials;建材拓展;Expansion of Building Materials;EBM
+dis-enchanting-table;15830;disenchanting_table;Dis-Enchanting Table;;
+;15831;al;服务器自动登录;AutoLogin;AL
+;15832;aemobile;Minecraft 赛博监工;AEMobile;
+gt-top-addition;15833;gttopaddition;格雷信息显示拓展;GT TOP Addition;GTTA
+gt-steam-tech;15834;gtsteam;格雷蒸汽科技;GT Steam Tech;GTS
+simpleanimator;15835;simple_animator;SimpleAnimator;;
+tianjin-metro;15836;tjmetro;天津地铁;Tianjin Metro;
+modular-flower-pots;15837;modularpots;模组化花盆;Modular Flower Pots;
+repurposed-structures-floralis-compat-mod;15838;repurposed_structures_floralis_compat;结构变体：Floralis 兼容模组;Repurposed Structures - Floralis Compat Mod;
+repurposed-structures-rats-compat;15839;repurposed_structures_rats_compat;结构变体：老鼠兼容数据包;Repurposed Structures - Rats Compat Datapack;
+balanced-shield;15840;balancedshield;Balanced Shield;;
+more-potion-effects;15841;more_potion_effects;更多药水效果;More Potion Effects;MPE
+jungle-villages;15842;jungle_villages;Jungle Villages;;
+truecherry;15843;truecherry;TrueCherry;;
+;15844;evampedtrades;Revamped Trades;;
+creeper-fireworks;15845;creeperfireworks;烟花苦力怕;Creeper Fireworks Mod;CF
+;15846;word_overflow;Word Overflow;;
+chatnotify;15847;chatnotify;Chat Notify;;
+;15848;serverutilities;ServerUtilities;;
+nbt-tool;15849;nbttool;NBT Tool;;
+;15850;mr_mc_paint;MC Paint;;
+;15851;dscf;DebugScreenClassFinder;;
+;15852;bp;更好的活塞;BetterPiston;BP
+;15853;adventure;冒险++;Adventure++;
+dglab-x-minecraft;15854;dglab;Minecraft x DgLab;;DgLab
+twintails;15855;twintails;双马尾;TwinTails;
+gt-wireless;15856;gtwireless;格雷无线科技;GT Wireless;GTW
+forcejava21;15857;forcejava21;强制 Java21;ForceJava21;
+blessings;15858;blessings;祝福;Blessings;
+crafted-core;15859;craftedcore;CraftedCore;;
+call-from-the-depths;15860;callfromthedepth_;深渊召唤;Call From The Depths;
+;15861;clover;四叶草Fabric版;Clover Fabric;
+champions-unofficial;15862;champions;冠军/强敌再续;Champions-Unofficial;
+aetherworks-refracted;15863;aetherworks;Aetherworks Refracted;;
+eidolon-repraised;15864;eidolon;Eidolon : Repraised;;
+create-northstar;15865;northstar;Create: Northstar;;
+create-pattern-schematics;15866;create_pattern_schematics;机械动力：模式蓝图;Create: Pattern Schematics;
+magic-merchant;15867;magicmerchant;Magic Merchant;;
+aether-villages;15868;aether_villages;天境村庄;Aether Villages;
+tricky-trials;15869;tricky_trials;Tricky Trials 1.21;;
+;15870;mr_evaporated_waterfalls;Evaporated Waterfalls;;
+;15871;clover;粥粥杰的三叶草;zhoujclover;
+abilities-the-boys;15872;abilities;超能力-无限;abilities;
+;15873;BetterCore;Better Core;;
+;15874;armor_custommodeldata;ArmorCustomModelData;;
+better-creative-tabs-forge-neoforge;15875;betterceativetabs;更好的创造标签页;Better Creative Tabs;BCT
+more-upgrade;15876;update;更多锻造模板;MoreUpgrade;
+;15877;railway_accelerator;你有这么高速运转的矿车进入中国;railway accelerator;RA
+;15878;faqv;FAQ 村民!;FAQ Villagers!;faqv
+avaritia-unofficial;15879;avaritia_remastered;Avaritia Remastered;;
+stellaris;15880;stellaris;Stellaris;;
+command-o-matic;15881;commandomatic;Command-O-Matic;;
+;15882;YHBotaniaWaila;植物魔法高亮信息;BotaniaWaila;BW
+realistic-physics;15883;realisticphysics;Realistic Physics;;
+cia;15884;customitemattributes;自定义物品属性;Custom Item Attributes;CIA
+item-wheel;15885;wheel;Item Wheel;;
+data-attributes-directors-cut;15886;data_attributes;Data Attributes: Directors Cut;;
+better-walls;15887;betterwalls;Better Walls;;
+the-pillager-legion;15888;the_pillager_legion_;The Pillager Legion;;
+the-frozen-kingdom;15889;the_frozen_kingdom;The Frozen Kingdom;;
+stardew-fishing;15890;stardew_fishing;Stardew Fishing;;
+lets-do-a-jumpscare;15891;letsdoajumpscare;Let's do a jumpscare;;
+epic-tinkers-fight;15892;;史诗匠魂战斗;Epic Tinkers' Fight;ETF
+;15893;numenors;努门诺尔物品;Numenor Sub Mod;
+the-quackening;15894;duckensinvasion;The Quackening;;
+better-trial-chambers;15895;minecraft_121_update;Better Trial Chambers;;
+coldsweat-tfc;15896;coldsweat_tfc;ColdSweat TFC;;
+deeper-nether-biomes;15897;deepernetherbiomes;Deeper Nether Biomes;;
+adventurers-beyond;15898;adventuresmod;Adventurer's Beyond;;
+mss-moogs-soaring-structures;15899;mss;Moog's Soaring Structures;;MSS
+goblins-tyranny;15900;goblins_tyranny;哥布林的统治;Goblins Tyranny;
+no-32768-limit;15901;no_32768_limit;没有32768限制;No 32768 Limit;
+;15902;stf;启动时间-Forge;StartupTimeForge;STF
+;15903;nsmer;没那么多实体渲染;NotSoManyEntityRendering;NSMER
+;15904;neta;无附魔台动画;NoEnchantmentTableAnimation;NETA
+reairdrop-supply;15906;airdrop_supply;空投供应：重生;ReAirdrop Supply;RAS
+;15907;minequery;MC宝;MineQuery;
+;15908;whycooldown;为什么冷却;WhyCooldown;WC
+;15909;simply_create_model;简单动力;Simply Create Model;SCM
+mountains-poem;15910;mountains_poem;峰峦辞;Mountain's Poem;MTP
+;15911;playtime;游戏时长计数器：重生;Playtime Reborn;PR
+;15912;flavor_immersed_daily;烟火凡人心;Flavor Immersed Daily;FID
+moon-between-medicine;15913;moonbetweenmedicine;在月亮之间：药学拓展;Moon Between : medicine;
+craftable-chainmail-reborn;15914;craftablechainmail;可制作的锁链甲：重生;Craftable Chainmail Reborn;
+;15915;automobility_fix;飞车奇匠-服务端修复;Automobility-Fix;
+thaumcraftfix;15916;thaumcraftfix;神秘时代6修复;Thaumcraft Fix;
+;15917;teleport_compass;传送指针;teleport compass;TPCP
+extended-industrialization;15918;extended_industrialization;Extended Industrialization;;EI
+small-tetra-additions;15919;smalltetraadditions;Small Tetra Additions;;
+lets-do-furniture;15920;furniture;[Let's Do] Furniture;;
+tesseract-api-neoforge;15921;tesseract_api;Tesseract API;;
+spectrelib;15923;spectrelib;SpectreLib;;
+;15924;no_more_string;刷线机疑似有点城市化了;no more string;NMS
+tfc-artisanal;15925;artisanal;TFC Artisanal;;
+;15926;;群峦传说：矿石淘洗与群峦传说：矿石焙烧兼容数据包;Processing and Washing;TFCp&TFCw
+;15927;real_time;现实时间;;TRT
+;15928;stacked;堆叠++;Stacked++;
+dragonoptifix;15929;dragonoptifix;DragonBlockC 与 OptiFine 的兼容修复;DragonOptiFix;
+effortless-fabric;15930;effortlessstructure;Effortless Structure;;
+;15931;barriers-dont-block-rain;Barriers Don't Block Rain 1.21 Fork;;
+system-dynamic-lights;15932;new;System Dynamic Light;;
+;15933;nochathide;NoChatHide;;
+inventory-tweaks-extrafoamy;15934;inventorytweakse;Inventory Tweaks ExtraFoamy;;
+automatic-infinite-elytra;15935;autoinfelytra;Automatic Infinite Elytra;;
+re-translator;15936;retranslator;Re: Translator;;
+yank-it-out;15937;yio;Yank It Out;;YIO
+vintage-kubejs;15938;vintage_kubejs;Vintage KubeJS;;
+emi-professions-emip;15939;emiprofessions;EMI professions;;EMIP
+grindstone-enchantments;15940;grindenc;Grindstone Enchantments;;
+;15941;;Starlight Legacy;;
+themetip;15942;themetip;themetip;;
+woodwalkers;15943;walkers;Woodwalkers;;
+peaceful-moon;15944;peacefulmoon;Peaceful Moon;;
+to-tweaks-irons-spells;15945;traveloptics;T.O Tweaks - Iron's Spells Addon;;
+horde-moon;15946;zombiemoon;Horde Moon;;
+;15947;mr_useful_mobs;Useful Mobs;;
+laser-mod-2;15948;lasermod;Advanced Laser;;
+mekanism-lasers;15949;mekanism_lasers;Mekanism Lasers;;
+wizards-reborn;15950;wizards_reborn;Wizard's Reborn;;
+tinkervillager;15951;tinker17,tinkervillager;工匠村民;Tinker Villager;TV
+customnpc-contentback;15952;cnpc_contentback;CustomNPC Items;;
+debug-stick;15953;debugstick;Debug Stick;;
+useful-bat;15954;useful_bat;Useful Bat;;
+runic-inscription;15955;runicinscription;Runic Inscription;;
+bamboo-stuff;15956;trollchan120;Bamboo Stuff;;
+;15957;moai_update;Moai Update;;
+junk-drawers;15958;junkdrawers;Junk Drawers;;
+playerex-directors-cut;15959;playerex;PlayerEx: Directors Cut;;
+lets-do-camping;15960;camping;摇曳露营;[Let's Do] Camping;
+;15961;startuptime;启动时间非官方版;StartupTime Unoffical;STU
+serverconfig-updater;15962;serverconfigupdater;ServerConfig Updater;;
+;15963;epiczoomer;EpicZoomer;;
+;15964;mr_datapack_reloadhelper;Datapack Reload Helper;;
+agenta;15965;aganta;Agenta;;
+;15966;;Area of Effect (Advent of Expansion);;
+more-beehive-variants;15967;quad-lolmbhv;More Beehive Variants;;
+;15968;jmmf;Josh's More Foods;;
+persistent-creative-inventory;15969;persistentcreativeinventory;Persistent Creative Inventory;;
+lets-do-wildernature;15970;wildernature;野性自然;[Let's Do] WilderNature;
+;15971;quitconfirm;QuitConfirm;;
+;15972;ressourcepackcommand;RessourcePackCommand;;
+;15973;sfb;简易全亮;SimplestFullBright;SFB
+neodymium-unofficial;15974;neodymium;钕：非官方版;Neodymium Unofficial;NdU
+;15975;carbon;碳;Carbon;
+coloredglowlib;15976;coloredglowlib;ColoredGlowLib;;CGL
+;15977;better-snow-coverage;更好的雪覆盖;Better Snow Coverage;
+;15978;drg;叶压地株;Don't Render Grass;
+trade-enchantment-display;15979;tradeenchantmentdisplay;交易附魔显示;Trade Enchantment Display;TED
+eternal-starlight;15980;eternal_starlight;永恒星光;Eternal Starlight;
+astral-patch;15981;astralpatch;星辉补丁;Astral Patch;
+fast-scrolling-fabric;15982;fastscroll;Fast Scrolling;;
+galoblender-updated;15983;galoblender_updated;Galoblender Updated;;
+more-tetra-materials;15984;mtetm;More Tetra Materials;;
+ageing-mobs;15985;ageingmobs;Ageing Mobs;;
+warm-ice-block;15986;warm_ice;Warm Ice Block;;
+smoke-signals;15987;smoke_signals;Smoke Signals;;
+wunderreich;15988;wunderreich;Wunderreich;;
+;15989;mr_named_villagers;Named Villagers;;
+ames-mobs-renew;15990;amesmobsmod;AME's Mobs Renew;;
+refreshdisplaylists;15991;redisplaylist;RefreshDisplayLists;;
+vulkanmod-android-libs;15992;vulkanmod-an-libs;Vulkan Android Libraries;;
+;15993;blackbarconcealer;Black Bar Concealer;;
+building-shift;15994;building-shift;Building Shift;;
+mob-ai-tweaks;15995;mob-ai-tweaks;Mob AI Tweaks;;
+the-masquerade-illager-boss;15996;masquerade_mod;The Masquerade (Illager Boss);;
+better-armory-x;15997;better_armory;Better Armory X;;
+sweetys-horse-armor-tweaks;15998;sweety_horse_armor_tweaks;Sweety's Horse Armor Tweaks;;
+fired-pots;15999;fired_pots;Fired Pots;;
+under-the-moon;16000;under_the_moon;驻月夜下;Under the Moon;
+coffeegs-colorful-world;16001;mr_coffeegs_colorfulworld;CoffeeG's Colorful World;;
+jeb_-wool;16002;jebwool;jeb_羊毛;jeb_ Wool;
+illage-and-spillage-finally-ported;16003;illageandspillage;Illage and Spillage: Respillaged;;
+more-runes-more-magic-series;16004;morerunes;更多符文;More Runes;
+battlemages-more-magic-series;16005;battlemages;Battlemages;;
+eidolon-rebrewed-data-recipes;16006;eidolonrecipes;Eidolon Rebrewed Data Recipes;;
+elemental-metals-magical-metallurgy-series;16007;elemental_metals;Elemental Metals;;
+dragonsteel-more-magic-series;16008;dragonsteel;Dragonsteel & Star Alloy;;
+dragon-scale;16009;dragonscale;Dragon Scale;;
+scholar;16010;scholar;Scholar;;
+;16011;elytraswimfix;ElytraSwimFix;;
+tacz-bullet-proof-enchant-add-on;16012;bulletproofenchant;TACZ Bullet Proof Enchant Add-on;;
+no-screen-bobbing;16013;viewbobbingmod,noscreenshake;No Screen Bobbing;;
+more-spell-attributes-more-magic-series;16014;more_spell_attributes;More Spell Attributes;;
+minos-particle-presets;16015;particlepresets;Mino's Particle Presets;;
+somewhat-hardcore-fabric-forge;16016;somewhathardcore;You Die You Lose a Heart;;
+;16017;blurredwindow;Blurred Window;;
+player-list-heads;16018;playerlisthead;Player List Heads;;
+;16019;antighost;AntiGhost FORK;;
+environs-mod;16020;environs;Environs;;
+;16021;bfc;更好的火焰弹;BetterFireCharge;BFC
+;16022;ie;成语附魔;IdiomEnchantments;IE
+unique-magic;16023;uniquemagic;Unique Magic & Enchantments;;
+;16024;;不是所有的建树，都来自原木。;NO TREE;NT
+;16025;ani_siege;围攻/攻城;The Siege Mod;
+epic-projectile-reflection;16026;epicfightextra;史诗弹射物反射;;
+zombie-island;16027;zombie_island;Zombie Island;;
+stratagems;16028;helldivers;Stratagems;;
+solar-hardcore;16029;solarhardcore;Solar Hardcore;;
+i-hate-flesh-reborn-ihfr;16030;ihfr;I HATE FLESH: Reborn;;IHFR
+;16031;mr_enchanted_goldenappleaddition;附魔金苹果附加;Enchanted Golden Apple Addition;
+;16032;particle-unlimit;粒子上限解除;Particle Unlimit;
+aaa-particles;16033;aaa_particles;AAA Particles;;
+;16034;anno;Anno;;
+compass3d;16035;compass3d;Compass3D;;
+;16036;clockin;Clock In;;
+diggus-maximus-reborn;16037;diggusmaximus;连锁挖掘重制版;Diggus Maximus Reborn;
+satisfying-buttons;16038;satisfying_buttons;Satisfying Buttons;;
+item-on-chest-fabric;16039;itemonchest;Item On Chest;;
+industrialreborn;16040;industrialreborn;IndustrialReborn;;
+;16041;hbm;HBM的核科技航天;HBM's Nuclear Tech Mod Space;NTM/HBM
+;16042;petrified_wood;石化木;Petrified Wood;
+several-food-craft;16043;foodcraft;Several Food Craft;;
+cakes-cosmetics;16044;cakescosmetics;Cake's Cosmetics;;
+boks-butterflies;16045;butterflies;Bok's Banging Butterflies;;
+;16046;immersivewind;Immersive Winds;;
+reef-redux;16047;reefredux;Reef Redux;;
+simple-quiver;16048;simple_quiver;Simple Quiver / Quiver;;
+too-many-paintings-forge-fabric;16049;toomanypaintings;Too Many Paintings!;;
+building-but-better;16050;bbb;Building But Better;;
+exchange-fuels;16051;efuels;Exchange Fuels;;
+more-craftings-of-runes;16052;mcrmod;More Craftings of Runes;;MCR
+mega-evolve;16053;megaevolve;Mega Evolve! (for Pixelmon);;
+pixeltweaks;16054;pixeltweaks;PixelTweaks;;
+hrbs-drills;16055;hrbsdrills;HRB's Drills;;
+index-librorum-prohibitorum;16056;index;禁书目录;Index-Librorum-Prohibitorum;Index
+bft;16057;mr_bft;Better Fletching Tables;;BFT
+heartbond;16058;heartbond;Heartbond;;
+breakerplacer;16059;breakerplacer;Block Breaker & Block Placer;;
+iron-ladders;16060;ironladders;更多梯子;Iron Ladders;
+crumbs-deepslate-button;16061;deepslate_button;Crumbs 的深板岩按钮;Crumbs' Deepslate Button;
+cl0uds-paxels;16063;cl0uds_pixels;Cl0ud's Paxels;;
+unique-weaponry;16064;uniqueweaponry;Unique Weaponry;;
+;16065;mr_epic_spartanweaponry;Epic Spartan Weaponry;;
+boss-keys;16066;iron_bushes;Boss Keys;;
+;16067;naturalkillerbunnies;Natural Killer Bunnies;;
+mace-variants;16068;macevariants;Mace Variants;;
+shortswords;16069;shortswords;Short Swords;;
+bbs-mod;16070;bbs;Blockbuster Studio;;BBS
+monocle;16071;monocle;Monocle;;
+move-ui;16072;move-hotbar;Move-UI;;
+terrafly;16073;terrafly;TerraFly;;
+achievements-mod-200;16074;achievements;MysticRift: Achievements;;
+;16075;villcurestack;Villager Cure Discount Stacking;;
+saturation-plus;16076;saturation_plus;Saturation Plus;;
+mod-and-resource-pack-checker-abras-additions;16077;abrasadditions;Mod and Resource Pack Checker (Abra's Additions);;
+createstuffadditions-fix;16078;createstuffadditionsfix;CreateStuffAdditions Fix;;
+warden-slayer-enchantment;16079;wardenslayer;Warden Slayer Enchantment;;
+mods-optimizer;16080;modsoptimizer;Mods Optimizer;;
+glowy-players-renewed;16081;glowyplayers;玩家高亮：重置版;Glowy Players Renewed;
+;16082;torcherino;加速火把GT版;TorcherinoGT;
+epic-fight-kenjis-combat-forms;16083;kenjiscombatforms;Epic Fight: Kenji's Combat Forms;;
+mekanism-unleashed;16084;mekanism_unleashed;Mekanism Unleashed;;
+;16085;llama_abilities;Ability Carpets for Llamas;;
+easy-cake;16086;easy_cakes;Easy Cake;;
+weave-craft;16087;pearsmod123;Weave Craft;;
+morefarming;16088;morefarming;更多农耕;MoreFarming;MFI
+iron-bushes;16089;iron_bushes;Iron Bushes;;
+forestry-community-edition;16090;forestry;林业：社区版;Forestry: Community Edition;
+;16091;blink;瞬移;Blink;
+specified-spawning;16092;specifiedspawning;Specified Spawning;;
+kubejs-create-for-fabric-1-20-1;16093;kubejs_create;KubeJS Create for Fabric;;
+portable-spawners;16094;ps;Portable Spawners;;PS
+bettertime;16095;bettertime;长期熟时/求闻时记/更好的时间;BetterTime;BT
+;16096;tokitotal;時之挑战;TokiTotal;TT
+;16097;recipeoverrides;原版合成覆写;;
+;16098;easytochange;简易获取注册名;EasyToChange;
+;16099;health_up;生命值增加;Health Up;
+lets-do-farm-charm;16100;farm_and_charm;沉浸农艺;[Let's Do] Farm & Charm;
+;16101;sand_basic;简易配方·进度;Easy Recipes · Progress;ER/ERP
+hunters-moon;16102;huntersmoon;Hunter's Moon;;
+miners-moon;16103;minersmoon;Miner's Moon;;
+ender-moon;16104;endermoon;Ender Moon;;
+extreme-horde-moon;16105;extremehordemoon;Extreme Horde Moon;;
+spider-moon;16106;spidermoon;Spider Moon;;
+;16107;parrot-breeding;Breed Parrots With Seeds;;
+persistent-parrots;16108;persistent_parrots;Persistent Parrots;;
+;16109;ultimateat;Ultimate Autototem;;
+anti-mob-cheese;16110;anti_mob_farm;Anti Mob Farm;;
+bad-horse-fix;16111;badhorsefix;Bad Horse Fix;;BHF
+vanilla-nei-fix;16112;vanillaneifix;Vanilla NEI Fix;;
+;16113;mr_no_skylimits;No Sky Limits;;
+;16114;fconfiglib;FConfigLib;;
+satin-free-wakes;16115;wakes;Satin Free Wakes;;
+blue-archive-paintings;16116;ba_painting;Sensei的珍藏;Blue Archive Paintings;
+;16117;ironspear_datapack;铁长矛数据包;;
+lunar-nether;16118;lunarnether;Lunar Nether;;
+yeehaw-towns;16119;yeehaw_towns;Yeehaw Towns!;;
+;16120;copperrails;CopperRails;;
+;16121;akashictome;Akashic Tome;;
+mana-unification;16122;manaunification;Mana Unification;;
+immersive-energistics;16123;immeng;Immersive Energistics;;
+specialised-cells;16124;specialised_cells;Specialised Cells;;
+random-chunks;16125;randomchunks;Random Chunks;;
+unique-commands;16126;uniquecommands;Unique Commands;;
+;16127;ncl;无指令限制;NoCommandLimits;NCL
+;16128;enchantview;附魔预览;EnchantView;
+flood;16129;flood;Flood;;
+block-prints;16130;blockprints;Block Prints;;
+;16131;nech;NEI拼音搜索;NeverEnoughCharacters;NECh
+;16132;redstones_expansion;红石的扩展;Redstone's Expansion;RE
+justleveling-x-ironspell;16133;justleveling_x_ironSpell;法有所归;Just Leveling x IronSpell;
+;16134;moreweapon;更多武器;MoreWeapon;MW
+hugme;16135;hugme;抱抱我!;HugMe!;
+;16136;xp_from_rightclick_harvest;从右键收获中获取经验;XP From Right Click Harvest;
+coins-ll;16137;coins;Coins LL;;
+purediscstrickytrials;16138;purediscstrickytrials;Pure Discs - Tricky Trials;;
+tinkers-in-the-sky;16139;tits;Tinkers' in the Sky;;
+create-tank-defenses;16140;create_tank_defenses;机械动力：坦克防御;Create Tank Defenses;CTD
+potato-update;16141;potato_update;Potato Update;;
+twilight-forest-fixes;16142;twilightforestfixes;Twilight Forest Fixes (Doors & Misc);;
+dietary-statistics;16143;dietarystatistics;Dietary Statistics;;
+day-zombies-rebooted;16144;ayzombierebooted;Day Zombies Rebooted;;
+viewboboptions;16145;viewboboptions;View Bobbing Options;;
+ender-pearl-anti-disappear;16146;pearlad;Ender Pearl AD;;
+;16147;thebombzenapi;ThebombzenAPI;;
+create-dynamic-lights;16148;createdynlight;Create: Dynamic Lights;;
+decorative-tin;16149;tin;Decorative Tin;;
+blended-compat;16150;blended-compat;Blended Compat;;
+hold-easy-place;16151;holdeasyplace;保持简单放置;Hold Easy Place;Hep
+;16152;killaura;杀戮光环--;Killaura--;
+;16153;suonotfounds_autolib;SuoNotFound 的 AutoLib;SuoNotFound's AutoLib;
+;16154;suonotfounds_api;SuoNotFound 的 API;SuoNotFound's API;
+endlesscompat;16155;endless_compat;无尽贪婪·伪附属;EndlessCompat;
+spartan-and-fire-lightning-edition;16156;spartanfire;斯巴达之冰与火-雷电版;Spartan and Fire - Lightning Edition;
+the-twilight-forest-deforestation-edition;16157;;暮色森林 - Deforestation 版;The Twilight Forest - Deforestation Edition;
+minieffects-legacy-extended-life;16159;;MiniEffects-Legacy Extended Life;;
+call-to-battle-ww2-vehicles-addon;16160;ctbvehicles;Call to Battle WW2 - Vehicles Addon!;;CTB
+thaumic_funnel;16161;thaumictinkerer_funnel;Thaumic Funnel;;
+ynet-an-xnet-fork;16162;;YNet [XNet Fork];;
+rosatech;16163;rosatech;RosaTech;;
+nutrition-gtceu;16164;nutrition_gtceu;Nutrition: GTCEu;;
+nutrition-unofficial-extended-life;16165;nutrition;营养学非官方延续版;Nutrition Unofficial Extended Life;
+;16166;mmmtweaks;魔金微调;ManaMetalMod Tweaks;M3-T
+ae2-crafting-tree;16167;ae2ct;合成树;AE2: Crafting Tree;ae2ct
+client-automatic-doors;16168;client_auto_door;客户端自动门;Client Automatic Doors;
+;16169;enchanterpearl;附魔师宝珠;Enchanter Pearl;
+;16170;build_tools;Chai's Build Tools;;
+forge-relocation;16171;ForgeRelocation;Forge Relocation;;
+forge-relocation-fmp-plugin;16172;RelocationFMP;Forge Relocation - FMP Plugin;;
+;16173;fish-lib;Fish Lib;;
+forgedapi-fork;16174;forgedapi;ForgedAPI Fork;;
+prioninfection;16175;prionmod;Prion Infection: Whispers From Within;;
+dark-shadow-monster;16176;dark_shadow_monster;暗影怪物;Dark Shadow Monster;
+the-mi-alliance-invasion;16177;mialliance;The Mi Alliance: Invasion!;;
+fancy-health-bar;16178;fancyhealthbar;Fancy Health Bar;;
+;16179;nojoinleavemessage;No Join Leave Messages;;
+data-trades;16180;data_trades;Data Trades;;
+;16181;craftden1al;CraftDen1al;;
+draconic-alchemy;16182;draconicalchemy;Draconic Alchemy;;
+fancymenu-animation-maker-tool;16183;;[FancyMenu] Animation Maker Tool;;
+jmx;16184;json-model-extensions;JMX;;
+;16185;dooms-elytra-rebalance;Elytra Rebalance;;
+another-dyeable-shulkers;16186;dyeable_shulkers;可染色潜影贝;Another Dyeable Shulkers;
+;16187;skullbug;重新引入头颅BUG;Skull Bug Reintroducer;SBR
+;16188;thatskyinteractions;ThatSkyInteractions;;TSI
+;16189;tinker_transplant;匠魂移植;Tinker Transplant;TTP
+chisatos-more-redstone;16190;cmrs;Chisato的更多红石;Chisato's More Redstone;CMRS
+assetmover;16191;AssetMover;AssetMover;;
+duclib;16192;duclib;DucLib;;
+;16193;asc;AutoServerCommand;;ASC
+orecrop;16194;orecrop;矿石作物;OreCrop;
+;16195;vinurl;VinURL Music;;
+nutritionz;16196;nutritionz;NutritionZ;;
+xxl-packets;16197;XXLPackets;XXL Packets;;
+uncharted;16198;Uncharted,uncharted;Uncharted;;
+mcfetch;16199;mcfetch;MC Fetch;;
+reignited-hud;16200;reignitedhud;Reignited HUD;;
+more-crafter-variants;16201;quad-lolmcrv;More Crafter Variants;;
+sharingan-addon-ahznbs-naruto-mod;16202;sharinganaddon;AHZNB's Naruto | Sharingans;;
+create-tacz-automation;16203;createtaczauto;Create: TacZ Automation;;
+tacz-plus-timeless-and-classics-feature-addon;16204;taczplus;TACZ: Plus;;
+fibers-guns-pack-for-tacz;16205;fibers;Fibers' Guns Pack for TACZ;;
+;16206;splinecart;Splinecart;;
+beams;16207;beams;Beams;;
+discarnate;16208;discarnate;Discarnate;;
+;16209;fishmc;Fish Weapons (FishMC);;
+mob-armor-trims;16210;mob_armor_trims;Mob Armor Trims;;
+bubbles-a-baubles-fork;16211;;Bubbles;;
+arst-motion-blur;16212;arst_motion_blur;Arst Motion Blur;;
+;16213;palladium;钯;Palladium;
+firehud;16214;firehud;Firehud;;
+;16215;elytraautopilot;Elytra Autopilot;;
+personal-worlds;16217;personalworlds;Personal Worlds;;
+pearltickets;16218;pearltickets;PearlTickets;;
+cobweb;16219;cobweb;Cobweb;;
+progression;16220;progression;Progression;;
+stop-repeating-command-block-reborn;16221;srcbr;停！循环型命令方块：重生;Stop Repeating Command Block Reborn;SRCBR
+parry-us;16222;parry;予以刀振/格挡！;Parry;
+;16223;random_clover;随机四叶草;Random Clover;RC
+frycooks-delight;16224;frycooks_delight;油炸乐事;Frycook's Delight;
+advancedae;16225;advanced_ae;高级AE;AdvancedAE;
+pretty-pipes-fluids;16227;ppfluid;更好的管道：流体;Pretty Pipes: Fluids;
+webstone;16228;webstone;Webstone;;
+rotatable-blocks;16229;rotatableblocks;Rotatable Blocks;;
+treasure-seas;16230;treasure_seas;宝藏海;Treasure Seas;TSeas
+ambidextrous;16231;ambidextrous;Ambidextrous;;
+;16232;always-sprint;Always Sprint;;
+tea-the-story-recount;16233;teastory;茶风·纪事：追叙;Tea the Story : Recount;TSR
+xp-challenge;16234;xp_challenge;经验挑战;XP Challenge;XPC
+;16235;styled_renaming;styled renaming;;
+;16236;simpleblockoverlay;Simple Block Overlay;;
+;16237;helpful_action_bar;Helpfull Action Bar;;HAB
+repeatable-trial-vaults;16238;repeatable_trial_vaults;Repeatable Trial Vaults;;
+fast-async-world-save-forge-fabric;16239;fastasyncworldsave;Fast Async World Save;;
+;16240;chatmagic;Chat Magic;;
+;16241;ftbschools;FTB School;;
+unlimitedelytra;16242;unlimitedelytra;无限鞘翅;UnlimitedElytra;
+recrafted-creatures;16243;recrafted_creatures;Recrafted Creatures;;
+reciperesearch;16244;reciperesearch;合成配方研究;RecipeResearch;
+thaumon;16245;thaumon;神秘再饰;Thaumon;
+create-firearms-patch;16246;kinetic_pixel;机械动力火器补丁;Create Firearms Patch(kinetic pixel);
+create-eureka;16247;create_eureka;Create: Eureka!;;
+forsaken-corpses;16248;lying_skeletons;Forsaken Corpses;;
+cat-variant-eggs;16249;catvarianteggs;Cat Variant Eggs;;
+more-colorful;16250;morecolorful;更加多彩的世界;More Colorful;
+void-island-control-2-0;16251;voidislandcontrol;Void Island Control Inverted Edition;;
+fishing-rod-fix;16252;fishingrodfix;Fishing Rod Fix;;
+;16253;additionalentityattributes;Additional Entity Attributes;;AEA
+;16254;additionalentityattributes;Additional Entity Attributes (Forge);;AEA
+kubejs-sanity;16255;sanityjs;KubeJS Sanity;;SanJS
+;16256;worleycaves;古早沃利的洞穴;Worley's Caves Archaic;WCA
+journeymap-web-map;16257;journeymap_webmap;旅行地图：网络地图;JourneyMap Web Map;
+rain-should-extinguish-campfires;16258;rsec;Rain should extinguish campfires;;RSEC
+;16259;mobdeathsound;Mob Death Sounds;;
+gauntlets;16260;gauntlets;Gallant Gauntlets / Gauntlets;;
+;16261;TimeVial;时间之瓶;TimeVial;
+;16262;lost_time_space;失落时空;Lost Time Space;LTS
+thrown;16263;thrown;扔!;Thrown;To
+tacz-npcs-also-vpb;16264;tacz_npcs;TACZ: Npcs;;
+;16265;srpaig;逃逸：无适应性发生器;Scape and Run Parasites Addon: Immalleable Generator;SRP:AIG
+;16266;crystaldream;晶彩梦艺;Crystal Dream;
+;16267;isscustom;Iron's Spells 'n Spellbooks：遥远挡震;ISSCustom;ISSC
+the-last-narrow-gauge-steam-locomotive;16268;;最后的蒸汽小火车;The last narrow-gauge steam locomotive;TLNT
+hotdog-delight;16269;hotdog_delight;Hotdog Delight;;
+lets-do-addon-corn-expansion;16270;cornexpansion;玉食俱馩;[Let's Do Addon] Corn Expansion;
+;16271;ornithe_carpet;OrnithedCarpet;;OC
+;16272;client_maps;Client Maps;;
+dragon-gear-renewed;16273;dragon_gear_renewed;Dragon Gear Renewed;;
+;16274;archers_plushies;Archer's Plushies;;
+;16275;hephaestusexpansion;Hephaestus Expansion;;
+create-structures-arise;16276;create_structures_arise;Create: Structures Arise;;
+;16277;kilt;Kilt;;
+gregtech-extended-chemistry-extended;16278;gtec;Gregtech: Extended Chemistry Extended;;
+ulv-covers-modern;16279;ulvcovm;ULV Covers Modern;;
+farmers-structures;16280;farmers_structures;Farmers Structures;;
+;16281;souloflegends;只狼死亡界面;SekiroDiedScreen;
+;16282;minecartspeeddisplay;矿车速度显示;MinecartSpeedDisplay;MSD
+crossstitch;16283;crossstitch;CrossStitch;;
+;16284;vanilla_portal;原版传送工艺;VanillaTeleportationTechnology;
+free-camera-api;16285;freecameraapi;自由相机API;FreeCameraAPI;
+;16286;flashback;Flashback;;
+bloodmagic-meteors-jei-support;16287;bmj;血魔法陨星显示;BloodMagic Meteors JEI Support;BMJ
+limited-damage-indicator-particle;16288;ldip;伤害粒子限制;Limited Damage Indicator Particle;LDIP
+netherite-extension;16289;netherite_ext;下界合金拓展续作;Netherite Extension;
+immersive-farming;16290;immersivefarming;沉浸农业;Immersive Farming;
+;16291;mr_vpb_toomanyguns;VPB: Too Many Guns;;
+death-angels;16292;death_angels;死亡天使;Death Angels;
+the-pale-hound;16293;pale_hound;The Pale Hound;;
+monsters-girls;16294;monsters_girls;Monsters & Girls;;
+monsters-girls-secrets-of-mermaids;16295;mg_secrets_of_mermaids;Monsters&Girls: Secrets of Mermaids;;
+dios-tiny-ore;16296;dio_tiny_ore;Dio's Tiny Ore;;
+defence-craft;16297;defence_craft;Defence Craft;;
+;16298;scraping_knife;Scraping Knife;;
+copper-equipment;16299;exlinecopperequipment;Exline's Copper Equipment;;
+terramity;16300;terramity;Terramity;;
+;16301;lovemod;结婚：芙宁娜版;LoveMod:Furina;LM
+;16302;smwl;简易模组白名单;SimplestModWhiteList;SMWL
+;16303;dt;数据包工具;Data Tools;DT
+neptune-lib;16304;neptune;Neptune;;
+sign-edit-lite;16305;signeditlite;告示牌编辑轻量版;Sign Edit Lite;
+;16306;book-formatting;Book Formatting;;
+;16307;morewaterlogging;More Waterlogging;;
+;16308;rdmr;随机死亡消息：重生;RandomDeathMessageReborn;RDMR
+;16309;csms;自定义望远镜覆盖层;CustomSpyglassMagnificationOverlay;CSMS
+;16310;chatting;Chatting;;
+;16311;polycrosshair;PolyCrosshair;;
+;16312;;备用重生点;;
+respawning-structures-forge-fabric;16313;respawningstructures;Respawning Structures;;
+;16314;sticky_honey;Sticky Honey;;
+horseman;16315;horseman;Horseman;;
+;16316;easyplacefix;轻松放置修复;EasyPlaceFix;
+screenshot-flash;16317;flash;一闪;Screenshot Flash / Flash;
+warp-zone;16318;warpzone;Warp Zone;;
+faded-widgets;16319;fadedwidgets;淡出界面;Faded Widgets;
+knowledges;16320;knowledges;知识库;Knowledges;
+panda-genetics-tweak;16321;panda_genetics_tweak;Panda Genetics Tweak;;
+colourful-llamas;16322;colourfulllamas;Colourful Llamas;;
+;16323;chenchen;Chen's Japanese Decoration;;
+;16324;netherite_scrap_plate;Netherite Scrap Piece;;
+create-halitosis-create-halitosis;16325;createhalitosis;Create: Halitosis;;
+create-unify;16326;unify;Create: Unify;;
+create-more-sand-papers;16327;createsandpapers;Create: More Sandpapers;;
+sawmill-house;16328;sawmillhouse;Sawmill House;;
+kaboom-moon;16329;kaboommoon;Kaboom Moon;;
+hardcore-revive-mod;16330;hardcore-revive-mod;Revivable Hardcore Players;;
+;16331;bamboo_sword;Bamboo Sword;;
+;16332;exlcore;Ex Life Core;;EXLC
+petrols-parts;16333;petrolsparts;Petrol 的机件;Petrol's Parts;
+slavic-delight;16334;slavic-delight;Slavic Delight;;
+aquamirae-delight;16335;aquamirae-delight;海灵乐事;Aquamirae Delight;
+dumplings-delight-rewrapped;16336;dumplings_delight;Dumplings Delight Rewrapped;;
+my-nethers-delight-refabricated;16337;mynethersdelight;My Nether's Delight Refabricated;;
+;16338;polyweather;PolyWeather;;
+shadow-x-axolotl-buckets-plus;16339;axolotlbucketsplus;Axolotl Buckets +;;
+daily-shop;16340;dailyshop;Daily Shop 🫙;;
+;16341;recipes;Recipes+;;
+no-tree-to-destory;16342;notreedestory;你不准破坏木头！;No Tree To Destory;NTD
+;16343;nodiparticle;去除伤害指示器粒子;nodiparticle;
+;16344;FireproofNetherite;Fireproof Netherite;;
+growable-goodies;16345;growablegoodies;Growable Goodies;;
+petrolpark-library;16346;petrolpark;Petrolpark 的库;Petrolpark's Library;
+;16347;ZeroPointBugfix;ZeroPointBugfix;;
+ancient-reforging;16348;ancientreforging;Ancient Reforging;;
+stackmob-fabric;16349;stackmob-fabric;StackMob Fabric;;
+itemindicator;16350;itemindicator;Item Indicator;;
+kenshiro-mod;16351;AS_Kenshiro,AS_KSM;北斗神拳;Kenshiro Mod;
+roamers;16352;roamers;Roamers;;
+;16353;les;LegacyCanEditSign;;
+title-screen-mobs;16354;title_screen_mobs;Title Screen Mobs;;
+;16355;chang_sheng_jue;中式内容;;
+antiblocksrechiseled;16356;antiblocksrechiseled;AntiBlocksReChiseled;;
+;16357;false_emerald;False Emerald;;
+end-ores;16358;endores;End Ores;;
+tnt-expanded;16359;tnt_expanded;TNT Expanded;;
+glimmering-tales;16360;glimmeringtales;微光纪事;Glimmering Tales;GT
+fluid-interaction-tweaker;16361;fluidintetweaker;自定义流体交互;Fluid Interaction Tweaker;FIT
+kubejs-extended-crafting;16362;kubejs_extended_crafting;KubeJS Extended Crafting;;
+kubejs-addon-blood-magic;16363;kubejsbloodmagic;KubeJS Addon - Blood Magic;;
+custom-portal-builder;16364;customportalsmod;Custom Portal Builder;;
+biome-difficulty;16365;biomedifficulty;Biome Difficulty;;
+;16366;viaaprilfools;ViaAprilFools;;
+tfc-weld-button;16367;tfcweldbutton;TFC Weld Button;;
+tfc-regrowing-forests;16368;tfcrf;TFC Regrowing Forests;;
+ccdbridge;16369;ccdbridge;CC: Destroy Bridge;;
+welcome-message;16370;welcomemessage;Welcome Message;;
+auto-attack-rebirth;16371;autoattack;Auto Attack Rebirth;;
+lotas;16372;lotas;LoTAS;;
+tasmod;16373;tasmod;TASmod;;
+canopy;16374;canopy;Canopy;;
+betterfly;16375;betterfly;飞起来！;BetterFly;BF
+;16376;leashedplayer;可拴玩家;LeashedPlayer;LP
+melodymagic;16377;melodymagic;旋律魔法;MelodyMagic;MM
+scaling-mob-difficulty-fork;16378;scalingmobs;知时修倍;Scaling Mob Difficulty Fork;
+trajectoryprojections;16379;trajectory;弹道预测;Trajectory;
+accessories;16380;accessories;Accessories;;
+onewholibs;16381;onewholibs;onewholibs;;
+nucleus;16382;nucleus_pauljoda;Nucleus;;
+;16383;equator;Equator;;
+accessories-cc-layer;16384;curios;Curios Compat Layer for Accessories;;
+accessories-tc-layer;16385;trinkets;Trinkets Compat Layer for Accessories;;
+;16386;confetti;Confetti Lib;;
+understudy;16387;understudy;Understudy;;
+;16388;gtlitecore;GregTech Lite Core;;
+material-replication;16389;materialreplication;Material Replication;;
+rsj;16390;rsjukeboxes;Redstone Jukeboxes;;
+irikana;16391;irikana;伊利康纳;Irikana;IKA
+mts-iv-aq-studios-himars;16392;m142_himars;AQ studios Himars;;
+immersive-vehicles-iv-mts-lindqvist;16393;lindqvist;Lindqvist;;
+immersive-vehicles-iv-mts-zroskyan-ordinary;16394;mc172_oak;Zroskyan Ordinary Vehicles;;
+petroleums-wigs;16395;petroleums_wigs;Petroleum's Wigs;;
+revenge-mark;16396;revengemark;遗怨待战/复仇标记;Revenge Mark;
+;16397;;烧制回收;;
+;16398;nestle;贴贴;Nestle;
+;16399;timesync;时间同步;TimeSync;
+;16400;mechano;Mechano;;
+;16401;coggle;Create: Coggle;;
+create-enchantable-machinery;16402;createenchantablemachinery;Create: Enchantable Machinery;;
+bad-eyes;16403;badeyes;近视眼;Bad Eyes;
+bad-dreams;16404;bad_sleep;噩梦;Bad Dreams;
+turtlebois-rpg-classes;16405;turtlerpgclasses;TurtleBoi's RPG Classes;;
+through-the-lily-pads-gently;16406;through-the-lilypads-gently;Through the lily pads, gently;;
+decofirmacraft;16407;dfc;DecoFirmaCraft;;DFC
+;16408;dust;Dust;;
+;16409;beeg-smol;Beeg Smol;;
+scaling-mobs;16410;scalingmobs;Scaling Mob Difficulty;;
+multiline-mastery;16411;multilinemastery;Multiline Mastery;;
+;16412;confetti-stuff;Confetti Stuff;;
+pirates-treasures;16413;pirates_treasures;Pirates & Treasures;;
+ars-nouveau-delight;16414;ars-nouveau-delight;Ars Nouveau Delight;;
+crossbow-enchants;16415;crossbow-enchants;Crossbow Enchants;;
+extendeddrawersaddon;16416;extendeddrawersaddon;ExtendedDrawersAddon;;
+minecolonies-letsdo;16417;minecolonies_letsdo;Let's Do addon for MineColonies;;
+earlystage;16418;earlystage;EarlyStage;;
+smitherz;16419;smitherz;SmitherZ;;
+additionz;16420;additionz;AdditionZ;;
+bjornlib;16421;bjornlib;BjornLib;;
+;16422;tsr;时间同步：重生;TimeSyncReborn;TSR
+;16423;taotiesmunchies;饕餮飨食;Taotie's Munchies;
+skewers-reflavored;16424;skewers;串起酥食/烤串：再调味;Skewers Reflavored;
+linear-xp-forge;16425;linearxpforge;验依定值/线性经验;Linear Xp Curve;
+;16426;solidarytinker;工匠联合;SolidaryTinker;ST
+;16427;CALCULATOR;计算器;;
+dumplings-delight-reload;16428;dumplings_delight;饺子乐事：重启;Dumplings Delight Reload;
+auto-switch-elytra;16429;auto-switch-elytra,auto_switch_elytra;自动切换鞘翅;Auto Switch Elytra;
+gregtech-placeable-emitters;16430;greg_emitters;GregTech Placeable Emitters;;
+;16431;;The old Durability101;;
+;16432;;UseCount;;
+;16433;;UseCount2;;
+;16434;jeihistory;JEI History;;
+zakuro;16435;zakuro;榴;Zakuro;
+dropoff;16436;dropoff;DropOff;;
+upgraded-totems;16437;upgraded-totems;Upgraded Totems;;
+;16438;playerchains;Player Chains;;
+anti-creative-drift;16439;anticreativedrift;Anti Creative Drift;;
+damage-incorporated;16440;damage_incorporated;Damage Incorporated;;
+;16441;gunskills;GunSkills;;GS
+;16442;totem_in_chest;箱子里的图腾;;
+;16443;hyjg_custom_healthbar;原版-血条显示;;
+;16444;potato_mace;Potato Mace;;
+exmodifier;16445;exmodifier;极墨重锻-革故鼎新;ExModifier;EM
+;16446;dr;受潮：重生;DampReborn;DR
+;16447;cbr;CreepersBurnReborn;;CBR
+lazy-dfu-forge;16448;lazydfu;DFU载入优化 [FORGE];Lazy DataFixerUpper(LazyDFU) [FORGE];
+;16449;hitokotomc;MC·一言API;HitokotoMC;
+;16450;creaturechat;CreatureChat;;
+helldivers-spread-democracy;16451;helldivers;Helldivers - Spread Democracy;;
+helldivers-2-gun-pack-vics-point-blank;16452;pointblank-helldivers2-pack;Helldivers 2 Gun Pack | Vic's Point Blank;;
+variant-tools-and-weaponry-more-weapons;16453;vtaw_mw;Variant Tools and Weaponry - More Weapons;;
+mgrr;16454;mgrr;Mine Gear Rising: Revengeance;;MGRR
+arcanemysteries;16455;projectshadow;Arcane Mysteries - Secrets of the World;;
+botanic-pledge;16456;botanicpledge;Botanic Pledge;;
+rediculous-ore-generation;16457;better_ore_generation;Ridiculous Ore Generation;;
+witchy-wearables;16458;witchywearables;Witchy Wearables;;
+simple-delights-recooked;16459;simpledelights;重启爽食/简单乐事：再烹饪;Simple Delights Recooked;
+braziliandelight;16460;braziliandelight;巴西乐事;Brazilian Delight;
+applied-energistics-delight;16461;applied-energistics-delight;Applied Energistics Delight;;
+extra-meat;16462;extrameat;Extra Meat;;
+peculiar-primordials;16463;peculiarprimordials;Peculiar Primordials;;
+time-wind-forge;16464;tawct;Time & Wind;;
+;16465;mcbrowser;MCBrowserz;;
+additional-trims;16466;additional-trims;Additional Trims;;
+upgraded-trims;16467;upgraded-trims;Upgraded Trims;;
+water-balloon;16468;waterballoon;Water Balloon;;
+cataclysm-spellbooks;16469;cataclysm_spellbooks;Cataclysm: Spellbooks;;
+call-of-drowner;16470;call_of_drowner;溺亡者之嚎;Call of Drowner;
+;16471;parasite_era;寄染之时 · 重生;The Parasite Era · Reborn;TPER
+;16472;endofdays;终焉之日;Endofdays;
+;16473;cleanenergy;清洁能源;Clean Energy;CE
+fastfood-delight-unofficial;16474;fastfooddelight;重启速食/快餐乐事非官方版;FastFood Delight Unofficial;
+faster-fly-block-breaking;16475;fasterflyblockbreak;飞行速速破;Faster Fly Block Breaking;
+upgraded-additional-trims;16476;upgraded-additional-trims;Upgraded Additional Trims;;
+create-let-the-adventure-begin;16477;create_ltab;Create: Let The Adventure Begin;;
+bountiful-critters;16478;bountiful_critters;Bountiful Critters;;
+flashlight-mcowners;16479;mcrowners_flashlight;Flashlight MCowners;;
+smartpot;16480;smart_pot;智能锅;SmartPot;
+;16481;dual_weapon_combat;双持战斗;;
+;16482;LibShapeDraw;LibShapeDraw;;
+merciful-void;16483;mercifulvoid;渊佑堕者/慈悲的虚空;Merciful Void;
+gsic2;16484;gsic2;星空工业;GSIC2;
+open-energistics;16485;openerg;Open Energistics;;OE
+;16486;friendsmod;The Friends Mod;;
+;16487;constructionwand;Construction Wand (Fabric);;
+osmiumspacetiers;16488;dfs;Osmium Space Tiers;;
+bodyguard;16489;bodyguard;Bodyguard;;
+;16490;quickmenu;快捷菜单;Quick Menu;
+lazrs-lib;16491;lazrslib;Lazr's Lib;;
+cute-words-chat-replacer;16492;cutewords;雅言订正/聊天内容替换;Cute Words;
+;16493;masi;魔法咏唱;;masi
+;16494;PotionColorizer;Potion Colorizer;;
+hotbath;16495;hotbath;热水澡;Hot Bath;
+;16496;no_double_sneak;No Double Sneak;;
+tfc-hammer-time;16497;tfc_hammer_time;TFC Hammer Time;;
+tfc-better-stone-age;16498;bsa;TFC Better Stone Age;;BSA
+battery-status-info;16499;batterystatusinfo;Battery Status Info;;
+mineteam;16500;mine_team;MineTeam;;
+;16501;ncm;禁用创造模式;NoCreativeMode;NCM
+;16502;dtbf;DarkTitleBarForge;;
+croaklib;16503;croaklib;CroakLib;;
+;16504;it_is_forbidden_to_drop_stones;禁止掉落石头;;
+nbt-copy;16505;nbt_copy;NBT Copy;;
+;16506;phtsg;虚化望远镜;Phantom Spyglass;
+more-totem-effects;16507;more_totem_effects;More Totem Effects;;
+bakeyourbread;16508;bakeyourbread;Bake Your Bread;;
+modern-debugify;16509;debugify;Modern Debugify;;
+recipe-essentials-forge-fabric;16510;recipeessentials;Recipe Essentials;;
+zombie-villager-control;16511;zombievillagercontrol;催起死尸/僵尸村民控制;Zombie Villager Control;
+;16512;pvp;1.8 PVP Mod;;
+;16513;bsq;黑屏安静;BlackScreenQuiet;BSQ
+;16514;sk;SuicideKeyReborn;;
+;16515;too_many_shortcuts;Too Many Shortcuts;;
+better-horse-movement;16516;betterhorses;Better Horse Movement;;
+tct-core;16517;tctcore;TCT Core;;
+obscure-tooltips-fix;16518;obscure_tooltips_fix;Obscure Tooltips Fix;;
+;16519;lazylogin;LazyLogin;;
+;16520;notica;Notica;;
+mountain-sea-and-continent-two;16521;shanhaicontinent;山海大陆3;Mountain Sea and Continent Three;
+zhonglv-12et;16522;zhonglv12et;钟吕十二律;ZhongLv-12ET;
+;16523;ding;打铁匠人;DingMod;
+;16524;furnitureplan;家具计划;FurniturePlan;FP
+just-another-random-spawn;16525;randomspawn;遥缘调址/随机出生点;Just Another Random Spawn;
+;16526;kaimyentity;KAI我的实体-C;KAIMyEntity-C;KAI
+realistic-mobs;16527;realistic-mobs;Realistic Mobs;;
+fullthrottle-alchemist;16528;Project_Alchemy;FullThrottle Alchemist;;FTA
+fullthrottle-nei;16529;fullthrottlenei;FullThrottle NEI;;
+creature-compendium;16530;creature_compendium;Creature Compendium;;
+desert-update;16531;desert_update;Desert Update;;
+ancient-elements;16532;ancient_elements;Ancient Elements;;
+left-behind;16533;leftbehind;Left Behind;;
+corrupted-witherskeleton-boss-mod;16534;corrupted_witherskeleton_boss;Corrupted Witherskeleton Boss;;
+;16535;ddd;Deadly Deadly Dungeon;;DDD
+mca-api;16536;mac;Doom Core/MAC API;;MAC
+;16537;mr_exp_leveluphealth;经验提升生命;Exp Level Up Health;ELUH
+sodium-leaf-culling;16538;sodiumleafculling;钠：树叶剔除;Sodium Leaf Culling;
+homing-xp-orb;16539;homingxporb;引验导追/归航经验球;Homing Xp Orb;
+multiblocked2;16540;mbd2;Multiblocked2;;MBD2
+armorstatushud-updated;16541;armorstatushud;耐久信息显示更新版;ArmorStatusHUD Updated;
+tfc-better-blast-furnace;16542;tfcbetterbf;TFC Better Blast Furnace;;
+tfc-textile;16543;tfc_textile;TFC Textile;;
+tfc-woodworking;16544;tfcwoodwork;TFC Woodworking;;
+tfc-auroras;16545;tfcauroras,auroras;Auroras;;
+greg-paintings;16546;greg_paintings;Greg Paintings;;
+gtmthings;16547;gtmthings;GTM Things;;GTMT
+create-trading-floor;16548;trading_floor;机械动力：交易站点;Create: Trading Floor;
+;16549;fishycreatestuffs;Yu的机械动力附属;Fishy Create Stuffs;FCS
+biolith;16550;biolith;Biolith;;
+hungrier;16551;hungrier;Hungrier;;
+furnace-pickaxe-mod;16553;furnace_pickaxe;Furnace Pickaxe Mod;;
+camouflage-doors-and-trapdoor;16554;camoflauge_doors_and_trapdoorfor;Camouflage Doors and Trapdoor;;
+dense-metals;16555;densemetals;Dense Metals;;
+actually-subtractions;16556;actuallyadditions;Actually Subtractions;;
+mechanical-botania;16557;mechanicalbotania;Mechanical Botania;;
+puddles;16558;puddles;Puddles;;
+yoyousukes-kabutoaddon-for-ahzs-shinobicraft;16559;kabutoaddon;KabutoAddon for AHZS's Shinobicraft Naruto Mod;;
+illager-world-war;16560;illager_world_war;Illager World War;;
+guns-craft-adventurers-arsenal;16561;gcaa;枪械工艺：冒险者的武器库;Guns Craft Adventurer's Arsenal;GCAA
+;16562;sins;Seven Deadly Sins Origins;;
+difficult-raids-stronghold-survival-edition;16563;difficultraids;Difficult Raids - Stronghold Survival Edition;;
+subnautica-flow;16564;subnautica_flow;Subnautica Flow;;
+cardinal-sins;16565;cardinal_sins;The Cardinal Sins;;
+unwrecked-ships-forge;16566;unwrecked_ships;Unwrecked Ships;;
+revamped-shipwrecks-mod;16567;revamped_shipwrecks;Revamped Shipwrecks;;
+christmas-culinary-desires-decorations;16568;christmas_culinary_desires;Christmas Culinary Desires & Decorations;;
+;16569;florum-sporum;Florum Sporum;;
+unofficial-bosses-of-mass-destruction-dungeon;16570;da;(Unofficial) Bosses of Mass Destruction + Dungeon Additions;;(Unofficial)BOMD+DA
+;16571;treasuretree;摇钱树;Treasure Tree;TT
+;16572;roadandtrafficlights;沥青路;;
+;16573;morethings_v3;更多物品;MoreThings;MT
+;16574;kill_sound;击杀特效自定义;kill_sound;
+explosionvisualizer;16575;explosion-visualizer;爆炸信息显示;;
+;16576;more_vanilla_foods;更多原版食物;More Vanilla Foods;
+let-me-feed-you;16577;letmefeedyou;吃取送食/玩家喂食;Let Me Feed You!;
+;16578;bigstru;更大的结构重制版;BiggerStructures;
+drg-laser-pointer;16579;drglaserpointer;深岩银河激光指示器;DRG Laser Pointer;DRGLP
+spawner-head;16580;spawnerhead;Spawner Head;;
+medieval-core-mod;16581;medieval;Medieval;;
+darkmining;16582;darkmining;DarkMining - Better Block Drops;;
+;16583;mr_fullbright_multiplayer;Fullbright [Permanent Night Vision];;
+;16584;visualkeys;VisualKeys;;
+sodium-extra-information;16585;sodiumextrainformation;Sodium Extra Information;;
+;16586;bulktrade;Bulk Villager Trading;;BVT
+omniscience;16587;Omniscience;Omniscience;;
+illusion-onslaught;16588;illusion_onslaught;Illusion Onslaught;;
+rar-compat;16589;rarcompat;Relics: Artifacts Compat;;
+wards;16590;wards;Wards;;
+moremcmeta-emissive-forge;16591;moremcmeta_emissive_plugin;MoreMcmeta Emissive Textures;;
+;16592;fantazia;Fantazia;;
+falling-attack;16593;fallingattack;Falling Attack;;
+lesraisins-armor;16594;lrarmor;LesRaisins Armor;;
+goety-spillage;16595;goety_spillage;Goety & Spillage;;
+waifucraft;16596;waifucraft;Waifucraft;;
+sign-to-chat;16597;sst_tcs;阅言得知/聊天栏读取告示牌;Sign to Chat;
+rainimatormod;16598;rainimator;Rainimator Mod;;
+realistic-airdrop;16599;dyairdrop;真实空投;Realistic Airdrop;
+keepers-of-the-stones-ii;16600;power;Keepers of the Stones II;;
+wooden-cog;16601;woodencog;Wooden Cog;;
+shadow-x-blocks-plus;16602;blocksplus;Blocks +;;
+pet-essence;16603;petessence;Pet Essence;;
+;16604;hcrplus;Hardcore Revive+;;
+watson;16605;watson,Watson;Watson;;
+;16606;pk_racks;Racks;;
+emerald-matcha-craft-v3;16607;emerald_matcha_craft_v3;翠茶工藝;Emerald Matcha Craft;EM-C
+cctv-camera;16608;camera_mods;CCTV Camera (CameraCraft);;
+trash-compactor;16609;trashcompactor;Trash Compactor;;
+rustic-delight;16610;rusticdelight;乡村乐事;Rustic Delight;
+;16611;binah;Total Assault;;
+sky-breaker;16612;skybreaker;天穹突破;Sky Breaker;
+;16613;scala3std;Scala3Std;;S3STD
+;16615;hoofprint;Hoofprint;;
+better-controls;16616;bettercontrols;Better Controls;;
+;16617;optibye;Optibye;;
+kubejei;16618;kube_jei;KubeJEI;;
+actually-harvest;16619;actuallyharvest;Actually Harvest;;
+city-craft;16620;citycraft;City Craft;;
+;16621;wpt;伍德的石化科技;Woody's Petrochemical Tech;WPT
+eggs-better-vanilla-food;16622;eggsbettervanillafood;Eggs Better Food;;
+shelf-mod;16623;shelfmod;Shelf Mod;;
+nebulus-cherryblossom-tree;16624;nebuluscherryblossomtree;Nebulus' Cherryblossom Tree;;
+ftb-rickety-water-wheel;16625;ftbricketyww;FTB Rickety Water Wheel;;
+cobblegen-galore;16626;cobblegengalore;Cobblegen Galore;;
+;16627;ringlesgunturret;Ringle's Gun Turret;;
+create-sky-village;16628;create_sky_village;Create: Sky Village;;
+create-crushing;16629;createcrushingresource;Create: Crushing;;
+cushy-pillows;16630;cushy-pillows;舒适枕头;Cushy Pillows;
+ice-and-fire-patcher;16631;iaf_patcher;冰火传说随意修复;Ice And Fire Patcher;IAFP
+goetyrevelation;16632;goety_revelation;诡厄巫法：启示录;Goety: Revelation;GR
+the-mandela-catalogue-alternates;16633;mandela_catalogue;The Mandela Catalogue: Alternates;;
+the-craftela-catalogue;16634;mandela;The Craftela Catalogue:Alternates;;
+the-ceilands;16635;ceilands;垂顶之地;The Ceilands;
+;16636;sharowings_better_dungeons;Sharowing's Better Dungeons;;
+snowbound;16637;snowbound;Snowbound;;
+opencomputers-icbm-classic-addon;16638;eternalsoap.icbm.opencomputers;Opencomputers ICBM-Classic Addon;;
+;16639;pandoras_frontier;Ad Astra: Pandora's Frontier;;
+cosmic-horizons;16640;cosmos;Cosmic Horizons;;
+shadow-x-netherite-scrap-from-piglin-brutes;16641;netheritescrapfrompiglinbrutes;猪灵蛮兵掉落下界合金碎片;Netherite Scrap From Piglin Brutes;
+;16642;etcw;外置传送窗口;ExternalTeleportCommandWindow;ETCW
+better-modlist-neoforge;16643;mod_menu;Better ModList;;
+sky-aesthetics;16644;sky_aesthetics;Sky Aesthetics;;
+headshot-bonus;16645;headshotbonus;已无可惧/简单爆头;Headshot Bonus;
+enchantlevelbrek;16646;enchantmentlevelbreak;附魔等级上限突破2;EnchantmentLevelBreak;ELB2
+global-gamerule-fabric;16647;globalgamerule;全局游戏规则Fabric版;Global GameRule [Fabric];
+biome-borders-revived-liteloader-only;16648;ArmorsHUDRevived;Biome Borders Revived;;
+chunkborders;16649;chunkborders,ChunkBorders;区块边界;ChunkBorders;
+burnt;16650;burnt;Burnt;;
+goatman;16651;goat_man;GoatMan;;
+armor-damage-limit;16653;armordamagelimit;甲哇！/盔甲耐久损失限制;Armor Damage Limit;
+knight-bodyguard-forge;16654;knight_mob;骑士保镖;Knight Bodyguard;
+deeper-depths;16655;deeperdepths;Deeper Depths;;
+unseens-nether-backport;16656;nb;Unseen's Nether Backport;;UNB
+delete-my-origins;16657;DeleteMyOrigins;内置种族禁用;Delete My Origins!;
+shadow-x-adventures-plus;16658;adventuresplus;Adventures +;;
+adventures-in-time;16659;ait;Adventures in Time;;AIT
+elementalist;16660;elementalist;Elementalist;;
+;16661;craft_slime_fabric;制作黏液球;Craft Slime Fabric;
+shadow-x-unactivated-totems;16662;unactivatedtotems;Unactivated Totems;;
+cagebox;16663;cagebox;CageBox;;
+;16664;BiomeBorders;Biome Borders;;
+rechiseled-ae2;16665;rechiseledae2;Rechiseled: AE2;;
+archeological;16666;archeological;Archeological;;
+clarity;16667;clarity;Clarity;;
+backpacked-world-of-color;16668;backpacked-world-of-color;Backpacked: World of Color;;
+nofov;16669;nofov;NoFov;;
+cobalt-custom-chunk-renderer;16670;cobaltmod;钴;Cobalt;
+spartacus-army-uniform;16671;main_mod;Spartacus' Army Uniform;;
+soviet-army-uniform;16672;sovietuniforms;Soviet Army Uniform;;
+german-uniforms-ww2;16673;germanuniforms;German Uniforms WW2;;
+;16674;fantasy_ending;梦幻终焉;FantasyEnding;FE
+;16675;dual_weapon_combat_append;双持战斗扩展;;
+;16676;honghuang_xuixian;洪荒修仙;HongHuang XiuXian;HX
+tameable;16677;tameable;Tameable;;
+slashblade-gamerelic;16678;srelic;拔刀剑重锋附属·游戏扩增;srelic;SR
+theovergrowth;16679;overgrowth;TheOvergrowth;;
+jadens-nether-expansion;16680;netherexp;Jaden's Nether Expansion;;JNE
+configurable;16682;configurable;Configurable;;
+;16683;crr;ClientRegistryReborn;;
+;16684;cpd;聊天框坐标显示;ChatPositionDisplay;CPD
+;16685;macros;Macro / Keybind Mod;;
+;16686;MyCTMLib;连接纹理非官方版;ConnectedTexturesModUnofficial;CTMU
+;16687;early-loading-screen;Forge 加载屏幕移植;(Neo)Forge Early Loading Screen for Fabric;
+;16688;ebe;EnlightenedBlockEntities;;EBE
+;16689;spawn;tpa传送命令;;
+patpat;16690;patpat;PatPat;;
+;16691;modernlifepatch;摩登生活补丁;Modern Life Patch;MLP
+;16692;ivr;IVR;;
+rusticdelight-refabricated;16693;rusticdelightrefabricated;乡村乐事：重织;RusticDelight: Refabricated;
+scape-and-run-meshi;16694;srpmeshi;逃逸：寄生饭;Scape and Run: Meshi;SRM
+;16695;bad_apple_world;Bad Apple World Preset;;
+gastronomy-works;16696;gastronomyworks;Gastronomy Works;;
+;16697;createairfabric;Create Air Fabric;;
+;16698;clockworkadditions;ClockworkAdditions;;
+colorfulwater;16699;colored_water;ColorfulWater;;
+yungs-cave-biomes;16700;yungs_cave_biomes,yungscavebiomes;YUNG的洞穴生物群系;YUNG's Cave Biomes;
+;16701;legacy_command_registry;旧式命令注册;Legacy Command Registry;LCR
+;16702;ss;屏保;Screensaver;SS
+;16703;st,stf;启动提示音;StartupTone;ST
+transparency-world-border;16704;Transparency-World-Border;透明化边界;Transparency World Border;TWB
+;16705;watson_macros;Watson Macro/Keybind Support;;
+;16706;mappreset;地图模板;MapPreset;
+va-11-hall-a-drinks;16707;va11halla;Vall-11 Hall-A饮品;Vall-11 Hall-A Drinks;
+bettergive-reborn;16708;bettergive;Better Give: Reborn;;BGR
+;16709;blurserveraddress;Blur Server Address;;
+foodvariations;16710;solclassic;Spice of Life: Classic Edition;;
+pizza-delight;16711;pizzadelight;Pizza Delight;;
+simplefog;16712;simplefog;Simple Fog Control;;
+;16713;butter;butter;;
+tnt-plus-mod;16714;tntplusmod;TNT Plus;;
+;16715;fj21r;强制 Java21：重生;ForceJava21 Reborn;FJ21R
+;16716;betterplayeranimations;Kelvin's Better Player Animations (Port);;
+tokusatsurecord;16717;tokusatsurecord;特摄唱片;Tokusatsu Record;TR
+;16718;amh;模组隐藏器;AlwaysModHider;AMH
+origins-backgrounds-forge;16719;origins_backgrounds;Origins: Backgrounds;;
+cataclysm-apotheosis-addon;16720;cataclysm-apotheosis-addon;Cataclysm Apotheosis Addon;;
+cave-dweller-reimagined;16721;cave_dweller;Cave Dweller Reimagined;;
+out-of-combat;16722;out_of_combat;脱战;Out of Combat;
+soulfragment;16723;soulfragment;灵魂碎片;Soul Fragment;
+;16724;gm4_mysterious_midnights;Mysterious Midnights;;
+create-peaceful;16725;create_peaceful;Create: Peaceful;;
+baby-players;16726;babyplayers;Baby Players;;
+dynaores;16727;dynaores;动态粗矿;Dynamic Raw Ores;
+all-arrows-infinity-fix;16728;allarrowsinfinityfix;All Arrows Infinity Fix;;
+bundles-backport;16729;bundles;Bundles Backport;;
+its-magispelling-time;16730;magispelling;It's Magispelling Time;;
+;16731;attribute_extra;额外属性;Attribute Extra;AE
+;16732;wso;Windows启动界面;WindowsStartingOverlay;
+;16733;dontsneakprogress;偷跑禁止;DontSneakProgress;
+;16734;nkindled;Unkindled;;
+recipe-generator;16735;recipe_generator;Recipe Generator;;
+;16736;carbonfltr;CarbonFLTR;;
+argonmod;16737;argon;氩;Argon;
+foggypalegarden;16738;foggy-pale-garden;Foggy Pale Garden;;
+;16739;itemsstack;Items Stack;;
+arkane-domains;16740;arkane_domains;ARKANE DOMAINS;;
+;16741;zip_package;真·炸药包;C4.ZIP.Package;C4.ZIP
+;16742;yakumoblade;刀藏录;yakumoblade;YA
+no-random-drop-offset;16743;norandomdropoffset;垂直落下/移除掉落随机偏移;No Random Drop Offset;
+croptopias-chocolaterie-unofficial;16744;cacao;巧克力工坊：非官方版;Croptopia's Chocolaterie Unofficial;
+epic-fight-wukong-moveset;16745;wukong;史诗战斗：悟空;Epic Fight - Wukong Moveset;
+;16746;wjtl;玩家头颅数据包;;
+;16747;petphrasex;口癖X;PetPhraseX;PPX
+;16748;identity_v_happy_ending_of_all;第五人格：全员幸终;Identity V: Happy Ending Of All;IVHEOA
+dust-and-ash;16749;dustandash;尘与烬;Dust and Ash;D&A
+;16750;eg_particle_interactions;Particle Interactions;;
+;16751;trialspawnertimer;试炼刷怪笼计时器;Trial Spawner Timer;
+enigmatic-delicacy;16752;enigmaticdelicacy;神秘佳肴;Enigmatic Delicacy;
+slashblade-resharped-renderfix-patch;16753;resharped_renderfix_patch;拔刀剑：重锋 渲染修复补丁;SlashBlade Resharped RenderFix Patch;SRRP
+;16754;no_weak_wheat;Invulnerable Wheat;;
+skin3d-but-not-cubic;16755;skins3d;Skin3D but not cubic;;
+leavesly;16756;leavesly;Leavesly;;
+create-totem-factory;16757;totemfactory;Create: Totem Factory;;
+snad-redstone-edition;16758;snad;子沙：红石版;Snad:Redstone Edition;
+;16759;party-flame;Party Flames (Dyeable Fire);;
+subtle-effects;16760;subtle_effects;Subtle Effects;;SE
+;16761;dma;DreamMasaAddition;;DMA
+cc-wasm;16762;ccwasm;cc wasm;;
+legacy-patch;16763;legacy-patch;Legacy Patch;;
+;16764;gm4_shapeless_portals;Shapeless Portals;;
+;16765;glowup;GlowUp;;
+;16766;customsavedirs;CustomSaveDirs;;
+just-enough-magiculture;16767;justenoughmagiculture;Just Enough Magiculture;;
+ae2-jei-integration;16768;ae2jeiintegration;AE2 JEI Integration;;
+entangled-fix;16769;entangledfix;Entangled Fix;;
+;16770;customdurabilitybar;Custom Durability Bar;;
+;16771;gm4_midnight_menaces;Midnight Menaces;;
+scape-and-run-revenants;16772;srrevenants;Scape and Run: Revenants;;SRR
+warden-s-domain;16773;wd;Warden's Domain;;WD
+more-wardens;16774;extrawardens;More Wardens;;
+hidden-realm;16775;hiddenrealm;Hidden Realm;;
+spells-gone-wrong;16776;spells_gone_wrong;Spells Gone Wrong (Iron's Spells N Spellbooks);;
+wandrous;16777;wandrous;Wandrous;;
+cnpc-dbc-addon;16778;npcdbc;CNPC+ DBC Addon;;
+salmons-genesis;16779;salmons_genesis;Salmon's Genesis;;
+the-afterdark;16780;the_afterdark;The Afterdark;;
+endlesssword;16781;endless_sword;无尽拔刀剑;Endless Sword;ES
+bh3;16782;bh3;崩坏3;;BH3
+;16783;mq_decrafting_table;MQ的分解台;;
+loaded-mods-checker;16784;loadedmodschecker;存档模组核对;Loaded Mods Checker;
+i-have-slept;16785;i_have_slept;朕已安寝;I have slept;
+;16786;itemstackpromax;物品堆叠ProMax;ItemStackProMax;ISPM
+item-split-bug-fix;16787;item_split_bug_fix;物品分裂修复;Item Split Bug Fix;
+spontaneous-replace-cobwebbed;16788;spontaneous-replace-cobwebbed;自然更替：蛛丝网迹;Spontaneous-Replace: Cobwebbed;
+modernconverter;16789;modernconverter,ModernConverter;ModernConverter;;
+frozify;16790;frozify;Frozify;;
+potato-library;16791;potato;PotatoLib;;
+swisscaves;16792;swisscaves;SwissCaves;;
+title-screen-blobcat;16793;title_blobcat;Title Screen Blobcat;;
+punching-creepers;16794;punchingcreepers;Punching Creepers;;
+ancient-curses;16795;ancientcurses;Ancient Curses;;
+resettleable-traders-forge-fabric;16796;resettleable_traders;流浪商人安家;Resettleable Traders;
+ihearttfc;16797;ihearttfc;I ❤ TFC;;
+itemphysic-1-7-10-unofficial;16798;itemphysic;物品物理掉落非官方版;ItemPhysic Legacy Unofficial;
+jei-area-fixer;16799;jei_area_fixer;JEI Area Fixer;;
+ars-elixirum-forge;16800;elixirum;Ars Elixirum;;
+gold-nugget-recycling;16801;mr_gold_nuggetrecycling;Gold Nugget Recycling;;
+sodium-options-api;16802;sodiumoptionsapi;Sodium/Embeddium Options API;;
+;16803;tr;TotomRegister;;TR
+;16804;satr;我TM睡睡睡睡睡睡睡：重铸;Sleep AnyTime:Reborn;SATR
+crazyae;16805;crazyae;疯狂的AE;CrazyAE;
+ae2-crafting-tree-legacy;16806;ae2ctl;AE2合成树-传统版;AE2CT-Legacy;AE2CTL
+ae2-alchemistry-addon;16807;ae2alchemistryaddon;AE2 Alchemistry Addon;;
+;16808;acedium;Acedium;;
+novaultlimit;16809;novaultlimit;NoVaultLimit;;
+game-discs;16810;gamediscs;游戏光碟;Game Discs;
+;16811;luncheonmeatsdelight;午餐肉乐事;Luncheon Meat 'S Delight;
+vanilla-plus-resourceful-tools;16813;resourceful_tools;Resourceful Tools;;
+create-horse-power;16814;createhorsepower;Create Horse Power;;
+ars-technica;16815;ars_technica;Ars Technica;;
+plustic-reforged;16816;plusticreforged;PlusTiC Reforged;;
+spawners-plus;16817;spawners_plus;刷怪笼拓展;Spawners+;
+dracolotl;16818;dracolotl;Dracolotl;;
+;16819;golems_tcon;Tinkers' Golems Addon Reborn;;
+sacks-n-such;16820;sns;Sacks 'N Such;;
+;16821;zbstpz;TPZ 传送命令;;tpz
+;16822;hbmaeaddon;以逸待整/汉;HBM-AEAddon;HAN
+camellialib;16823;camellialib;山茶花核心;CamelliaLib;
+cameliaarmory;16824;cameliaarmory;花朵武器库;FlowerArmory;
+;16825;spongeneo;海绵端插件支持 NeoForge 版;SpongeNeo;
+moonrise;16826;moonrise;Moonrise;;
+corpsecomplex-unofficial;16827;corpsecomplex;Corpse Complex-Unofficial;;CCU
+;16828;starlish;Starlish ⭐;;
+languagereloadunofficial;16829;languagereload;LanguageReloadUnofficial;;
+mekanism-covers;16830;mekanismcovers;Mekanism Covers;;
+enchanted-wilderness-elegant-countryside;16831;elegant_countryside;雅致乡下;Elegant Countryside;EC
+better-durability-reforged;16832;betterdurability;更好的耐久度：重铸;Better Durability Reforged;
+sos;16833;help_me;我来助你！;SOS;
+cherry-on-1-12-2;16834;suikecherry;1.12.2的樱花;Cherry_on_1.12.2;
+scape-and-spartan-parasites;16835;swparasites;寄体斯巴达;Scape and Spartan: Parasites;SSP
+;16836;rotp_extra_dg;Ripples of the Past: Extra Stands Addon;;
+the-knocker;16837;the_knocker;The Knocker;;
+vll-r-mystery;16838;vllr_mystery;Vll r Mystery - Creepypasta;;
+scp-origin;16839;scp_origin;SCP: Origin;;
+sniffers-delicacies;16840;sniffers-delicacies;Sniffer's delicacies;;
+fix-changed;16841;fc;Fix Changed;;FC
+valkyrien-pirates;16842;pirates;瓦尔基里海盗;Valkyrien Pirates;VP
+pathogen;16843;pathogen;Pathogen : Monster plague;;
+chrysalis;16844;chrysalis;Chrysalis;;
+alekis-ridiculously-simple-roofs;16845;alekiroofs;aleki's Ridiculously Simple Roofs;;
+;16846;mc-trails;Trails;;
+rainboows;16847;rainbows;Rainbows!;;
+texturized-particles;16848;texturized-particles;Texturized Particles;;
+rple;16849;rple;Right Proper Lighting Engine;;RPLE
+reign-of-nether-rts-in-minecraft;16850;reignofnether;下界之治;Reign of Nether RTS;RoN
+the-secret-doors;16851;tsdpp;The Secret Doors;;
+;16852;NHUtilities;NH Utilities;;NHU
+;16853;auweschvebc,auweschvebc1,auweschvebc2;“改进-2000”;;IM2K
+tame-tools;16854;tame_tools;驯兽工具;Tame Tools;TT
+;16855;bia;Bedrock Inventory Animations;;BIA
+vounierns-turrets;16856;v_turrets;Vouniern's Turrets;;
+seafarer-forge;16857;seafarer;Seafarer;;
+zombies-plus-frenzied-horde;16858;zombies_plus;Zombies+;;
+;16859;tetrismc;Tetris MC;;
+ecliptic-seasons;16860;ecliptic-seasons;节气;Ecliptic Seasons;
+xibaoxx;16861;xibaoxx;喜报 ××;XiBao ××;XBXX
+;16862;ga;杀戮光环：枪械;GunAura;GA
+;16863;;更好的匠魂战斗;Tinkers 'Better Combat;
+murasama-daker;16864;murasama;鬼妖村正;Murasama;
+particle-storm;16865;particlestorm;粒子风暴;Particle Storm;PS
+;16866;flat-minecraft;2D Minecraft;;
+till-it-breaks-updated;16867;tillitbreaks;Till It Breaks Updated;;
+debark;16868;debark;Debark;;
+till-it-breaks;16869;tillitbreaks;Till it Breaks;;
+end-reborn-expansion;16870;end_reborn;End Reborn;;
+;16871;origins-genshin;Origins: Genshin;;
+;16872;;更好的创造服局域网;laiyipianVC-pack;LVCP
+;16873;log2me;聊天栏日志显示;Log2Me;
+the-glitched-one;16874;man;The Glitched One;;
+progression-reborn;16875;progression_reborn;Progression Reborn;;
+;16876;effecticularity;Effecticularity🫐;;
+;16877;coords_mod;Simple Info Display;;
+;16878;automaticmemories;AutomaticMemories;;
+zoom-camera;16879;zoom;Zoom;;
+dpi-fix;16880;dpi-fix;DPI-Fix;;
+;16881;item_information_display;物品信息显示;Item Information Display;IID
+almanac-lib;16882;almanac;Almanac LIB;;
+;16883;cbrecorder;命令方块日志记录;CBRecorder;CBR
+remove-blindness;16884;template-mod;移除失明;Remove Blindess;
+simplerpgcore;16885;simple_rpg_core;SimpleRPGCore;;SRC
+droppable-villager-trades;16886;droppablevillagertrades;Droppable Villager Trades;;
+stackupper;16887;stackupper;StackUpper;;
+colorful-orbs;16888;colorful-orbs;Colorful Orbs;;
+;16889;idmxd;I Died, My Xp Didn't.;;IDMXD
+modernxl-2-in-survival;16890;modernxl_ii;Modernxl 2;;
+creepercollateral;16891;CreeperCollateral,CreeperCollateralPreloader;CreeperCollateral;;
+findmyitemsandfluids;16892;findme;Find My Items And Fluids;;
+;16893;numeric-experience-info;Numeric Experience Info;;
+aquapatch;16894;aquapatch;AquaPatch;;
+aviator-dreams;16895;aviator_dream;Aviator Dreams;;
+macaws-stairs;16896;mcwstairs;Macaw's Stairs;;
+cross-stitch-colours;16897;dufxcsc;Cross Stitch Colours;;CSC
+gaming-deco;16898;gamingdeco;Gaming Deco;;
+;16899;reactivemusic;韵律回响;Reactive Music;
+easel-does-it;16900;easel_does_it;Easel Does It!;;
+rbasamoyais-betsy-ross;16901;betsyross;rbasamoyai's Betsy Ross;;
+;16902;contingameimesuper;游戏内输入法Super;ContingameIMESuper;
+;16903;negorerouse;尼格洛兹·无尽曈曚：非官方版;NegoreRouse: unofficial;NRU
+;16905;level_strengthen_attributes;升级，加点！;;
+;16906;celestial_addition_tetra;星月附加：Tetra;Celestial Addition Tetra;
+dropped-item-tweaks;16907;droppeditemtweaks;掉落物调整;Dropped Item Tweaks;
+movingquickly;16908;movingquickly;禁用快速移动检查;MovingQuickly;
+;16909;soupapi;Soup API (PvP visuals);;
+;16910;tsa-decorations;Toms Server Additions: Decorations & Furniture;;
+;16911;autofarmmod;Autofarm Mod;;
+gelato-galore-2;16912;gelato_galore;Gelato Galore 2;;
+dyeable-jack-olanterns;16913;ls_djl;Dyeable Jack o'Lanterns;;
+white-pumpkins;16914;white_pumpkins;White Pumpkins;;
+dawn-of-the-flood;16915;dotf;Dawn of the Flood;;DOTF
+deatbutthreereload;16916;deatbutthreereload;逝不过三：重开;Death But Three Reload;DBTR
+common-weapons;16917;common_weapons;Common Weapons;;CW
+ore-silverfish-mod;16918;oresilverfish;Ore Silverfish Mod;;
+gtbcs-spellbooks;16919;gametechbcs_spellbooks;GTBC's Spellbooks - Iron's Spells Addon;;
+project-lambda;16920;lambda;Project Lambda;;
+;16921;mr_create_bigglobecompatability;Create: Big Globe Compatability;;
+;16922;mr_big_globeyungsbetteroceanmonumentscompatibility;Big Globe - YUNG's Better Ocean Monuments Compatibility;;
+;16923;mr_big_globeyungsbetternetherfortressescompatibility;Big Globe - YUNG's Better Nether Fortresses Compatibility;;
+;16924;mr_big_globeyungsbetterwitchhutscompatibility;Big Globe - YUNG's Better Witch Huts Compatibility;;
+;16925;cushop;贸易学：通用商店;Catallactics: Universal Shop;CUshop
+;16926;prettyhitboxes_createaddition;可配置的碰撞箱显示-机械动力功能附加;Pretty Hitbox-Create Addition;
+watersource-reborn;16927;watersource;水源：重生;WaterSource: Reborn;WSR
+locks-unofficial;16928;locks;锁：非官方版;Locks-Unofficial;LU
+;16929;epicfight_improve;史诗战斗：改进;EpicFight：Improve;EFIR
+just-in-nether;16930;just_in_nether;Just-In NETHER;;
+jinghui;16931;jinghui;镜回;JingHui;
+;16932;rotp_mandom;RotP：男人领域附属;Ripples of the Past: Mandom Addon;
+;16933;autogg;Auto GG;;
+better-brightness-slider-respawn;16934;betterbrightnesssliderrespawn;Better Brightness Slider Respawn;;BBSR
+;16935;mr_nice_villagersremastered;Nice Villagers Remastered;;
+;16936;pg;PlayerGyro;;PG
+animatica-foxified;16937;animatica;Animatica Foxified;;
+mcchatgpt;16938;mcchatgpt;MCChatgpt;;
+;16939;aimobs;AImobs;;
+ambiances;16940;ambiance;氛围！;Ambiance!;
+screw-your-items;16941;screwyouritems;Screw Your Items;;
+mace-port;16942;mace_port;Mace Combat Backport;;
+bloodlines;16943;bloodlines;Bloodlines - A Vampirism Addon;;
+vampiric-ageing-a-vampirism-addon;16944;vampiricageing;Vampiric Ageing - A Vampirism Addon;;
+extra-enchantments-and-curses;16945;extra-enchantments-and-curses;Extra Enchantments and Curses;;
+enchanting-tweaker;16946;enchantingtweaks;Enchanting Tweaker/Enchanting Tweaks;;
+just-a-lot-more-enchantments;16947;jlme;Just a lot more enchantments;;JLME
+alessandrvs-enchantments;16948;alessandrvenchantments;Alessandrv's Enchantments;;
+armor-abilities;16949;aabilites;Armor Abilities;;
+sleepy-hollows;16950;sleepy_hollows;Sleepy Hollows;;
+;16951;epw;本地鞘翅穿墙飞行;LocalElytraPenetratesWalls;
+nametag-tweaks;16952;nametagtweaks;名称标签调整;Nametag (Display) Tweaks;
+;16953;sodium-no-alerts;Sodium No Alerts;;
+headshot-respawn;16954;headshotrespawn;爆头：重生;Head Shot Respawn;HSR
+leafdecaystopper;16955;leaf_decay_stopper;树叶腐烂抑制器;Leaf Decay Stopper;
+animated-loading-screen;16956;animated-logo;Animated loading screen;;
+;16957;rotp_whitesnake;RotP：白蛇附属;Whitesnake Addon (Ripples of the Past);
+;16958;rotp_mih;RotP：天堂制造附属;Ripples of the Past: Made in Heaven Addon;
+;16959;rotp_cm;RotP：新月附属;Ripples of the Past: C-Moon Addon;
+imbued-gear;16960;imbued_gear;Imbued Gear;;
+tacz-js;16961;taczjs;TaCZ JS;;
+ipla;16962;ipla;Ipla;;
+bcg-util;16963;bcgutil;BCG Util;;
+sciophobia;16964;sciophobia;全局自定义文本阴影渲染;Sciophobia;
+lithic-addon-mod;16965;lithicaddon;Lithic TFC Addon;;
+light-blocks-from-1-17;16966;light;Light Block Mod;;
+light-and-shadow;16967;light_and_shadow;Light And Shadow;;
+excavein;16968;excavein;Excavein;;
+spanish-delight-a-farmers-delight-add-on;16969;spanishdelight;西班牙乐事;Spanish Delight;
+ars-nouveaus-flavors-delight;16970;arsdelight;新生乐事;Ars Nouveau's Flavors & Delight / Ars Delight;
+oceanic-delight;16971;oceanic_delight;海之乐事;Oceanic Delight;
+the-player;16972;the_player;The "Player";;
+kelka-craftable-animals;16973;craftableanimalsneo;Craftable Animals;;
+super-hyper;16974;hyperremaster;Hyper (Boss & More);;
+wans-ancient-beasts;16975;wan_ancient_beasts;Wan's Ancient Beasts;;WAB
+invocations-spell-engine;16976;invoke;Invocations (Spell Engine);;
+gearifiers;16977;gearifiers;Gearifiers;;
+recall-potion-neoforge;16978;recall_potion;回忆药水;Recall Potion;
+flowing-fluids;16979;flowing_fluids;Flowing Fluids;;
+frights-and-foliage;16980;frights_and_foliage;Frights and Foliage;;
+blorfstone;16981;blorfstone;Blorfstone;;
+filinkus-s-huge-tools;16982;hugetools;FilinKus`s Huge Tools;;
+necromancer-mod;16983;necromancer;Necromancer Mod;;
+e_kedis-electronics;16984;ekedis_electronics;E_Kedi's Electronics;;
+uprade-yourself;16985;upmod;Upgrade yourself!;;
+;16986;takeyourpills;魔法征途;Magic Adventure;MA
+smelting-touch-enchantment;16987;smelting_touch_rebooted;Smelting Touch Enchantment;;
+shinobiorigins-utils;16988;originsutils;ShinobiOrigin's Utils;;
+unifine;16989;unifine;Unifine;;
+trailier-tales;16990;trailiertales;Trailier Tales;;
+mixinjs-coremod;16991;mixinjs;MixinJs;;
+mcwen;16992;mcwen;MCWen;;
+rank-system;16993;rank_system;评分系统;Rank System;RS
+;16994;copf;Creative One-Punch Forge;;COPF
+bundle-inventory;16995;bundleinventory;Bundle Inventory;;
+scroll-tweaks;16996;scrolltweaks;鼠标滚轮调整;Scroll Tweaks;
+neko-server;16997;neko_server;Neko Server;;
+ride-every-thing;16998;rideeverything;骑乘一切;Ride Every Thing;RET
+cit-resewn-neopatcher;16999;citresewn_neopatcher;CITResewnNeoPatcher;;
+legendary-creatures;17000;legendarycreatures;传说生物;Legendary Creatures;
+;17001;meowcraft;Meowcraft;;
+;17002;mr_big_globeyungsbetterjungletemplescompatibility;Big Globe - YUNG's Better Jungle Temples Compatibility;;
+;17003;mr_big_globeyungsbetterdeserttemplescompatibility;Big Globe - YUNG's Better Desert Temples Compatibility;;
+;17004;mr_big_globeyungsbetterstrongholdscompatibility;Big Globe - YUNG's Better Strongholds Compatibility;;
+;17005;mr_big_globeyungsbetterdungeonscompatibility;Big Globe - YUNG's Better Dungeons Compatibility;;
+frozenlib;17006;frozenlib;FrozenLib;;
+clientblock;17007;clientblock;Banned Client;;
+eventjs;17008;eventjs;EventJS;;
+backup-manager;17009;backupmanager;Backup Manager;;
+the-root-of-fear;17010;rootoffear;The Root of Fear;;
+the-modifiger;17011;the_modifiger;The Modifiger;;
+;17012;keypreset;键位预设;KeyPreset;
+;17013;tmm;TweakerooFeaturesMenu;;
+sanity-prequel;17014;sanity;理智：前传;Sanity: Prequel;SP
+ayame-paperdoll;17015;ayame_paperdoll;Ayame 纸娃娃;Ayame PaperDoll;
+;17016;registry-helper-lib;Registry Helper Lib;;
+;17017;carpet-permissions;Carpet Permissions;;
+passive-shield;17018;passiveshield;Passive Shield;;
+trap-expansion;17019;trapexpansion;Trap Expansion;;
+roost-2-flying-higher;17020;roost2;Roost 2: Flying Higher;;
+;17021;amber;Amber;;
+;17022;liteminer;Liteminer;;
+;17023;fin_better_netherz;Level Z - Better Nether;;
+;17024;fin_better_end_z;Level Z - Better End;;
+cc-shops;17025;ccshops;CC Shops;;
+modular-machinery-reborn;17026;modular_machinery_reborn;Modular Machinery Reborn;;
+flare;17027;flare;Flare;;
+rs-crafting-monitor-in-grid;17028;rs_cmig;RS: Crafting Monitor in Grid;;
+;17029;photonics;Photonics;;
+lambdynamiclights-unofficial-neoforge;17030;lambdynlights;LambDynamicLights [Unofficial NeoForge];;
+;17031;healthcommand;More Command;;
+;17032;heraclesbutton;Heracles Button;;
+voicecontrol;17033;voicecontrol;声控;Voicecontrol;VC
+hex-ars-linker;17034;hex_ars_link;魔力媒质链接;Hex-Ars Linker;
+bingolobby;17035;bingolobby;宾果游戏大厅;BingoLobby;
+worldedit-legacy;17036;worldedit;WorldEdit Legacy / WorldEdit Enhanced;;
+;17037;nohealthbar;No Health Bar;;
+asm-fixes-j-a-f-m;17038;asmfixes;ASM Fixes;;J.A.F.M
+moestweaks;17039;moestweaks;MoesTweaks;;
+prickle;17040;prickle;Prickle;;
+farming-3x3;17041;farming-3v3;Farming 3x3;;
+trickery;17042;trickery;Trickery;;
+kebab;17043;kebab;Kebab;;
+farmers-croptopia;17044;farmers_croptopia;Farmer's Croptopia;;
+all-trees-drop-apples;17045;all_trees_drop_apples;All Trees Drop Apples;;
+;17046;infinity;Infinite Dimensions;;
+;17047;mr_big_globeadastracompatibility;Big Globe - Ad Astra Compatibility;;
+mofus-broken-constellations;17048;mofus_better_end_;Mofu's Broken Constellations;;
+starlance;17049;vsch;Starlance;;
+beneath;17050;beneath;Beneath;;
+;17051;scb;简易客户端：基础;SimpleClientBase;SCB
+;17052;dynamic_watermark;动态水印;DynamicWatermark;
+;17053;autologin;自动登录;AutoLogin;AL
+ultimate-enchantment;17054;ultimate_enchantment;终极附魔;Ultimate Enchantment;UE
+ron-settings;17055;ronsettings;Ron Settings;;
+backpack-display;17056;backpackdisplay;背包物品内容显示;Backpack Display;
+horrrs-pvz;17057;horrrs_pvz;Horrrs的植物大战僵尸;Horrrs Pvz;HPVZ
+;17058;optifabric;OptiBabric;;
+item-restrictions;17059;itemrestrictions;Item Restrictions;;
+vintage-animations;17060;vintage_animations;Vintage Animations;;
+the-one-who-watches;17061;the_one_who_watches;The One Who Watches;;TOWW
+scp-ultimate;17062;scp_ultimate;SCP: Ultimate;;
+herobrines-omen;17063;herobrinesomen;Herobrines Omen;;
+sws-wukong;17064;sw_wukong;SW's wukong: better combat & epic fight;;
+dragns-valiant-vehicles;17065;dragnvehicles;DragN's Valiant Vehicles!;;
+bio-factory;17066;biofactory;机械动力：血肉工厂;Create: Bio-Factory;
+create-ad-astra-compatibility;17067;create_ad_astra_compat;Create: Ad Astra Compatibility;;
+create-mechanical-chicken;17068;create_mechanical_chicken;Create Mechanical Chicken;;
+zbgt;17069;zbgt;Zorbatron's GT: CEu Extras;;ZBGT
+casinocraft;17070;casinocraft;CasinoCraft;;
+;17071;msl;Max's QOL Library;;MSL
+toadlib;17072;toadlib;ToadLib;;
+;17073;;喜报-1.8.9;xibao-1.8.9;
+;17074;mantra;口头禅;Mantra;
+crosshair-tweaks;17075;crosshairtweaks;十字准星调整;Crosshair Tweaks;
+what-did-i-just-kill;17076;whatdidijustkill;What Did I Just Kill?;;
+scalablelux;17077;scalablelux;ScalableLux;;
+weather-changer;17078;weatherchanger;Weather Changer;;
+iron-nugget-recycling;17079;mr_iron_nuggetrecycling;Iron Nugget Recycling;;
+;17080;picohud;PicoHUD;;
+re-exposer;17081;exposer;Exposer 重置版;Re-Exposer;
+gtmoreoreprocessing;17082;mop;GTMoreOreProcessing;;MOP
+computercraftedu;17083;ComputerCraftEdu;ComputerCraftEdu;;CCE
+bibliocraft-legacy;17084;bibliocraft;Bibliocraft Legacy;;
+simple-clouds;17085;simpleclouds;Simple Clouds;;
+;17086;kakan;KAKAN;;
+;17087;bigtrees;The BigTrees Mod;;
+furniture-modcraft;17088;furniturecraft;Several Furniture Craft;;FC
+;17089;bmcat;MCAT-免费拓展包 v1;MCAT Free Mod v1;BMCAT
+spellblades-and-such-hexblade;17090;hexblade;Spellblades and Such: Hexblade;;
+;17091;spellbooks_attribute;铁魔法属性;Spellbooks Attribute;
+sons-of-sins-organs-additions;17092;sosorgans;七罪之子：器官添加;Sons Of Sins: Organs Additions;
+sons-of-sins-organs-museum;17093;sos_organ_museum;七罪之子：器官博物馆;Sons of Sins: Organ Museum;
+mobs-of-sins-alexs-mobs-integration-forge;17094;mobs_of_sins;七罪之子: Alex的生物集成;Mobs of Sins: Alex's Mobs Integration [Forge];
+stitched-sins;17095;stitched_sins;缝合的罪;Stitched Sins;
+;17096;bio_delight;血肉乐事;Biomantic Delight;
+;17097;caged_mobs_integration;笼中生物联动;Caged Mobs Integration;
+the-sculpture;17098;the_sculpture;SCP-173，The Sculpture;;
+goop;17099;goop;Goop;;
+neepmeat;17100;neepmeat;NEEPMeat;;
+tacz-emx-arms-gunpack;17101;emxarms;EMX-逆境重科电磁武器包;;
+tacz-emx-atlas-gun-pack;17102;emxmors;EMX-ATLAS电磁武器包;;
+;17103;hybridcreatures;我的世界杂交版;Hybrid Creatures;HC
+;17104;more_monster;更多怪物;HuangSheng1's More Monster;MM
+creeping-woods;17105;creepingwoods;Creeping Woods;;
+;17106;zombie_apocalypse_core;Zombie Apocalypse Core;;
+dragon-mounts-2;17107;dragonmounts;龙骑士2：延续;DragonMounts2: Continued;DM2:C
+life-fruits;17108;lifefruit;生命果;Life Fruits;
+ati-structures;17109;ati_structures_fabric,ati_structures;ATi Structures;;
+fantasy-armor;17110;fantasy_armor;Fantasy Armor;;
+beautiful-enchanted-books;17111;beautiful-enchanted-books;Beautiful Enchanted Books;;
+;17112;OmniOcularUnofficial;Omni Ocular Unofficial;;OOU
+morphe-lins-ron-rts-tools;17113;rw_fix;墨灵的RTS优化;;
+void-fog;17114;voidfog;Void Fog;;
+;17115;legacy_rocket_model;旧版火箭模型;Legacy Rocket Model;LRM
+;17116;autocommand;自动指令;Auto Command;
+;17117;emergencystop;急停;Emergency Stop;
+;17118;simple_tetra_js;我要造词;Simple Tetra Js;
+tinker-i-o-ce;17119;tinker_io;工匠接口社区版;Tinker I/O CE;
+more-shield-variants;17120;lolmsv;More Shield Variants;;
+;17121;mr_no_attacktimedelay;No attack time delay;;
+bendy-items;17122;bendy_and_the_items;Bendy Items;;
+paladins-oath;17123;paladins_oath;Paladin's Oath;;PO
+;17124;squirrelmod;小松鼠;Small Squirrel;
+roundabout-the-jojo-mod;17125;roundabout;Roundabout: The JoJo Mod;;
+;17126;rotp_zwa;RotP：白色相簿附属;White Album (Ripples of the Past addon);
+;17127;rotp_waytoheaven;RotP：天堂之路附属;The Way to Heaven (Ripples of the Past addon);
+enviromine-continuation;17128;enviromine;EnviroMine continuation;;
+;17129;toffys_hooks;Toffy's Hooks;;
+mutants-buff;17130;mutantsbuff;Mutants Plus;;
+;17131;scc;简易客户端：指令;SimpleClientCommands;SCC
+;17132;wai;玩家方块模型;BlockPlayer;BP
+terrablenderfix;17133;terrablenderfix;TerraBlenderFix;;
+craterlib;17134;craterlib;CraterLib;;
+;17135;caramelchat;caramelChat;;
+spark-unforged;17136;;Spark Unforged;;
+pack-mode-reborn;17137;packmode;PackMode Reborn;;PMR
+all-the-wood-weve-got;17138;woodwevegot;All The Wood We've Got;;WWG
+bibliowoods-legacy;17139;bibliowoods;Bibliowoods Legacy;;
+hydrological;17140;hydrol;Hydrological;;
+unilib;17141;unilib,mod_UniLib;UniLib;;
+;17142;madv;更多进度;More Advancements;MAdv
+modchu_playerformlittlemaidfml;17143;pflmf;PlayerFormLittleMaid FML;;PFLMF
+quiet;17144;quiet;迁噪碍音/玩家禁言;Quiet;
+galacticraft-compatibility;17145;galacticraftcompatibility;星系兼容;Galacticraft Compatibility;GCC
+;17146;better-tab;Better Tab;;
+modular-machinery-reborn-mekanism;17147;modular_machinery_reborn_mekanism;Modular Machinery Reborn Mekanism;;
+;17148;;Smooth Swapping 1.21 Port;;
+dawn-of-time-roa-edition;17149;dawnoftimebuilder;Dawn of Time: RoA Edition;;
+buildpaste;17150;buildpaste;BuildPaste;;
+mutils;17151;mutils;ModpackUtils;;
+better-campfires;17152;bettercampfires;更好的营火;Better Campfires;
+;17153;renfe;MTR Renfe Addon;;
+;17154;gtca;GT Community Additions;;GTCA
+more-create-burners;17155;moreburners;机械动力：燃烧室附加;More Create Burners;
+create-logistics;17156;create_logistics;Create Logistics;;
+create-pneumatic-equipment;17157;create_pneuequip;Create: Pneumatic Equipment;;
+collisiondamage;17158;collisiondamage;碰撞伤害;CollisionDamage;CD
+;17159;absolutely-proprietary;Absolutely Proprietary;;
+tensura-reincarnated;17160;tensura;关于我转生变成史莱姆这档事：转生;Tensura: Reincarnated;T:R
+transformer;17161;transformer;奥特化身：无限;Becomes Ultraman:Infinity;BUI
+henshin;17162;henshin;变身;Henshin;HS
+ridiculous-world;17163;RidiculousWorld;Ridiculous World;;
+;17164;enhancedbiomes;Enhanced Biomes;;
+quartz_craft;17165;quartzcraft;石英工艺;Quartz_Craft;QC
+cursed-stare;17166;cursed_stare;Cursed Stare;;
+legendblade;17167;legendblade;传世之刃;LegendBlade;LB
+;17168;hypothermic;Hypothermic Reforged;;
+scape-and-run-parasites-extra;17169;srpextra;逃逸：寄生体扩展;Scape and Run: Parasites Extra;
+lauchs-shutters;17170;shutter;The New Shutters;;
+golden-foods;17171;golden_foods;Golden Foods!;;
+;17172;alexcaves_delight;Alex's Caves Delight;;
+;17173;spmreborn;烤地瓜：重生;Sweet Potato Reborn;SPR
+dragon-fight-config-endergetic-addon;17174;dragonfightconfigendergetic;Dragon Fight Config - Endergetic Addon;;
+hour-clock-24;17175;hourclock24;24小时制;24Hourclock;24HC
+;17176;mr_stone_disappearance,stone_disappearance;石头消失;Stone Disappearance;SD
+;17177;;DatapackTools;;
+celestial-forge;17178;celestial_forge;星月再锻;Celestial Forge;
+mahjongcraft;17179;mahjongcraft;麻将工艺;MahjongCraft;
+formidulus;17180;formidulus;Formidulus;;
+ames-stranger-things;17181;stranger_things;AME's Stranger Things;;
+herobrine-origins;17182;herobrineorigins;Herobrine Origins;;
+milkable-blazes;17183;milkable_blazes;Milkable Blazes;;
+;17184;stone_legacy;RotP：暗之遗物;Stone Legacy (Ripples of the Past addon);
+furniture-beetle;17185;beetle_f;Furniture Beetle;;
+mekanism-x-create-northstar;17186;mek_x_star;Mekanism x Create: Northstar;;
+;17187;mr_createz;CreateZ;;
+create-smart-crafter;17188;smartcrafter;Create: Smart Crafter;;
+create-fuel-and-water-information;17189;cfwinfo;Create: Fuel & Water Information;;
+thematic;17190;thematic;🖌️ Thematic;;
+;17191;lolmcmv;More Composter Variants;;
+more-fletching-tables;17192;lolmft;More Fletching Tables;;
+more-grindstone-variants;17193;lolmgv;More Grindstone Variants;;
+more-bed-variants;17194;quad-lolmbdv;More Bed Variants;;
+more-loom-variants;17195;lolmlmv;More Loom Variants;;
+more-feeding-trough-variants;17196;lolmcmv-aft;More Feeding Trough Variants;;
+more-smoker-variants;17197;quad-lolmsmv;More Smoker Variants;;
+manascore;17198;manascore;ManasCore;;
+ames-mobs-configuration;17199;amemobsettings;AME生物配置;Ame's Mobs' Configuration;Amc
+display-delight;17200;displaydelight;Display Delight;;
+realistic-torches-roa-edition;17201;realistictorches;Realistic Torches: RoA Edition;;
+;17202;explorerscompass;探险者指南针 修改;Explorer's Compass Edited;
+;17203;mr_auto_luckyblock,auto_lucky_block;自动幸运方块;auto lucky block;ALB
+;17204;slime;Slime;;
+x-backup;17205;x-backup;X Backup;;XB
+iron-barrels-forge;17206;ironbarrels;Iron Barrels;;
+spectral-decorations;17207;spectral-decorations;Spectral Decorations;;
+;17208;long-dark;LongDark黑夜求生;;LD
+;17209;yuanlinAutoDefense;园霖的自动防御模组[监控器版本];;YAD
+trims-on-tools;17210;trims_on_tools;Trims on Tools;;
+galacticraft-automatic-resources;17211;galacticraftresources;星系自动资源;Galacticraft Automatic Resources;
+;17212;tetrasimplyaddon;Tetra简易刀剑附属;TetraSimplyAddon;
+;17213;lx_lightassisttool;轻辅助工具;light assist tool;
+;17214;gamaos_tactical_equipment;噶猫的战术装备;Gamao's Tactical Equipment;GTE
+;17215;lucky_block_island;幸运方块空岛;Lucky Block Island;LBI
+roberts-building-pack;17216;roberts_building_pack;Robert的建筑扩展包;Robert's Building Pack;RBP
+arcanus-continuum;17217;arcanuscontinuum;Arcanus: Continuum;;
+ultimate-chess;17218;chessmod;Ultimate Chess;;
+sparkweave;17219;sparkweave;Sparkweave Engine;;
+visualjs;17220;visualjs;VisualJS;;
+lights-out;17221;lights_out;Lights Out;;
+a-night-stalker;17222;man;A Night Stalker;;
+the-faceless-duo;17223;the_faceless_duo;The Faceless Duo;;
+scape-and-run-parasites-meteorite;17224;srpmeteor;逃逸：祸从天降;Scape and Run: Parasites Meteorite;
+cravencrafts-bloody-bits;17225;bloodybits;CravenCraft's Bloody Bits;;
+;17226;scm;简易客户端：模块;SimpleClientModules;SCM
+;17227;ccs;撞车;CarCrash;CCS
+;17228;yuanlinautobot;园霖的自动机器人;Yuanlin's AutoBot;YAB
+fastlang;17229;fastlangmod;FastLang;;
+min-3-hall-a;17230;min3halla;MIN-3 Hall-A;;MH
+modular-machinery-reborn-energistics;17231;modular_machinery_reborn_energistics;Modular Machinery Reborn Energistics;;
+tweaks-for-galactic-science;17232;galacticScience_Tweaks;Tweaks for Galactic Science;;
+java-version-checker;17233;JavaVersionChecker;Java Checker;;
+chatcopyrite;17234;chatcopyrite;Chatcopyrite;;
+chat-boost;17235;chatboost;聊天增强;Chat Boost;
+terracart;17236;terracart;Terracart;;
+noteblock-backport;17237;noteblock_backport;Noteblock Backport;;
+scape-and-run-parasite-dimension;17238;eextra;逃逸：寄染之世;Scape and Run: Dimension;
+hexdebug;17239;hexdebug;咒术调试;HexDebug;
+paths-of-sin;17240;paths_of_sin;Paths Of Sin;;
+;17241;mapperplugin;MapperPlugin;;MP
+;17242;gtb;附魔分解;Enchantment Dismantling;GTB
+hide-key-binding;17243;hide_key_binding;隐藏按键绑定;Hide Key Binding;HKB
+;17244;dfl,mr_datapackets_functionslib;数据包函数支持库;datapackets functions LIB;DFL
+inline;17245;inline;Inline;;
+fluffy-fur;17246;fluffy_fur;Fluffy Fur;;
+;17248;hugescreenshot;巨型截图;HugeScreenshotMod;HSM
+head-cutter;17249;headcutter;玩家剪头;Head Cutter;
+salty-s-realistic-forging;17250;realisticforging;Salty's Realistic Forging;;
+;17251;vs-wakes-compat;Wakes Compat for Valkyrien Skies;;
+;17252;vscrumbles;VS Crumbles;;
+;17253;ship-in-a-bottle;Ship In A Bottle;;
+rustic-pancakes;17254;rusticpancakes;Rustic Pancakes;;
+ice-and-fire-delight;17255;ice_and_fire_delight;冰火传说乐事;Ice and Fire Delight;
+additional-dragons;17256;additionaldragons;Additional Dragons;;
+enigmatic-unity;17257;enigmaticunity;Enigmatic Unity;;
+ephemera;17258;ephemera;Ephemera;;
+theurgy-kubejs;17259;theurgy_kubejs;Theurgy KubeJS;;
+immersive-lanterns;17260;immersivelanterns;Toni's Immersive Lanterns;;
+txnilib;17261;txnilib;TxniLib;;
+default-key-setup;17262;default_key_setup;默认按键配置;Default Key Setup;DKS
+the-man-king;17263;man;The Man King;;
+create-arms-race;17264;createarmsrace;Create: Arms Race;;
+powered-flashlight;17265;powered_flashlight;Powered Flashlight;;
+vmc-mc;17266;vmc-mc;Virtual Motion Capture for Minecraft;;VMC-MC
+;17267;hexcellular;Hexcellular;;
+hex-conjuring;17268;hexconjuring;咒术构筑;Hex Conjuring;
+hexjs;17269;hex_js;HexJS;;
+craftsense;17270;craftsense;CraftSense;;
+;17271;chimera27metroid;Metroid Cubed;;
+zenkorium-creatures;17272;leshen;Zenkorium Creatures;;
+zhengelss-techguns-addon;17273;zhengels_techguns_addon;Zhengels's Techguns Addon;;
+more-artifacts;17274;more_artifacts;More Artifacts;;
+;17275;mr_mtimer;Timer;;
+tfcgenviewer;17276;tfcgenviewer;TFCGenViewer;;
+terra-math;17277;terramath;TerraMath;;
+lukis-crazy-chambers;17278;mr_lukis_crazychambers;Luki's Crazy Chambers;;
+tumbleweed-wasteland;17279;tumbleweed;Tumbleweed Wasteland;;
+irons-jewelry;17280;irons_jewelry;Iron's Gems 'n Jewelry;;
+atlas-api;17281;atlas_api;Atlas API;;AA
+loading-screen-messages;17282;loading_screen_messages;Loading Screen Messages;;
+;17283;pss;PipeSounds;;PSS
+nemos-invertory-sorting;17284;nemos_inventory_sorting;Nemo's Inventory Sorting;;
+;17285;betterux;BetterUX;;
+;17286;hudmini;HudMini;;
+ribs-panning;17287;ribspanning;Ribs Panning;;
+hotkettles;17288;hotkettles;Hot Kettles;;
+gift-drop;17289;gift_drop;Gift Drop;;
+dragns-livestock-overhaul;17290;dragnlivestock;DragN's Livestock Overhaul!;;LO
+storage-drawers-unofficial;17291;;储物抽屉非官方版;Storage Drawers Unofficial;
+;17292;;探索者背包2;AdventureBackpack2;
+centrifuge-tiers-reproduced;17293;centrifugetiersreproduced;Centrifuge Tiers: Reproduced;;
+dense-mekanism;17294;denseores;Dense Mekanism;;
+simple-missles;17295;simplemissiles;Simple Missiles;;
+galosphere-spellbooks;17296;galosphere_spellbooks;Galosphere: Spellbooks;;
+discerning-the-eldritch;17297;discerning_the_eldritch;Discerning The Eldritch;;
+;17298;hexcassettes;Hexcassettes;;
+wardens-plus;17299;wardens_plus;Wardens+;;
+ender-wyrmlings;17300;ender_wyrmlings;Ender Wyrmlings;;
+;17301;draw_arrows;拔箭;Draw Arrows;
+;17302;blackflood-hardermonster;黑潮：更困难的怪物;Black Flood:Harder Monster;BFHM
+new-classic-battle-towers;17303;new_classic_battle_towers;New Classic Battle Towers;;
+chitin-equipment;17304;chitin;甲壳装备;Chitin Equipment;
+mowzies-cataclysm;17305;mowzies_cataclysm;Mowzie的灾变;Mowzie's Cataclysm;
+stardew-fishing-fabric;17306;stardew_fishing;Stardew Fishing Fabric;;
+piglin-slayer;17307;overworldpiglins;Piglin Slayer;;
+cataclysm-tools;17308;cataclysm_tools;Cataclysm Tools;;
+witherite-gear;17309;witherite_armor;Cataclysm Witherite Armor;;
+faunus;17310;faunus;Faunus;;
+oo-ee-a-e-a;17311;oo_ee_a_e_a;OO EE A E A;;
+;17312;translator;翻译器;Translator;
+;17313;opencmd;游戏指令窗;Open Command;OCMD
+;17314;mr_daycounter;Day Counter (Original);;
+sodium-embeddium-options-mod-compat;17315;sodiumoptionsmodcompat;Sodium Options Mod Compat;;
+secureseed-reborn;17316;secure-seed-reborn;SecureSeed-Reborn;;
+creative-eats;17317;eating;Creative Eats;;
+mazerooms;17318;mazerooms;MazeRooms;;
+friendly-chests;17319;friendly_chests;Friendly Chests;;
+;17320;chitinous_ties;Chitinous Ties;;
+brewable-dragons-breath;17321;brewable_dragons_breath;龙息可酿造;Brewable Dragon's Breath;
+flerovium;17322;flerovium;鈇;Flerovium;
+;17323;ender_random_creation;末影工艺;EnderRandomCreation;ERC
+;17324;cherrytinker;樱桃工匠;Cherry Tinker;CT
+gathering-torches-become-sunlight;17325;torchesbecomesunlight;薪火，造炬成阳;Gathering Torches Become Sunlight;
+;17326;spec;切旁观数据包;spec;
+;17327;bml;更多聊天记录-NeoForge;MoreChatHistoryNeoForge;
+no-arrows-in-you-respawn;17328;noarrowsinyou;No Arrows In You: Respawn;;NAYR
+;17329;naturescompassedited;生物群系指南针 修改;NaturesCompassEdited;
+glowcase;17330;glowcase;Glowcase;;
+hitbox-api;17331;hitboxapi;Hitbox Api;;
+;17332;polynametag;PolyNametag;;
+broken-nametags;17333;broken_nametags;Broken Nametags;;
+;17334;usefullflesh;Compostable Flesh;;
+a-cute-little-crock-pot;17335;crockpot;A Cute Little Crock Pot;;
+;17336;bountifulharvest;感恩节乐事;Bountiful Harvest;
+wasteland-grocers;17337;wastelandgrocers;Wasteland Grocers;;
+arcane-tablet;17338;projex;Arcane Tablet;;
+;17339;unflavoured_pipes;Unflavoured Pipes;;
+curvy-pipes;17340;curvy_pipes;Curvy Pipes;;
+;17341;SC0_SpaceCore;SpaceCore;;
+;17342;transport_to_your_death;死亡点传送;Transport To Your Death;TTYD
+classic-bar-legacy;17343;classicbar;经典状态条 延续版;Classic Bar Legacy;
+glowing-eyeblossom;17344;glowing-eyeblossom;Glowing Eyeblossom;;
+openlink;17345;openlink;开放式联机;OpenLink;OL
+;17346;vsgrapples;VS Grapples;;
+;17347;mydriasis;Mydriasis;;
+no-mob-spawning-on-plants;17348;nmsop;No Mob Spawning On Plants;;
+matmos2;17349;matmos,MAtmos;MAtmos ambient sound;;
+durability-rework;17350;unbreakable;Unbreakable (Durability Rework);;
+more-villagers-re-employed;17351;morevillagers;More Villagers : Re-employed;;
+similsax-transtructors;17352;similsaxtranstructors;Similsax Transtructors - Builder's Wands;;
+tcw-bedrock-breaker;17353;bedrockbreaker;TCW Bedrock Breaker;;
+apothic-reforge-tokens;17354;apotheosis_reforge_token;Apothic Reforge Tokens;;
+advanced-skills-remastered;17355;advskills_re;进阶技能：重制版;Advanced Skills: Remastered;ASRe
+monsters-and-dungeons;17356;monstersanddungeons;Monsters and Dungeons;;
+cultivate-the-eternal-realm;17357;waifu_of_god;Cultivate the Eternal Realm;;
+too-much-bosses;17358;too_much_bosses;Too Much Bosses;;
+valoria;17359;valoria;Valoria;;
+glowroot;17360;glowroot;Glowroot Caves;;
+;17361;instaminabledeepslate;Instaminable Deepslate;;
+;17362;mr_daycounter_legacy;Day Counter (Legacy);;
+greedy-bag;17363;greedybag;Greedy Bag (ItemStages Bag);;
+naughthirium;17364;naughthirium;Naughthirium;;
+chunkpurge;17365;ChunkPurge;区块清除;ChunkPurge;
+kubejs-tfmg;17366;tfmgjs;KubeJS TFMG;;
+gauges-and-switches-ported;17367;rsgauges;Gauges and Switches Ported;;
+mifa;17368;mifa;More Industrial Foregoing Addons;;MIFA
+tis-vs;17369;tisvs;TIS-VS;;
+pistronics-2;17370;Pistronics2;Pistronics 2;;
+;17371;awakened_skeleton;骷髅觉醒了;AwakenedSkeleton;
+;17372;primeval;原初;Primeval;PL
+gladius-combat-evolved;17373;combat;Gladius - Combat Evolved;;
+hungry-chests;17374;hungrychests;Hungry Chests;;
+better-withered-mobs;17375;better_withered_mobs;Better Withered Mobs;;
+pkgbadges;17376;cobblebadges;PKGBadges / CobbleBadges;;
+;17377;carbasa;Carbasa;;
+countereds-settlement-roads;17378;countereds_settlement_roads;Countered's Settlement Roads;;
+countereds-terrain-slabs;17379;terrainslabs;Countered's Terrain Slabs;;
+explosive-enhancement-reforged;17381;explosiveenhancement;Explosive Enhancement: Reforged;;
+tmtravlrs-arrow-trails;17382;arrowtrails;Tmtravlr的箭矢轨迹;Tmtravlr's Arrow Trails;
+biome-replacer;17383;biome_replacer;群系替换器;Biome Replacer;
+custom-suspicious-stew;17384;customsuspiciousstew;自定义谜之炖菜;Custom Suspicious Stew;
+;17385;cfms;子文件夹Mod扫描器;Child Folder Mod Scanner;CFMS
+;17386;plant_spread;植物蔓延;Plant Spread;
+;17387;createstressdebug;Create Stress Debug;;
+create-kart;17388;create_kart;Create Kart;;
+;17389;barometry;Barometry;;
+menufpsunlocker;17391;mfpu;MenuFPSUnlocker;;
+bogged-spawn;17392;boggedspawn;Bogged Spawn;;
+unicode-fix;17393;unicodefix;Unicode Fix;;
+insanity;17394;insanity;InSanity;;
+;17395;sepals;Sepals;;
+frustum-culling-advanced;17396;frustumculling;Frustum Culling (More fps);;
+;17397;seat_ball;原版座位;Seat Ball;
+;17398;zombie_horse_spawning;僵尸马生成;Zombie-horse-spawning;
+star-meow-craft;17399;smc;星喵工艺;Star Meow Craft;SMC
+;17400;defile;Defile;;
+vanishmod;17401;vmod;Vanishmod;;
+;17402;ei;Eat It;;
+f1-y-f5-mod;17403;f1_f3_f5;Perspective Lock;;
+meddlebootstrap;17404;meddlebootstrap,exitpatch;MeddleBootstrap;;
+alltheleaks;17405;alltheleaks;AllTheLeaks (Memory Leak Fix);;
+walk-overhaul;17406;walkoverhaul;Walk Overhaul;;
+no-strip;17407;nostrip;No Strip;;
+mcplus-remastered;17408;mc+region,mc+base;MCPlus：重置版;MCPlus Remastered;
+instant-classic-houses;17409;instant_classic_houses;Instant Classic Houses;;
+hexparse;17410;hexparse;HexParse;;
+betterraid;17411;better_raid;更好的劫掠;BetterRaid;
+villagermetafix;17412;VillagerMetaFix;VillagerMetaFix;;
+create-better-villager;17413;create_better_villagers;Create: Better Villager;;
+filesjs;17414;filesjs;FilesJS;;
+robotic-parts-first-aid-compat;17415;cyberware;Robotic Parts & First Aid Compat;;
+craftingpad-fabric;17416;craftingpad;CraftingPad;;
+;17417;ore_deposites,mr_ore_deposits;Ore Deposits;;
+exlines-sushi-mod;17418;sushimod;寿司;Sushi Mod;
+demanding-saplings;17419;demandingsaplings;Demanding Saplings;;
+coastal-waves;17420;waves;Coastal Waves;;
+;17421;nonadar_pyronix;No Swimming;;
+;17422;Blocks3D;Blocks3D Mod;;
+stone-zone;17423;stonezone;泛用兼容：石材;Every Compat (Stone Zone);
+a-man-with-plushies;17425;a_man_with_plushies;A Man With Plushies;;
+enchantmentransfer;17426;gtb;附魔转移;Enchantment Transfer;ET
+;17427;don_it;戴它;Don it;donit
+;17428;friendship_bracelet;友谊徽章;FriendshipBracelet;
+;17429;setblock_tnt,mr_setblock_tnt;TNT生成;SetBlock-TNT;SBT
+;17430;async;Async;;
+;17431;mtrsteamloco;Aphrodite的纸板箱的交通扩展;Aphrodite Nemo Transit Expansion;ANTE
+;17432;touchcontroller;TouchController;;TC
+;17433;llpswhyrz;llpsw的火影忍者;llpsw Naruto Mod;lnm
+let-me-click-and-send;17434;letmeclickandsend;Let Me Click And Send;;
+;17435;maker_namespace;玩家头颅生成器;Player Skull Maker;
+careful-cast-corrector-ccc;17436;CarefulCastCorrector;Careful Cast Corrector;;CCC
+lagbgon-revived;17437;lagbgonrevived;Lag'B'Gon Revived;;
+project-steam;17438;projectsteam;Age of Steam Core;;
+extended-crafting-terminals-for-applied;17439;ae2exttable;Extended Crafting Terminals for Applied Energistics 2;;
+sweety-archeo;17440;sweety_archaeology;Sweety's Archaeology;;
+;17441;musket;火帽枪;Musket;
+chamber-clarity-tac-z;17442;chamber_clarity;Chamber Clarity;;
+;17443;techguns;Techguns 2 Completion Update;;
+;17444;showspawntime;Show Spawn Time;;SST
+;17445;jdinpack;JDINPack;;
+selfexpression-slim;17446;selfexpression_slim;Selfexpression: Slim;;
+nothing-dimension;17447;nothing;Nothing Dimension;;
+;17448;glassitemframes;Glass Item Frames;;
+portable-stations;17449;portable-stations;Portable Stations;;
+new-world-mod;17450;newworld;New World;;NW
+;17451;ornithe-loader;Ornithe;;
+;17452;123Technology;123科技;123Technology;123t
+;17453;;更好的任务非官方版;BetterQuesting;BQ
+;17454;backhand;Backhand Unofficial;;
+book-scroll;17455;book_scroll;Book Scroll;;
+;17456;journalmod;日志模组;Journal Mod;
+;17457;at;自动工具;AutoTool;AT
+;17458;fv;FakeVanilla;;FV
+;17460;sakura_sign_in;樱花签;Sakura Sign-In;SS
+;17461;exp_merge;经验合并;;
+;17462;easier_mc,mr_easier_mc;更简单的MC;Easier MC;EMC
+;17463;qca;Qualia Carpet Addition;;QCA
+mouse-tweaks-unofficial;17464;;鼠标手势非官方版;Mouse Tweaks Unofficial;
+baubles-lts;17465;baubles;Baubles-LTS;;
+elysium-api;17466;elysium_api;Elysium API;;
+noisethreader;17467;noisethreader;NoiseThreader;;
+;17468;no-bats;No Bats;;
+antibat;17469;antibat;Antibat;;
+illage-and-spell-age;17470;iss_spellbook;Illage and Spell-age: Iron's Spells Addon;;
+origincore;17471;origincore;起源核心;Origincore;OC
+;17472;ImmerGears;沉浸装备0;ImmerGears0;IG0
+;17473;petconnect;收容宠物;Pet Connect;
+heaven-destiny-moment;17474;heaven_destiny_moment;天命时刻;Heaven Destiny Moment;
+industrial-foregoing-extra-upgrades;17475;ifeu;工业先锋:更多升级;Industrial Foregoing: Extra Upgrades;IFEU
+growableores-extension;17476;growableores_extension;甘蔗转换机;GrowableOres Extension;
+oneiricconcept;17477;oneiricconcept;梦华构想;OneiricConcept;OC
+simelectricity;17478;simelectricity;SimElectricity;;
+somnia-refreshed;17479;somnia;Somnia Refreshed;;
+terramoment;17480;terra_moment;泰拉时刻;TerraMoment;
+miners-diary-beyond-village;17481;md_bv;Miner's Diary - Beyond Village;;
+biggerchathistory;17482;biggerchathistory;Bigger Chat History;;BCH
+unifier;17483;Unifier;Unifier;;
+compass-ribbon;17484;cr-compass-ribbon;Compass Ribbon;;
+raiyons-tree-capitator-addon;17485;raiyon;Raiyon's Tree Chop-Capitator;;
+;17486;elytrahud;Elytra HUD;;
+creeper-drops-tnt;17487;creeperdropstnt;Chokbok's creeper drops TNT !?!!;;
+visual-novel-framework;17488;mobtalkerredux;Visual Novel Framework / Mob Talker Redux;;
+;17489;experienceprogress;Experience Progress;;
+yapping-tooltips;17490;yapping_tooltips;Yapping Tooltips;;
+bird-nests;17491;birdnests;Bird Nests;;
+tfc-purified-water;17492;purified_water;TFC Purified Water;;
+;17493;exparticle;粒子扩展;ExParticle;EP
+;17494;entityrenderdisabler;Entity Render Disabler;;
+quick-right-click;17495;quick-right-click;Quick Right-Click;;
+alchimiae-magicae;17496;alchimiae;炼金魔法师;Alchimicae Magicae;
+thaumic-forever;17497;thaumicforever;Thaumic Forever;;
+gregfluxology;17498;gregfluxology;GTCEu/GTM能源拓展;Gregfluxology;
+create-crowns;17499;crowns;Create: CROWNS;;
+;17500;create_modular_tools;Create: Modular Tools;;
+ae2-wireless-terminal-lts;17501;;AE2 Wireless Terminal-LTS;;
+;17502;cme_suck_my_duck;并发修改什么的不要鸭;CME is Bad;
+enchantment-harmony;17503;enchantmentharmony;和谐相处的附魔书;EnchantmentHarmony;EH
+quick-refine;17504;quick_refine;快捷锻刀;Quick Refine;QR
+rubinated-nether;17505;rubinated_nether;耀红下界;Rubinated Nether;
+cornucopia-bypizza573;17506;cornucopia;丰饶之角;Cornucopia;
+;17507;efbowtweak;Epic Fight Bow Tweak;;
+slash-blade-addon;17508;tunekeshi;Slash Blade Addon;;
+jjkutilities;17509;jujutsucraftutilities;JujutsuCraft Utilities;;JJCU
+crystal-chronicles;17510;crystal_chronicles;Crystal Chronicles;;
+;17511;dynmapblockscan;DynmapBlockScan;;
+water-particles-render-fix;17512;particlesrenderfix;Water/Particles Render Fix;;
+ray-trace-library;17513;mrdimkaraytracelib;Ray Trace Library;;
+delayed-thunder;17514;betterlightning;Delayed Thunder;;
+book-and-quick-save;17515;book_and_quick_save;Book and Quick Save;;
+keybaordjs;17516;keyboardjs;Keyboard JS;;KBJS
+better-eating-mod;17517;bettereating;Better Eating Mod;;
+;17519;heart-effects;Heart Effects;;
+;17520;globalwind;Global Wind;;
+botaniavisualizer;17521;BotaniaVisualizer,botaniavisualizer;BotaniaVisualizer;;
+mana-visualizer;17522;manavisualizer;Mana Visualizer;;
+manavisualizer;17523;manavisualizer;ManaVisualizer;;
+easierworldcreator;17524;easierworldcreator;Easier World Creator;;EWC
+kubejs-diesel-generators;17525;dg_js;KubeJS Diesel Generators;;
+create-slugma;17526;createslugma;Create Slugma;;
+cobblemonrider;17527;cobblemonrider;CobblemonRider;;
+cobbledex;17528;cobbledex;Cobblemon Pokedex (Cobbledex);;
+;17529;legends_untold;Cobblemon: Legends Untold;;
+item-descriptions;17530;item_descriptions;Item Descriptions;;
+item-production-lib;17531;itemproductionlib;Item Production Lib;;
+;17532;goawaydfu;GoAwayDFU!;;
+connectedtexturesmod-backport;17533;ctm;ConnectedTexturesMod Backport;;
+;17534;litematica_printer;投影打印机;Litematica-Printer-Easyplace-Extension;
+elegant-architecture;17535;elegant_architecture;雅致画栋;Elegant Architecture;EA
+extended-workbench-reborn;17536;extended_workbench;扩展工作台重置版;Extended Workbench Reborn;
+;17537;hydrogenation_tinker;氢化匠魂;HydrogenationTinker;HYTIC
+;17538;deathshot;Stan's Deathshot;;
+pathunderfencegates;17539;pathunderfencegates;Path Under Fence Gates;;
+;17540;mr_ketkets_furnicraft;FurniCraft;;
+latiao-craft-2;17541;ltc2;辣条工艺 2;Latiao Craft 2;LTC2
+canned;17542;canned;Canned;;
+mushroooms;17543;mushrooomsmod;Mushroooms;;
+tacz-compatibility;17544;tacaid;TACZ Compatibility;;
+;17545;naturaldisasters;Baablu's Natural Disasters;;
+;17546;tacztweaks;TaCZ Tweaks;;
+un-saddle;17547;unsaddle;Un-saddle;;
+;17548;item-landing-sound;Item Landing Sound;;
+rehooked;17549;rehooked;ReHooked;;
+;17550;mr_catenary;Catenary;;
+;17551;legendarywheatmod;传奇小麦;Legendary Wheat;
+;17552;anvil_falling;铁砧掉落;Anvil Falling;AF
+better-night-vision;17553;betternightvision;更好的夜视;Better Night Vision;
+;17554;aoawikihelpermod;AoAWikiHelperMod;;
+manors-bounty;17555;manors_bounty;庄园馀事;Manor's Bounty;
+;17556;translation_mod;AI翻译器;Kimi Message Translator;ATM
+;17557;auto_smelt,mr_auto_smelt2;自动冶炼;Auto Smelt;AS
+ftb-money-legacy;17558;ftbmoney;FTB交易 延续版;FTB Money Legacy;FTBML
+;17559;;Flying Machine;;
+;17560;;Playable Piano;;
+vanilla-anvil-repair;17561;vanillaanvilrepair;Vanilla Anvil Repair;;
+tiered-depths;17562;tiereddepths;Tiered Depths;;
+tooltip-tweaker;17563;rttweaker;Tooltip Tweaker;;
+editableedibles;17564;editableedibles;EditableEdibles;;
+;17565;liar_bar;骗子酒馆 for Kyou;Liar's Bar for Kyou;LBFK
+;17566;mcdrcommand;MCDR Command Fabric;;
+;17567;betterbuilderswandsfix;BetterBuildersWandsFix;;
+pigzilla;17568;pigzilla;Pigzilla;;
+pale-garden-backport;17569;palegardenbackport;Pale Garden Backport: The Garden Awakens;;
+seasons-greetings;17570;seasonsgreetings;Season's Greetings;;
+ex-nihilo-coloratus;17571;exnihilocoloratus;无中生有：多彩;Ex Nihilo: Coloratus;
+granular-mob-griefing;17572;granularmobgriefing;Granular Mob Griefing;;GMG
+;17573;dashloader-portinglib-compat;Dashloader PortingLib Compat;;
+fermiumbooter2mixinbooter;17574;fermiumbooter;FermiumBooterDepoliticization;;
+immersive-optimization;17575;immersive_optimization;Immersive Optimization;;
+;17576;no_entity_lag;实体卡顿优化;No Entity Lag;NEL
+tab-tweaks;17577;tabtweaks;Tab Tweaks;;
+fermiumasm;17578;normalasm;FermiumASM;;
+all-mobs-out-of-the-pool;17579;outofthepool;All undead out of the pool!;;
+clipboardplus;17580;clipboard;Clipboard;;
+misty-world-unveiled;17581;mist;Misty World Unveiled;;
+balkons-weaponmod-legacy;17582;weaponmod;更多武器：传承;Balkon's WeaponMod: Legacy;
+betterendforge-backport;17583;betterendforge;BetterEndForge Backport;;
+epic-fight-mod-rapier-moveset-addon;17584;refm;Epic Fight - Rapier Moveset Addon;;REFM
+legendary-warriors;17585;epicfightmultiverse;Legendary Warriors: Epic Fight Bosses;;
+scape-and-run-holiday;17586;srpholiday;逃逸：节日;Scape and Run: Holiday;
+crimson-steves-mutant-mobs;17587;crimsonsteves_mutant_mobs;Crimson Steve's Mutant Mobs;;
+kinetic-pixel;17588;pointblank;机素动能;Create Firearms-Kinetic Pixel;
+tactical-imbuements;17589;tactical_imbuements;Tactical Imbuements;;
+puppy-paws;17590;puppypaws;Puppy Paws;;
+ae2-mega-things;17591;ae2_mega_things;AE2 MEGA Things;;
+solar-flux-reboot;17592;SolarFluxReboot;Solar Flux: Reboot;;
+solar-flux-additions;17593;wearsfr;Solar Flux Additions;;
+anvil-cell-workbench;17594;anvil_cell_workbench;Anvil Cell Workbench;;
+;17595;ultimatefurnacemod;Ultimate Furnace;;
+create-sifting-fabric;17596;createsifter;Create Sifting Fabric;;
+create-magics;17597;create_magics;Create: Magics;;
+;17598;crypto;Crypto;;
+;17599;polyfactory;PolyFactory;;
+buildcraft-legacy;17600;buildcraft;Buildcraft-Legacy;;
+;17601;foolish_datapack;笨蛋数据包;;
+wither-storm-delight;17602;witherstorm_delight;风暴乐事;Wither Storm Delight;WSD
+;17603;iron_block_elevator;铁块电梯;Iron block Elevator;IBE
+x1000-botania;17604;loooxbotania;x1000 Botania;;
+angel-ring-classic;17605;doomangelring;天使指环经典版;Angel Ring Classic;
+;17606;mr_physical_fallingtrees;Physical Falling Trees;;
+better-animations-collection-revived-2;17607;BetterAnimationsCollectionRebuilt;Better Animations Collection Revived 2;;
+scape-and-run-parasites-tweaker;17608;srptweaks;Scape and Run Tweaker;;
+scape-and-run-parasites-medical-addon;17609;srp_medical_addon;Scape and Run: Parasites Medical Addon;;
+durability-overhaul;17610;improved_damage;Durability Overhaul;;DO
+quick-hotkeys;17611;quick_hotkeys;Quick Elytra Reborn / Quick Hotkeys;;
+;17612;acd;永远的圣诞节;AlwaysChristmasDay;ACD
+;17613;sl;强运;StrongLuck;
+;17614;mr_whwdzgs_recipe,whwdzgs-recipe;whwdzg的配方;whwdzg's Recipe;
+uncrafted;17615;uncrafted;Uncrafted;;
+mcjtylib-refilmed;17616;mcjtylib_ng;McJtyLib Refilmed;;
+nanny;17617;nanny;NaNny (Fix NaN Health / Absorption);;
+resource-library;17618;resourcelibrary;Resource Library;;
+resource-config-api;17619;resourceconfigapi;Resource Config API;;
+;17620;threatengl;ThreatenGL;;
+hybridfix;17621;hybridfix;混合修复;HybridFix;
+;17622;disableportalchecks;Disable Portal Checks;;
+eat-eat-eat;17623;eat_eat_eat;吃吃吃;Eat Eat Eat;EEE
+;17624;recipestagesjs;配方阶段;Recipe Stages JS;
+create-morerecipes;17625;cmr;Create More Recipes;;CMR
+portable-craft-bench;17626;pcb;Portable Craft Bench;;
+portable-tables;17627;portable_tables;Portable Tables;;
+;17628;;Flux Network Fork NeoForge;;
+resource-backpacks;17629;resource_backpacks;Resource Backpack's;;
+etherology;17630;etherology;Etherology;;
+snackpirates-aeromancy-additions;17631;aero_additions;SnackPirate's Aeromancy Additions;;
+apothic-enchanting;17632;apothic_enchanting;Apothic Enchanting;;
+maidsoul-kitchen;17633;maidsoulkitchen;女仆厨房;Maidsoul Kitchen;
+refinedtools;17634;rftools;ReFinedTools;;
+programmed-circuit-card;17635;pccard;Programmed Circuit Card;;
+ae2-toogleable-view-cell;17636;ae2_toggleable_view_cell;AE2可切换显示元件;AE2 Toggleable ViewCell;
+;17637;cobblemonarmors;Cobblemon Armors;;
+letmorefishlove;17638;letmorefishlove;Let More Fish Love;;
+l_ender-s-delight;17639;lendersdelight;L_Ender 's Cataclysm Delight;;
+ofaw-of-faith-and-war-1237;17640;ofaw;信仰与战争1237;Of Faith and War 1237;OFAW
+lotmoresteves;17641;lotmoresteves;LotMoreSteves;;LMS
+;17642;mr_better_enderdragon;Better Ender Dragon;;
+legendary-armory-zelda-mod;17643;zeldamod;Legendary Armory;;
+hot-update-1-23-by-gt;17644;hot_update;Hot Update 1.23 by GT;;
+management-wanted;17645;management_wanted;FNAF Management Wanted;;
+perception;17646;perception;Perception;;
+fancy-vfx;17647;fancy-vfx;Fancy VFX;;
+;17648;sprucedvanilla;Spruced Vanilla;;
+pretty-rain;17649;particlerain;Pretty Rain;;
+alchemancy;17650;alchemancy;Alchemancy;;
+flavorful;17651;flavorful;Flavorful;;
+heavy-fallings;17652;heavy_fallings;Heavy Fallings;;
+erudite-tweaks;17653;eruditetweaks;Erudite Tweaks;;
+keymap-presets;17654;keymappresets;Keymap Presets;;
+mekanism-no-thanks-nbt;17655;mekanism_ntn;Mekanism No Thanks NBT;;
+;17656;lootbeams;Loot Beams;;
+;17657;tekst;Tekst;;
+ledger-databases;17658;ledger-databases;Ledger Databases;;
+;17659;shut_up_enderman;Enderman Death Silence;;
+infectious-zombie-apocalypse;17660;infectious;Infectious - Zombie Apocalypse;;
+xiaoanfc;17661;xiaoanfc;小安的农业核心;Xiaoan's Farming Core;
+;17662;enchant-golden-apple-reborn;附魔金苹果重生;Enchant Golden Apple Reborn;EGAR
+cursor-mod-reload;17663;customcursormod;自定义光标：重生;Custom Cursor: Reload;CCR
+;17664;academy;AcademyCraft-Reborn;;
+celestial-overhaul;17665;celestial_overhaul;星月改革;Celestial Overhaul;
+simple-faqi;17666;simplefaqi;简单法器;Simple FaQi;
+redes-coins;17667;redes_coins;Rede的硬币;Rede's Coins;RC
+;17668;teleport_commands;传送指令;Teleport Commands;
+;17669;gcl;GenericCodeLibrary;;GCL
+cosmeticarmours;17670;cosmeticarmoursmod;CosmeticArmours;;
+ooo-jar;17671;ashes1ashes;000.jar / ooo.jar;;
+spawner-tweaks;17672;spawner_tweaks;Spawner Tweaks;;
+mob-brawlers;17673;mobbrawlers;Mob Brawlers;;
+;17674;transformhandlers;Transform Handlers;;
+player-totem;17675;playertotem;Player Totem of Undying;;
+;17676;screenshot-uploader;Screenshot Uploader;;
+cute-companions-ducks;17677;cute_companions_ducks;Cute Companions: Ducks;;
+loot-n-explore;17678;loot_n_explore;Loot & Explore;;
+epic-knights-ice-and-fire;17679;epic_knights_ice_and_fire;Epic Knights: Ice and Fire;;
+medieval-origins-revival;17680;medievalorigins;Medieval Origins Revival;;
+construction-sticks;17681;constructionstick;Construction Sticks;;
+sophisticated-storage-in-motion;17682;sophisticated-storage-in-motion,sophisticatedstorageinmotion;精妙存储：矿车物流;Sophisticated Storage in Motion;
+imgur-display;17683;imgurdisplay;Imgur Display;;
+extra-sponges;17684;extrasponges;更多海绵;Extra Sponges;
+more-wolf-armors;17685;more_wolf_armors;更多狼铠;More Wolf Armors;MWA
+not-enough-rocks;17686;ner;Not Enough Rocks;;NER
+pedestal;17687;pedestals;Pedestal;;
+;17688;snowballkb;Snowball and Egg Knockback;;
+forestry-worktable-display;17689;forestryworktabledisplay;Forestry: Worktable Display;;
+accessorify;17690;accessorify;Accessorify;;
+high-quality-crops;17691;highqualitycrops;高品质作物;High Quality Crops;HQC
+immortal-enchantment;17692;immortal_enchantment;不死附魔;Immortal Enchantment;IE
+awesome-storage;17693;awesome_storage;魔法存储;Awesome Storage;ams
+;17694;wp;Wallpaper;;WP
+;17695;kill_entity_strengthen_equip;击杀强化装备;;
+;17696;modifyplayerdata;Modify Player Data;;
+idcv;17697;idcv;ID冲突查看器;ID Conflicts Viewer;IDCV
+eaglemixins;17698;eaglemixins;EagleMixins;;
+kubejs-thermal-augments;17699;kubejsthermalaugments;KubeJS Thermal Augments;;KTA
+;17700;minopp;Mino++;;
+;17701;;粘液乐事基岩版;;
+;17702;;下界乐事基岩版;;
+;17703;randomflower;一些随意的花朵;Some Random Flower;
+;17704;atlantis;亚特兰蒂斯：水寒火暖;Atlantis: Fire Beneath Water;
+camera-anim;17705;camera_anim;相机大师;Camera Anim;
+mekanism-upgrades-reborn;17706;mekanismupgradesreborn;通用机械升级突破：重生;Mekanism Upgrades: Reborn;
+;17707;zunpet;Zun号;ZUNPet;ZPT
+epic-fight-x-irons-spells-animation-fix;17708;efiscompat;Epic Fight x Iron's Spells Animation Fix;;
+epic-fight-x-wings-reborn-animation-fix;17709;efwingscompat;Epic Fight x Wings Reborn Animation Fix;;
+ef-bs;17710;epic_fight_battle_styles;Epic Fight - Battle Arts;;
+alshanexs-familiars;17711;alshanex_familiars;Alshanex's Familiars;;
+feur-skyland;17712;feur_skyland;Feur Skyland;;
+balkons-expansion;17713;balkonsexpansion;Balkon's Expansion;;
+ascendant-mobs;17715;ascendant_mobs;AM - RPG Mob Leveling System;;
+duarm;17716;du_arm;羽化盔甲;DuArm;
+bomd-addon;17717;bomd_addon;BOMD addon;;
+create-the-air-war;17718;create_the_air_wars;Create: The Air War;;
+bew76;17719;bew76;Block Entity Wrench;;
+block-swapper;17720;blockswapper;Block Swapper;;
+;17721;sm;简易地图;SimpleMap;
+;17722;oneconfig;OneConfig;;
+iron-chest-unofficial;17723;;更多箱子非官方版;Iron Chest Unofficial;
+notenoughids-unofficial-1-7-10;17724;;增加ID上限非官方版;NotEnoughIDs Unofficial;
+;17725;shutdown;ShutDown;;
+;17726;ejectorplus;发射器Plus;Ejectorplus;ETP
+tornado-mod-classic;17727;weather_classic;局部气候&风暴经典版;Weather and Tornadoes Classic;
+strange-berries;17728;strangeberries;Strange Berries;;
+jeffs-cursed-walking-structures;17729;jeffs_cursed_walking_structures;Jeff's Cursed Walking Structures;;
+terra-entity;17730;terra_entity;泰拉生物;Terra Entity;TE
+not-interested;17731;not_interested;Not interested!;;
+;17732;new_soviet;New Soviet Era;;NSE
+;17733;tinkersancient;远古匠艺;Tinkers Ancient;TA
+;17734;gt5r;GT5 Reimagined;;GT5R
+ragexs-nuclear-tech;17735;;Ragex的核科技;Ragex's Nuclear Tech;
+civcraft;17736;civcraft;CivCraft;;
+create-springs-loaded;17737;csl;Create: Spring Loaded;;
+mekanism-the-factory-must-grow-compatibility;17738;mekanism_tfmg_compat;Mekanism The Factory Must Grow Compatibility;;
+cfm-refurbished-circuit-breaker;17739;cfm_circuit_breaker;CFM Refurbished: Circuit Breaker;;
+diving-bell-for-tfc;17740;tfcdivingbell;Diving Bell for TFC;;
+;17741;tobc;芝士之书;The Book of Cheese;TBoC
+piglin-safety-reburn;17742;piglinsafety;猪灵 多喝岩浆：重生;Piglin Safety: Reburn;
+papers-please;17743;papers_please;请出示证件;Papers, Please;
+the-twilight-forest-unofficial;17744;twilightforest;暮色森林非官方版;The Twilight Forest Unofficial;
+somnia-awoken-gui-beautify;17745;somnia;梦醒时分 - GUI美化;Somnia Awoken - GUI Beautify;
+redstonecraft;17746;redstonecraft;红石工艺;RedStoneCraft;RSC
+mowzies-mobs-baubles;17747;mmbaubles;Mowzie 的生物饰品;Mowzie's Mobs' Baubles;
+;17748;tcpl;拔刀剑：最后战线附属包;SlashBlade: The End Battle Line Addon;TCPL
+;17749;zhiling;虚无世界武器技能扩展;AoA Weapon Expansion;
+dungeons-and-combat;17750;dungeons_and_combat;Dungeons And Combat[Complete Edition];;
+;17751;blossom-lib;BlossomLib;;
+mod-erate-loading-screen-forge;17752;mls;Mod-erate Loading Screen-Forge;;
+fastquit-forge;17753;fastquit;FastQuit-Forge;;
+ingame-info-reborn;17754;ingameinfo;游戏信息显示复兴版;InGame Info Reborn;IGIR
+;17755;overlay-mod;Overlay HUD Mod;;
+bedisnottoofarawayrefoxed;17756;bintfarf;就要睡觉;Bed Is Not Too Far Away Refoxed;
+goopreforged;17757;goop;GoopReforged;;
+;17758;deathcost;死亡惩罚;Death Cost;
+;17759;catj;Crimes Against the JVM;;CATJ
+better-split-stack;17760;bettersplitstack;Better Split Stack;;
+sdm-engine-core;17761;sdmcore;SDM Engine Core;;
+sdm-gamestages;17762;sdmgamestages;SDM GameStages;;
+;17763;;附魔不冲突/附魔互相兼容;;
+huh-fabric;17765;huh;哼？;Huh?;
+;17766;acme_admin;ACME Admin Tools;;
+custom-nausea;17767;customnausea;Custom Nausea;;
+accesstransformerjs;17768;access_transformer_js;AccessTransformerJS;;ATJS
+;17769;mr_better_mob_drop;更好的生物掉落;Better Mob Drop;
+checklist;17770;checklist;Checklist;;
+;17771;sleep;睡！;Sleep;
+;17772;pr;PacketReSender;;PR
+;17773;kee;艹：早产;KusaEaterEarly;KEE
+;17774;aichat;AI接管聊天;AIchat;AC
+puncher;17775;puncher;Puncher;;
+sensible-stackables;17776;sensible_stackables;Sensible Stackables;;
+rei-addons-ic2classic;17777;ic2rei;IC2Classic: REI Addon;;
+;17778;blossom-tpa;BlossomTpa;;
+;17779;lithium-raycast-fix;Lithium Raycast Fix;;
+;17780;yet-another-minecraft-bingo;Yet Another Bingo;;
+tools-attack;17781;tools_attack;工具也横扫！;Tools Attack;TA
+darkster-epic-guns-tacz-epicfight;17782;mr_darkster_epicgunstaczepicfight;Darkster Epic Guns / TaCZ + EpicFight;;
+epic-tweaks;17783;epictweaks;Epic Tweaks;;
+epic-fight-x-gliders;17784;efxgliders;[FORGE] Epic Fight X Gliders;;
+no-more-axolotl-despawns;17785;mr_no_moreaxolotldespawns;No More Axolotl Despawns!;;
+;17786;creeperspecies;CreeperSpecies;;
+familiar-faces;17787;familiar_faces;Familiar Faces;;
+eyes-in-the-dark;17788;eyesinthedark;SCP-280, Eyes in the Dark;;
+;17789;influenza_virus;流感;Influenza Virus;
+jellyfishing-delight;17790;jellyfishingdelight;抓水母乐事;Jellyfishing Delight;
+immersive-engineering-datapack-mystical-cloche;17791;gotuxd;immersive engineering datapack mystical cloche;;
+carrot-rarity;17792;carrot_rarity;Carrot Rarity;;
+more-husbandry;17793;husbandry;More Husbandry;;
+chest-with-legs;17794;chest_with_legs;Chest With Legs;;
+biodiverse;17795;biodiverse;Biodiverse;;
+railway-wires;17796;wires;Railway Wires / Wires;;
+bullseye;17797;bullseye;靶心;Bullseye;
+;17798;chuansong;传送纸;end pearl;
+;17799;mr_randomisland;Random Island;;
+create-mob-spawners;17800;create_mob_spawners;Create: Mob Spawners;;
+salvation-archives-lobotomy;17801;lobotomy;Salvation Archives: Lobotomy;;
+rlcraft-parasited;17802;srpmultiplier;RLCraft Parasited;;
+dregora-rl;17803;worldpacker,dregorarl;Dregora RL;;
+underneath;17804;underneath,worldpacker;Underneath;;
+;17805;leafmealone;Leaf Me Alone;;
+rocket-mons;17806;rocket_mons;Rocket Mons [Cobblemon] / Just Celesteela;;
+farsighted-mobs;17807;farsightedmobs,farsighted-mobs;Farsighted Mobs;;
+;17808;hev_suit;HEV Suit Voice System;;
+astral-sorcery-anti-anti-fake-player-asaafp;17809;asaafp;Astral Sorcery Anti Anti Fake Player;;ASAAFP
+apotheosis-ascended;17810;apotheosis_ascended;Apotheosis Ascended;;
+;17811;wolves;Better Than Wolves Legacy Unofficial;;
+warium;17812;crusty_chunks;Warium;;
+;17813;aitplus;AiT Plus;;
+fabulous-fletching;17814;fabulousfletching;Fabulous Fletching;;
+universal-wrench;17815;universalwrench;Universal Wrench;;
+;17816;bottle_ship;瓶中船;Bottle Ship;
+smallblueslimes-ladders;17817;sbsladders;SmallBlueSlime's More Ladders;;
+doomsday-decoration;17818;doomsday_decoration;末日装饰;Doomsday Decoration;DD
+overclocked-watches;17819;overclocked_watches;Overclocked Watches;;
+portable-wardrobes-easy-armor-swap;17820;portablewardrobearmorswap;Portable Wardrobes (Easy Armor Swap);;
+;17821;msrpp;MC百科资料搜索 重生 ++;;MSRPP
+;17822;dtaeml;DontThrowStitcherExceptionsStitcher;;
+;17823;cml;自定义模组列表;CustomModList;CML
+;17824;eternalappetite;永恒食欲;Eternal Appetite;
+platform;17826;platform;Platform;;
+wandering-cocoa;17827;wanderingcocoa;流浪的可可豆;Wandering Cocoa;
+;17828;realtotem;真实的图腾;RealTotem;RT
+no-more-potion-particles;17829;nomorepotionparticles;No More Potion Particles;;
+larion-world-generation;17830;larion;Larion World Generation;;LWG
+blueprint-texture-issue-fix;17831;blueprintfix;Blueprint Texture Issue Fix;;
+transparentcapespatch;17832;transparentcapespatch;透明披风修复;TransparentCapesPatch;
+;17833;;北欧12轴大力士;;IORE
+;17834;jscmetro;江双成轨道交通;;JSCMetro
+saltyfish-vehicle;17835;saltyfishairline;SaltyFish Vehicle;;
+;17836;combatdepot;作战仓库;Combat Depot;
+tacz-leawinds-third-person-compat;17837;tacz_leawindtps_compat;TaCZ: Leawind's Third Person Compat;;
+;17838;sinobrush;华夏云墨;SinoBrush;SBR
+;17839;underworld;地下世界;Underworld;
+gtmaid;17840;gtmaid;血汗工厂;GTMaid;GM
+;17841;idwptpmm;IDontWantPeopleToPlayMyMinecraft;;idwptpmm
+;17842;damage-tilt-fix;Damage Tilt Fix;;
+illager-raid-music;17843;illagerraidmusic;Illager Raid Music;;
+;17844;apron;Apron;;
+;17845;coordinatedcompass;Coordinated Compass;;
+;17846;prinegorerouse;尼格洛兹·旧日重铸/尼格洛兹·万神重归;Prinegorerouse;PN
+feur-extension-desert;17847;feur_extension_desert;Feur - Extension Desert;;
+scape-and-run-parasites-quark;17848;srpquark;Scape and Run: Parasites Quark;;
+infested-swarms-and-spiders;17849;infested_swarms_spiders;Infested: Swarms and Spiders;;
+integrated-cataclysm;17850;integrated_cataclysm;Integrated Cataclysm;;
+;17851;oo_ee_a_e_a_f;OO EE A E A Forge;;
+;17852;mdf;MCreator模组检测器-Fabric;MCreatorDetectorFabric;MDF
+;17853;dydanmaku;抖音弹幕获取;DyDanmaku;
+;17854;chatheadsYG;聊天头像;Chat Heads YG;
+;17855;searchworldenhance;SearchWorldEnhance;;
+colonies-maid-citizen;17856;colonies_maidcitizen;殖民地女仆市民;Colonies Maid Citizen;
+relictium;17857;relictium;Relictium;;
+royal-city-gladiolus-sweep;17858;royal_city_gladiolus_sweep;王城剑兰-清理;Royal City Gladiolus Sweep;RCGS
+;17859;eg-inventory-blur;Inventory Blur;;
+personal-cloud-storage;17860;personalcloudstorage;个人云存储;Personal Cloud Storage;PCS
+;17861;floral_herb_blade;花草剑;Floral Herb Blade;FHB
+;17862;omnimobs;Omni-Mobs;;
+;17863;him;Him;;
+steve-anomaly;17864;anomaly;Red's Anomaly / The Anomaly;;
+integrated-simply-swords;17865;integrated_simply_swords;Integrated Simply Swords;;
+obsidian-equipment;17866;obsidianequipment;Obsidian Equipment;;
+;17867;mr_echo_horn;Echo Horn;;
+;17868;mr_echo_spyglass;Echo Spyglass;;
+;17869;mr_echo_trim;Echo Trim;;
+the-deep-void;17870;the_deep_void;The Deep Void;;
+;17871;grinder_enhance;怪物磨床增强;;
+cataclysm-incinerators-try-hard;17872;incineratorstryhard;灾变：武器技参数配置/冒火的剑;Cataclysm: Weapon Skill Config/ Incinerator's Try Hard;
+scp-apollyon-scp-apollyon;17873;scp_apollyon;SCP Apollyon - SCP Mod;;
+trickster;17874;trickster;Trickster;;
+pale-garden;17875;palegarden;Pale Garden and Creaking;;
+shulker-enchantments;17876;shulker_enchantments;Shulker Enchantments;;
+xenotech;17877;xenotech;XenoTech;;
+sewing-kit;17878;sewingkit;Sewing Kit;;
+zephyr;17879;zephyr;Zephyr;;
+create-radars;17880;create_radar;机械动力:雷达;Create: Radars;
+create-more-additions;17881;create_more_additions;Create: Crafts & (More) Additions;;
+;17882;cci;仅客户端创造模式背包;ClientCreativeInventory;CCI
+;17883;Flan;Flan非官方Forge精神续作版;Flan Unofficial Forge Spirit Sequel Edition;FUE
+minecart-turning-reforged;17884;minecart-turning,minecart_turning;Minecart Turning;;
+offlimits;17885;offlimits;Offlimits;;
+apotheosis-threat;17886;apothluckaffix;Apotheosis Threat Multiplier;;
+;17887;stringduperfix;String Duper Fix Remover;;
+;17888;super_resolution;超分辨率;Super Resolution;SR
+special-model-loader;17889;special-model-loader;Special Model Loader;;SML
+vs-ship-handler;17890;shiphandler;VS: Ship Handler;;
+;17891;ap;自动替换;AutoReplace;AP
+;17892;blue_skies_edit;蓝天修复;Blue Skies Edit;
+;17893;dice;Dice Rebuild;;
+lets-do-apple-wood;17894;applewood;[Let's Do] Apple Wood;;
+ascended-quark;17895;ascended_quark;Ascended Quark;;
+enchanted-vertical-slabs;17896;evs;Enchanted Vertical Slabs;;
+;17897;betterladdersmod;Better Ladders;;
+would;17898;would;Would;;
+;17899;mr_lectern_overhaul;Lectern Overhaul;;
+gendustry-community-edition;17900;gendustry;基因工业：社区版;Gendustry: Community Edition;
+ae2fix;17901;ae2fix;AE2修复;AE2Fix;
+;17902;rememoryusagebar;内存使用率条-重制;Re-MemoryUsageBar;RMUB
+;17903;aa;AutoArmor;;AA
+betterenddelight;17904;betterenddelight;更好的末地乐事;BetterEndDelight;BED
+;17905;hiddendelight;隐藏乐事;Hidden Delight;HYD
+;17906;;Spanish Delight Refabricated;;
+crate-delight-croptopia;17907;cratedelightcroptopia;Crate Delight: Croptopia;;
+foodspoiling;17908;foodspoiling;Food Spoiling;;
+natura-legacy;17909;natura;Natura (Legacy 1.12.2);;
+potted-farms;17910;potted_farms,mr_potted_farms;Potted Farms;;
+;17911;mcmoditemsearchrebornagainpro;MC百科资料搜索：再重生Pro;MCMOD Item Search Reborn Again Pro;
+;17912;;我能看什么;What Can I See;
+;17913;timesync;时间同步-重制;Re-TimeSync;RTS
+;17914;linearxpfabric;线性经验-Fabric;Linear Xp Curve Fabric;LXCF
+;17915;;彼岸幻梦;THE_OTHER_SHORE: Dream;OPAL
+riding-partners-reforged;17916;riding_partners;双人骑行：重铸;Riding Partners：Reforged;RPR
+;17917;retargetato-fabric;ReTargetato-Fabric;;
+cat-healing;17918;cathealing;Cat Healing;;
+plumbob;17919;plumbob;Plumbob;;
+;17920;variants-cit;Variants-CIT;;
+;17921;rc;RandomCrash;;RC
+;17922;enchantseries;豆浆更多附魔;More Enchantments by Soybeani;
+;17923;mr_no_collision;NoCollision;;
+;17924;clearview;Clearviews;;
+;17925;medival_weapon_sounds;Immersive Weapon Draw Sounds;;
+epic-fight-invincible;17926;invincible;无坚不摧;Epic Fight - Invincible;
+ore-dict-re-order;17927;oredictreorder;Ore Dict Re-Order;;
+electrostatics;17928;electrostatics;KJ's Electrostatics;;
+;17929;radiocraft;RadioCraft;;
+evil-captcha;17930;captcha;Evil Captcha;;
+;17931;el;EventLib;;EL
+;17932;ca;ConfigAPI;;
+;17933;ms_1144;MC百科资料搜索 - 1.14.4;MCMOD Item Search in 1.14.4;
+;17934;fpsmatch;通用射击游戏比赛框架;FPSMatch;FPSM
+mythic-charms;17935;mythic_charms;神话护符;Mythic Charms;
+;17936;tinkers_waste;工匠的实用小物件;Tinkers' Useful Items;TUI
+;17937;baguette;法棍工艺;Baguette craft;
+;17938;;草神赐福;;
+minecraft-add;17939;minecraft_add;原版补充;Minecraft Add;MA
+stacked-blocks;17940;stackedblocks;Stacked Blocks;;
+stacked-blocks-farmers-delight;17941;stackedblocksfarmersdelight;Stacked Blocks: Farmer's Delight;;
+;17942;fowlplay;Fowl Play;;
+;17943;mr_amethyst_corruption;Amethyst Corruption;;
+ender-totem;17944;endertotem;Ender Totem;;
+;17945;diversity;Diversity;;
+tonsofenchants;17946;tonsofenchants;Tons Of Enchants;;
+;17947;fk.proximitylamp;Proximity Lamp;;
+;17948;bookofexperience;Book of Experience;;
+cave-root;17949;caveroot;KJ's Cave Root;;
+;17950;tooltrims;Tool Trims;;
+whos-there-ghost-players;17951;whos_there;Who's There ?: Ghost Players;;
+the-cuckoo-clock;17952;the_cuckoo_clock;SCP-4975, The Cuckoo Clock;;
+final-samurai;17953;final_samurai;Final Samurai;;
+classic-battle-towers;17954;battletowers;经典战斗高塔;Classic Battle Towers;
+sihywtcamd-extensions;17955;sihywtcamd_extensions;SIHYWTCAMD Extensions;;
+;17956;sanitydim;理智-Doge版;sanitydim;san
+;17957;heart_crystals;Heart Crystals;;
+;17958;partialhearts;PartialHearts;;
+;17959;the_abyss;The Abyss;;
+cosy-critters;17960;cosycritters;Cosy Critters & Creepy Crawlies;;
+omnilib;17961;omnilib;Omnilib;;
+astages;17962;astages;AStages;;
+;17963;mindful-loading-info;Aloria Loading;;
+;17964;parentalcontrols;Parental Controls;;
+jason-bot;17965;jasonbot;Jason机器人;Jason Bot;JB
+;17966;ex_enigmaticlegacy;神秘传说;EXEnigmaticlegacy;EXE
+fly-in-the-sky;17967;fly_in_the_sky;高空飞行;Fly in the sky;
+;17968;smart-elytra;智能鞘翅;SmartElytra;SE
+;17969;momotinker;墨工坊;momotinker;
+electrostaticsre;17970;electrostatics;每日任务;ElectrostaticsRE;
+;17971;staretilltheygrowrereborn;盯到它们熟为止-重生！;Stare Till They Grow Reborn!;
+brooms-unofficial;17972;broomsmod;扫帚：非官方版;Brooms Unofficial;
+fishing-dangers;17973;fishingdangers;Fishing Dangers;;
+distinctpaintings;17974;distinctpaintings;Distinct Paintings;;
+search-on-mcmod;17975;searchonmcmod;MC百科搜索;Search on MCMOD;
+infinite-lava-renewed;17976;infinite-lava;Infinite Lava: Renewed;;
+;17977;better-fabric-console;Better Fabric Console;;BFC
+;17978;minetooltip;Mine Tooltips;;
+fastchest-reforged;17979;fastchest;FastChest Reforged;;
+;17980;bettercaves;古早洞穴优化;Better Caves Archaic;BCA
+;17981;ves;Venti Script;;VES
+alexis-64-food;17982;alexis_food;Alexis 64's Food;;
+cosmetic-armor-revitalized-fabric;17983;cosmetic-armor;Cosmetic Armor: Revitalized;;
+;17984;walksyambience;Ambience V2;;
+umapyoi-addon-pack;17985;umapyoi_addon;马儿蹦跳：拓展包;Umapyoi：Addon Pack;UAP
+the-god-of-roadkill;17986;thegodofroadkill;The God Of Roadkill;;
+;17987;visual-snowy-leaves;[Bedrock Parity] Visual Snowy Leaves;;
+verdant;17988;verdant;Verdant;;
+grounded;17989;verdant;Grounded;;
+gallery;17990;gallery;Gallery;;
+;17991;the_titans1;The Titans Mod CLASSIC;;
+lost-cities-survive-the-dead-edition;17992;lostcities;Lost Cities - Survive the Dead Edition;;
+;17993;gss;给某人某物;Give Sb. Sth.;GSS
+;17994;gim;Give it to me;;GIM
+power-of-the-void;17995;power_of_the_void;虚空之力;Power of the Void;PofV
+aerlune-rpg;17996;world;Aerlune RPG;;
+;17997;mr_epic_fightxspartanweaponry;Epic Fight - Dual Spears;;
+hitboxbackport;17998;playerhitboxbackport;HitboxBackport;;
+fsmm;17999;fsmm;Fex's Small Money Mod;;FSMM
+create-pantographs-and-wires;18000;pantographsandwires;Create: Pantographs & Wires;;
+footwork-api;18001;footwork;Footwork API;;
+;18002;halplibe;HalpLibe;;
+;18003;wmlib;战争机器库;WarMachineLib;WML
+;18004;vcm;音控鼠标;VoiceControlledMouse;VCM
+crash-assistant;18005;crash_assistant;Crash Assistant;;
+;18006;bf;撞火;BumpFire;BF
+;18007;tkf;The Open Sauce Toast Killer Forge;;
+inventorytweak;18008;inventorytweak;InventoryTweak;;
+;18009;miss;MISS;;
+legendary-tabs;18010;legendarytabs;传说选项卡;Legendary Tabs;
+sky-breaker-blue-skies-limit-remover-1-18-2;18011;skybreaker;天穹突破_1.18.2;Sky Breaker_1.18.2;
+;18012;libves;Lib VES;;
+;18013;diyu_kuang;地狱矿;;
+;18014;prismarine;海晶合金;;
+;18015;stellar_radiance;星·辉;StellarRadiance;
+;18016;mxatools;MX的工具A;MXA Tools;
+;18017;cloudertinker;浮云工坊;Clouder Tinker;CTK
+xiyus-lucky-block;18018;luckyblocks;饩雨的幸运方块;Xiyu's Lucky Block;XYLB
+;18019;epicfight_oldsolar;史诗战斗：旧版solar;EpicFight_oldsolar;EF_OS
+reskillable-reimagined;18020;reskillable;Reskillable Reimagined;;
+renaissance-core;18021;renaissance_core;Renaissance Core;;
+;18022;startup-chime;启动音效;Startup Chime;
+carpet-takeneko-addition;18023;carpet-takeneko-addition;竹猫的地毯扩展;Carpet Takeneko Addition;TNCA
+chain-mod;18024;chains_mod;Chain Mod;;
+speedrunmod;18025;sr;SpeedrunMod;;
+insta-boom;18026;;Insta Boom;;
+infinite-night;18027;;Infinite Night;;
+nether-lake;18028;netherlake;Nether Lake;;
+;18029;create_cards;Create: Cards;;
+create-powerlines;18030;createpowerlines;Create: Powerlines;;
+emerald-nugget;18031;emeraldnugget;Emerald Nugget;;
+what-dah-dog-doin-tetra-compat;18032;whatdahdogdointetracompat;What Dah Dog Doin Tetra Compat;;
+endbiome;18033;endbiome;EndBiome;;
+jasons-fly-mod;18034;flymod;Jasons Fly Mod;;
+conium;18035;conium;Conium;;
+yellowtext;18036;yellowtext;YellowText;;
+;18037;bb;信标向下移植;BiggerBeacons;
+healight;18038;healight;Healight;;
+;18039;bodyhealthsystem;Body Health System;;
+savemykeybinds;18040;savemykeybinds;SaveMyKeybinds;;
+nomenublur;18041;nomenublur;NoMenuBlur;;
+;18042;bh;BeaconHalo;;BH
+more-loot-tables;18043;moreloottables;More Loot Tables;;
+noteblocks;18044;notepp;Noteblocks++;;
+;18045;crunchy_crunchy_advancements;Crunchy Crunchy Advancements;;
+chainvein;18046;chainmining;ChainVein;;
+mobs-on-rails;18047;mobsonrails;Mobs On Rails;;
+;18048;viewmodel;View Model;;
+gravestone-x-curios-api-compat;18049;gravestonecurioscompat;Gravestone x Curios API Compat;;
+nolijium;18050;nolijium;Nolijium;;
+eventslib;18051;eventslib;EventsLib;;
+;18052;etstlib;乙硫醇的匠魂词条库;EtST Lib;EtSTl
+orbs-of-crafting;18053;orbs_of_crafting;Orbs of Crafting;;
+;18054;leonmtr;Leon轨道交通Mod;;LMod
+;18055;npcagent;村民智能体;npcagent;NPCA
+;18056;fastcommand;Carpet指令降级;FastCommand Carpet;FCC
+;18057;starkettleac;StarkettleAntiCheat;;SkAc
+;18058;littletail;聊天小尾巴;LittleTail;
+;18059;ac;坠机;AirCrash;AC
+;18060;wip;正击何键;What I'm Pressing;
+;18061;no-enchantment-restrictions;自定义等级限制;No Enchantment Restrictions;NER
+;18062;;更改试炼密室生成维度：末地;;
+stackcraft;18063;stackcraft;Stackcraft;;
+;18064;extremeview;ExtremeView;;
+;18065;materialexcavator;Material Excavator;;
+;18066;startinthenether;StartInTheNether;;
+mekanismmixinhelp;18067;mekmixinhelp;MekanismMixinHelp;;
+simple-warp-commands;18068;simple_warp_commands;简单传送指令;Simple warp commands;
+;18069;mojangfix;MojangFix;;
+tatercart;18070;tatercart;TaterCart;;
+irons-spell-book-mob-attribute-addon;18071;iron_att;Iron's spell book mob attribute addon;;
+epic-fightexsilium-gladius;18072;exsiliumgladius;EpicFight—放逐之刃;Epic Fight — Exsilium Gladius;
+;18073;kamen_rider_weapon_craft;假面骑士武器大全集;KamenRiderWeaponCraft;KRW
+;18074;substitute_totem_for_death;替死图腾;Totem of Substitution;TS
+;18075;advancearmy;先遣部队;AdvanceArmy;
+;18076;blood_blade;Blood Blade;;
+;18077;mineimpact;方神;MineImpact;MI
+jadens-nether-expansion-delight;18078;jadensnetherexpansiondelight;Jaden's Nether Expansion Delight;;
+;18079;shadow_charlie;黑暗中的查理;Shadow Charlie;
+archery-expansion;18080;archeryexp;Archery Expansion;;
+jjsk;18081;jujutsucrafts;JJSK;;
+;18082;MoreEnchants;More Enchants;;
+;18083;so_crazy_try;频增趣事;So Crazy Try;SCTY
+ash-of-sin-overlord;18084;ash_of_sin_overlord;罪业余烬：Overlord;Ash Of Sin: Overlord;
+;18085;carbonstrip;碳条工艺：加强版;Carbon Strip Craft:Augmented Edition;CSCA
+;18086;rotp_zbc;RotP：极恶中队附属;Ripples of the Past: Bad Company Addon;
+true-prime-piece;18087;trueprimepiecetwo;True | Prime Piece;;
+maxims-core;18088;maxims_core;箴言与本源;Maxims&Core;M&C
+arphex;18089;arphex;Arthropod Phobia Expansions + Horror Bosses (Spider Moth);;ArPhEx
+cubic-combat-simulator;18090;ccsm;Cubic Combat Simulator Mod;;CCSM
+;18091;groove-theft-auto-ime;去你大爷的输入法;Groove Theft Auto-IME;GTA
+webmapview;18092;webmapview;网页地图浏览;webmapview;wmapv
+f3-is-my-shawty;18093;f3ismyshawty;F3 Is My Shawty;;
+ollamachat;18094;ollamachat;ollamachat;;olm
+potion-stacker;18095;potionstacker;Potion Stacker;;
+;18096;better_weather;Better Weather;;
+better-gamemode;18097;bettergamemode;better gamemode;;
+better-command;18098;bettercommand;Better command;;
+fishermans-haven;18099;fishermans_haven;Fisherman's Haven;;
+bakeries;18100;bakeries;烘焙坊;Bakeries;
+;18101;finaldragon;终湮龙神;Final Dragon;
+female-plastic-surgery-bust-limit-tweaker;18102;femaleplasticsurgery;Female Plastic Surgery: Bust Limit Tweaker;;
+;18103;si;ShootIt;;SI
+feur-pet-hat-forge;18104;feur_beauty_pet;Feur Pet Hat;;
+feur-dimensional-skyland;18105;feur_dimensional_skyland;Feur Dimensional Skyland;;
+feur-colors;18106;feur_colors;Feur Colors;;
+feur-statue;18107;feur_statue;Feur Statue;;
+feur-builder;18108;feur_builder;Feur Builder;;
+feur-elytra-wings;18109;feur_elytra_wings;Feur Elytra Wings;;
+feur-magic-more-enchantments-xp-bottle-forge;18110;feur_magic;Feur Magic;;
+veggies-delight;18111;veggiesdelight;蔬菜乐事;Veggies Delight;
+;18112;tinkers_delight_extra;匠魂乐事扩展;Tinkers' Delight Extra;TDE
+ramadan-delight;18113;ramadandelight;Ramadan Delight;;
+;18115;iui_nf;ImproperUINeoForge;;
+potion-core-reborn;18116;;药水核心:重生;Potion Core Reborn;
+;18117;nitrogen_internals;Nitrogen;;
+rolling-gate;18118;rolling_gate;卷帘门;Rolling Gate;RG
+bettertab;18119;bettertab;更好的Tab;BetterTab;BT
+;18120;let_me_see_see;让我看看;LetMeSeeSee(YourCode);LMS
+put-mana-in;18121;put_mana_in;手充魔力;Put Mana In;
+ars-botania;18122;ars_botania;Ars Botania;;
+linweiyun-mod;18123;linweiyun;Linweiyun的附魔;;
+baublesex;18124;;BaublesEX;;
+;18125;blockhighlight;自定义方块高亮;Custom Block Highlight;
+tinkers-simple;18126;;Tinkers Simple;;
+threedmusket;18127;;ThreeDMusket;;
+rtmmetro;18128;rtmmetro;真实火车：地铁扩展;RTMMetro;
+bicycles-fws;18129;;Bicycles FWS;;
+;18130;bubblevehicles;Bubble Vehicles;;
+ir-cr-ss8;18131;;中国铁路第一速;[IR/Immersive Railroading]China Railways SS8;CRFF
+lobotomy;18132;lobotomy;Lobotomy;;
+parrot-power;18133;parrotpower;Parrot Power;;
+fortune-ores-2;18134;FortuneOres;FortuneOres;;
+;18135;tekdrone;Tek Drone;;
+darkage-bizarre-addon-remake;18136;;DarkAge Bizarre;;
+feur-dungeon-spawner;18137;feur_dungeon_spawner;Feur - Dungeon Spawner;;
+feur-extension-fossil;18138;feur_extension_fossil;Feur - Extension Fossil;;
+feur-extension-jungle;18139;feur_extension_jungle;Feur - Extension Jungle;;
+cybernetic-system;18140;cybernetic_system;Cybernetic System;;
+;18141;make_the_cover_;绿幕;make the cover;MTC
+;18142;mushroom_daydream;蘑菇幻想;Mushroom Daydream;
+liquid-dirt;18143;liquidDirt;Liquid Dirt;;
+liquid-blocks;18144;liquidblocks;Liquid Blocks;;
+apothic-combat;18145;apothiccombat;Apothic Combat;;
+toms-trading-network;18146;toms_trading_network;Tom's Trading Network;;
+somanyapples;18147;so_many_apples;So Many Apples;;
+static-block;18148;staticblock;Static Block;;
+cherryvillage;18149;cherry_village;Cherry Village;;
+ductwork;18150;ductwork;管道;Ductwork;
+cooldown-coordinator;18151;cooldown-coordinator;Cooldown Coordinator;;
+librarianlib-continuous;18152;librarianlib;LibrarianLib-Continuous;;LLC
+luna;18153;luna;Luna;;
+loot-integrations;18154;lootintegrations;Loot Intergration;;
+realtimescale;18155;realtimescale;RealTimeScale;;
+;18156;world2recyclebin;World2RecycleBin;;
+crafting-recipe-exporter;18157;craftingrecipeexporter;Crafting Recipe Exporter;;
+;18158;legacy_completion;旧版命令补全;Legacy Completion;
+extra-apoth-compat;18159;extra_apoth_compat;Extra Apoth Compat;;
+pathtracker;18160;pathtracker;PathTracker;;
+elytra-protection;18161;elytraprotection;Elytra Protection;;
+skip-sleep;18162;skipsleep;Skip Sleep;;
+stony-cliffs-are-cool;18163;stonycliffs;Stony Cliffs Are Cool;;
+simple-ender-things;18164;SimpleEnderThings;Simple Ender Things;;
+mimecraft-mod;18165;warden_armor;Warden Armor;;
+warden-sword;18166;warden_sword;Warden Sword;;
+arch-bows;18167;archbows;Arch Bows;;
+fancy-trinkets;18168;;精美的小饰品;Fancy Trinkets;
+block-n-zapping;18169;create_bnz;Create: Block n' Zapping;;
+cgs;18170;cgs;Create: Gunsmithing;;
+dynamic-trees-jadens;18171;dtjadens;Dynamic Trees - Jaden's Nether Expansion;;
+dynamic-trees-croptopia-new;18172;dtcroptopia;Dynamic Trees - Croptopia;;
+stacksonstacks;18173;StacksOnStacks;Stacks on Stacks;;
+more-of-all;18174;more_of_all;More Of All;;

--- a/FCL/src/main/assets/modpack_data.txt
+++ b/FCL/src/main/assets/modpack_data.txt
@@ -1,9 +1,9 @@
 #
 # Hello Minecraft! Launcher
-# Copyright (C) 2024  huangyuhui <huanghongxun2008@126.com> and contributors
+# Copyright (C) 2025 huangyuhui <huanghongxun2008@126.com> and contributors
 #
 # mcmod.cn
-# Copyright (C) 2024. All Rights Reserved.
+# Copyright (C) 2025. All Rights Reserved.
 #
 gt-new-horizons;1;;格雷科技：新视野;GT: New Horizons;GTNH
 enigtech-2;2;;玄理2;EnigTech 2;ET2
@@ -39,7 +39,7 @@ modern-skyblock-3-departed;31;;现代空岛3;Modern Skyblock 3: Departed;
 gregblock;32;;格雷空岛;Gregblock;
 sevtech-ages;33;;赛文科技;SevTech: Ages;STA
 ;34;;伊卡洛斯号迫降;Icarus Landing;IL
-greedycraft;35;;贪婪整合包;GreedyCraft;
+greedycraft;35;;贪婪整合包;GreedyCraft;GC
 stoneblock;36;;StoneBlock;;
 ftb-presents-skyfactory-3;37;;天空工厂3;FTB Presents SkyFactory 3;SF3
 space-astronomy;38;;Space Astronomy;;
@@ -142,7 +142,7 @@ awakening-sky-of-diamonds;135;;Awakening - Sky of Diamonds;;
 ragnamod-v;136;;Ragnamod V;;
 all-the-mods-3-expert;137;;All the Mods 3 专家版;All the Mods 3 Expert;ATM3E
 seablock-rustic-waters;138;;乡村水域;Seablock: Rustic Waters;
-engineers-life;139;;Engineer's Life;;
+engineers-life;139;;Engineer's Life;;EL
 star-factory;140;;Star Factory;;
 lunar-laboratory;141;;Lunar Laboratory;;
 glacial-awakening;142;;Glacial Awakening;;
@@ -170,7 +170,7 @@ all-the-mods-6;164;;All the Mods 6;;ATM6
 garden-of-glass-questbook-edition;165;;Garden of Glass (Questbook Edition);;
 ;166;;圣剑传奇;Sword Legendary;
 ;167;;FTB Presents Direwolf20 1.16;;
-team-rustic;168;;Team Rustic;;TR
+team-rustic;168;;Rusty Sink 1.20;;
 enigmatica2expertskyblock;169;;Enigmatica 2: Expert Skyblock;;E2ES
 ;170;;休闲-生存-2021版;Leisure Survival-2021;ls21
 hexxit-updated;171;;Hexxit Updated;;
@@ -217,7 +217,7 @@ airaka-tech;211;;艾瑞卡科技;Airaka Tech;
 originssmp;213;;起源SMP;OriginsSMP;
 create-live-2;214;;Create Live 2;;
 origin-smp-copy;215;;Origin - SMP;;
-;216;;逆迫降;INUERSE FORCED LANDING;
+;216;;逆迫降;INVERSE FORCED LANDING;
 avatar-the-four-elements;217;;Avatar: The Four Elements;;
 seaopolis;218;;Seaopolis;;
 zombie-apocalypse-remastered;219;;僵尸启示录：重制;Zombie Apocalypse Remastered;ZAR
@@ -253,9 +253,9 @@ evolution-reset;250;;进化：重启;Evolution: Reset;ER
 the-nuclear-wasteland;251;;核荒原;The Nuclear Wasteland;
 blessed-or-cursed-expedition-to-infinite-force;252;;祝福或诅咒：无限力量之征;Blessed or Cursed: Expedition to Infinite Force;BOC
 ;253;;边界生存;Border Survival;BSV
-medieval-mc-fabric;255;;Medieval Minecraft;;
+medieval-mc-fabric;255;;Medieval Minecraft;;MMC
 heavens-of-sorcery;256;;巫术天堂;Heavens of Sorcery;
-herodotus;257;;希罗多德;Herodotus;HDS
+herodotus;257;;希罗多德;Herodotus-Authentic Edition:Official;HDS
 ;258;;重生世界;Rebirth world;RW
 permafrost-eots;259;;永久冻土：风暴之眼;Permafrost - Eyes of the Storm;
 ultimate-alchemy;260;;终极炼金;Ultimate Alchemy;
@@ -269,7 +269,7 @@ the-kingdom-of-daldar-forge-labs;267;;The Kingdom of Daldar - Forge Labs;;
 demon-slayers-unleashed;268;;Demon Slayers Unleashed;;
 valhelsia-enhanced-vanilla;269;;Valhelsia: Enhanced Vanilla;;
 ;270;;FTB University 1.16;;
-thaumic-renaissance-kedition;271;;神秘复兴;Thaumic Renaissance Kedition;
+thaumic-renaissance-kedition;271;;神秘复兴;Thaumic Renaissance / Thaumic Renaissance - Kedition;
 the-winter-rescue;273;;冬季救援;The Winter Rescue;TWR
 ;274;;飞翔之路;Flying Road;
 forever-stranded-lost-souls;275;;Forever Stranded Lost Souls;;
@@ -281,11 +281,11 @@ manufactio;281;;Manufactio;;
 world-of-dragons-ii;282;;World of Dragons II;;
 tensura-unleashed;283;;Tensura Unleashed;;
 skyopolis-4;284;;Skyopolis 4;;
-;286;;FTB OceanBlock;;
+ftb-oceanblock;286;;FTB OceanBlock;;
 tolkiencraft-iii-return-to-middle-earth;287;;TolkienCraft III - Return to Middle-earth;;
 delivery-inc;288;;Delivery Inc.;;
 poetica;289;;Poetica;;
-divine-journey-2;290;;Divine Journey 2;;DJ2
+divine-journey-2;290;;神圣之旅2;Divine Journey 2;DJ2
 all-the-mods-7;291;;All the Mods 7;;ATM7
 skyfactory-one;292;;SkyFactory One;;
 feed-the-singularity;293;;喂养奇点生存;Feed the Singularity;
@@ -374,12 +374,11 @@ jurassic-world-reborn;376;;Jurassic World Reborn;;
 ;377;;FTB Omnia;;
 fantazy-tech-expert-mode;378;;幻想科技;Fantazy Tech;
 crainer-craft-2;379;;Crainer Craft 2;;
-;380;;All The Forge 8;;
+all-the-forge-8;380;;All The Forge 8;;
 colony-space-modpack;381;;KN: Colony New Worlds;;
 skyopolis-3;382;;Skyopolis 3;;
-aboe-3;383;;A Bit of Everything 3;;
+aboe-3;383;;A Bit of Everything 3;;ABOE3
 sky-alchemist;384;;天空炼金术士;Sky Alchemist;
-epicadventure;385;;奥德赛;OdysseyCraft;OC
 ;386;;字字落实;;
 nuclear-earth-reirradiated;387;;核地球：再辐照;Nuclear Earth: Reirradiated;
 god-block;388;;God Block;;
@@ -392,7 +391,7 @@ gregtech-community-pack;393;;GregTech Community Pack;;GCP
 create-yourself;395;;Create Yourself;;
 starrynight-pray-stp;397;;星夜祈临;StarryNight Pray;StP
 rustic-waters-ii;398;;乡村水域2;Rustic Waters II;
-enigmatica6expert;399;;Enigmatica 6 Expert;;E6E
+enigmatica6expert;399;;Enigmatica 6: Expert;;E6E
 celestial-journey;400;;Celestial Journey;;
 ;401;;天空舞台;Skyblock Create Show;
 project-architect;402;;Project Architect;;
@@ -406,10 +405,10 @@ kimetsu-no-yaiba-demon-slayer-mod-pack;409;;鬼灭之刃;Kimetsu no Yaiba;
 ;410;;七曜之际;FOR A WEEK;
 not-too-complicated;411;;Not Too Complicated;;NTC
 fiefdom;412;;列土封疆;Fiefdom;
-reinforce-reality;413;;死亡工艺&重生;Deathcraft & Rebirth;
+reinforce-reality;413;;死亡工艺&重生;Deathcraft & Rebirth / Reinforce Reality;
 afterlife;414;;The Afterlife;;
 create-skyblock;415;;CREATE Skyblock;;
-lightcraftproject;416;;Light Craft;;
+lightcraftprojectlite;416;;Light Craft;;
 epoch-runner-formerly-nuclear-beyond-modpack;417;;时代领跑人;Epoch Runner;
 ;418;;星海征途;The Journey of Star Sea;TJoSS
 roguelike-adventures-and-dungeons-2;419;;冒险与地牢2;Roguelike Adventures and Dungeons 2;RAD2
@@ -422,7 +421,7 @@ magnificia;423;;Magnificia;;
 chroma-sky-2;426;;色度空岛2;Chroma Sky 2;
 infinity-fabric;427;;无限;Infinity;IF
 enigmatica-2-expert-extended;428;;Enigmatica 2: Expert - Extended;;E2E-E
-;429;;水星迫降重制版;Mercury landing;
+mercury-landing;429;;水星迫降重制版;Mercury landing;
 magic-sky;430;;Magic Sky;;
 ;431;;科技飞升;Rise of Tech;RoT
 not-too-complicated-2;432;;Not Too Complicated 2;;
@@ -448,7 +447,7 @@ lcw;453;;失落文明：野原;Lost_Civilization:Wilds;LCW
 promo-cinematic;454;;Minecraft trailer recreation | Promo-Cinematic Modpack;;
 the-last-one;455;;最后一人;The Last One;TLO
 ;456;;帕斯特之梦;PasterDream;PD
-;457;;失落的米德加尔特;Lost Midgard;LM
+lost-midgard;457;;失落的米德加尔特;Lost Midgard;LM
 ;458;;真实空岛;Real Island;RI
 abyss-hunter;459;;深渊猎人;Abyss Hunter;AH
 blackstone-block;460;;Blackstone Block;;
@@ -458,14 +457,14 @@ mcdoom-modpack;463;;MCDoom Modpack;;
 poko;464;;Poko;;
 ;465;;永无止境：重缝;Cabricality;CABF
 aperomods;466;;Aperomods;;APM
-;467;;XPlus 2.0 基础整合;XPlus Modpack;X+
+;467;;XPlus 2.0 基础整合;XPlus 2.0 Modpack;X+
 crazy-crave-5;468;;Crazy Crave 5;;
 sky-research;469;;Sky Research;;
 ;470;;魔力做功;Work Done by Mana;WDM
 ;471;;Beyond Reality;;
 slcp4;472;;微笑草坪4;SmileLawn 4;SLCP4
 crazy-craft-updated;473;;Crazy Craft Updated;;
-planetary;474;;Planetary;;
+planetary;474;;行星;Planetary;
 slcp5;475;;微笑草坪5;SmileLawn 5;SLCP5
 ;476;;寂静传说;tales of silent;TOS
 Wightcraft;477;;Wightcraft;;
@@ -481,7 +480,7 @@ jetpack-cat;482;;喷气背包猫;Jetpack Cat;
 mineshafts-monsters-lite;487;;Mineshafts & Monsters - LITE;;
 ;488;;AELife;;AEL
 mineshafts-monsters-adventure;489;;Mineshafts & Monsters - Adventure;;
-dimensionhopper;490;;DimensionHopper;;
+dimensionhopper;490;;Dimension Hopper：The Fall;;
 technology-empty-island;491;;科技空岛;RxanGrben;
 greed-the-resource-4-infinity;492;;Greed the Resource 4 - Infinity;;
 caveopolis;493;;Caveopolis;;
@@ -500,8 +499,8 @@ other-body;504;;Other Body;;
 ;506;;莱姆星云;Lime Nebula;LN
 void-genesis;507;;Void Genesis;;
 create-flavored;508;;Create Flavored;;
-terrafirmagreg;509;;TerraFirmaGreg;;TFG
-create-astral;510;;Create: Astral;;
+terrafirmagreg-vintage;509;;TerraFirmaGreg;;TFG
+create-astral;510;;机械动力：星辰;Create: Astral;
 ;511;;起源创造;CreateOrigin;CO
 random-item-skyblock-recondite-i;512;;Random Item Island - Recondite I;;
 infinity-foundation;513;;Infinity Foundation;;
@@ -517,7 +516,7 @@ tankoptimization;521;;坦坦优化;Tankoptimization;
 pick-the-stars;523;;摘星;Pick The Stars;PTS
 earth-technology;524;;Earth Technology;;
 ;525;;核乐不为;;ZMC
-;526;;FTB StoneBlock 3;;
+ftb-stoneblock-3;526;;FTB StoneBlock 3;;
 create-mod-plus;527;;Create +;;
 multiplayer-optimization;528;;RawDiamondMC的优化包;RawDiamondMC's optimization pack;MPO
 chroma-endless;529;;Chroma Endless;;
@@ -532,12 +531,12 @@ fos-community-edition;534;;奇点工厂1：社区版;Factory of Singularity:Comm
 ;538;;跃迁计划;CT TransitionPlan;CTTP
 astropolis;539;;Astropolis;;
 ;540;;筑梦者;Builder Dream;
-;541;;尘埃传说;dusttale;
+;541;;尘埃传说;;
 magiculture-2;542;;Magiculture 2;;
 ;543;;交错维度2;Among Dimensions 2;AD
 hexteria-skies;544;;Hexteria Skies;;
 ;545;;Omniworld;;
-a-l;546;;冒险生活;Adventure Life;
+al-legacy;546;;冒险生活-L;Adventure Life - Legacy;ALL
 skymachina;547;;SkyMachina;;
 all-of-fabric-6;548;;All of Fabric 6;;AOF6
 ;549;;机械动力：锄与锤;;CHH
@@ -546,11 +545,11 @@ technologicaljourney;552;;Technological Journey;;TJ
 ;553;;末世工匠;End-Time Craftsmen;EdTC
 ;554;;光芒消逝之日;;VL
 gregic-skies;555;;Gregic Skies;;
-;556;;勇者之章;Chapter of Yuusha;
+;556;;勇者之章;Chapter of Yuusha;CY
 ;557;;齿轮颂歌：暮光;Gear Carol;
 pluma;558;;Pluma, a Journey to the Future!;;Pluma
 all-the-mods-7-to-the-sky;559;;All the Mods 7 - To the Sky;;ATM7S
-;560;;月见苍穹传说:大地演化;TskimiCanopyCraft:Terra Evolution;TSCC:TE
+;560;;月见苍穹传说：大地演化;TskimiCanopyCraft: Terra Evolution;TSCC:TE
 ;561;;最后的战役：劫后余生;The Last Stand:Aftermath;LSA/TLS
 ;562;;小猪配平;Peppa Pig's Burning Broom;2P2B
 zerblands-remastered;563;;Zerblands-Remastered;;
@@ -565,7 +564,7 @@ provefrom;569;;忘却之刻;Provefrom;PvF
 darkrpg-forge;572;;DarkRPG Forge;;
 expert-of-magic-art-world;573;;魔艺世界;Expert of Magic Art World;EOMAW
 ;574;;龙境;Dragoncraft;DGC
-nuclear-radiation-2;576;;核污染二;;NR2
+nuclear-radiation-2;576;;核污染二;nuclear radiation 2;NR2
 ;577;;白狐铃的奇思妙想;Arctic Fox Ling Fantasy;AFLF
 ;578;;MineSpace;;MS
 ;579;;史诗战斗：兵团战争;EPIC Fight Corps War;EFC
@@ -579,22 +578,22 @@ multiblock-madness-2;583;;MultiBlock Madness 2;;MBM2
 e2eu;587;;Enigmatica 2 Expert Unofficial;;E2Eu
 e2eus;588;;Enigmatica 2 Expert Unofficial Skybound;;E2EuS
 ;589;;龙之冒险;;
-;590;;格雷：量子跃迁;GregTech:QuantumTransition;GTQT
+gregtech-quantum-transition;590;;格雷：量子跃迁;GregTech:QuantumTransition;GTQT
 the-winter-frontier;591;;冬境边域;The Winter Frontier;TWF
 ;592;;林深不知处;NO, is killed by... Twlight Forest?;NON
 ;593;;太阳机械厂;Create Sun;CS
-dawn-craft;594;;破晓之界;DawnCraft;
+dawn-craft;594;;破晓之界;DawnCraft: Echoes of Legends;DC
 aof-presents-skylore;595;;AOF: Skylore;;
-;596;;可乐兔的格雷整合包;GtMagic;
-;597;;FTB Skies;;
+keletus-gregpack;596;;可乐兔的格雷整合包;Keletu's GregPack;
+ftb-skies;597;;FTB Skies;;
 tnp-limitless-5;598;;TNP Limitless 5;;
 create-back-on-track;599;;Create: Back on Track;;
 ;600;;重构：炼金术;Refactoring: Alchemy;RA
 ;601;;地心;Geocentric;GOC
-;602;;巫师·古老恶意;;
+;602;;巫师·古老恶意;Wizard against wicked;WaW
 ;603;;进化太阳生存;Evolutionary Sun Survival;ESS
 changfeng;604;;长峰漫路;Long peak Long road;LPR
-techopolis-2;605;;Techopolis 2;;
+techopolis-2;605;;科技城2;Techopolis 2;
 ;606;;Arcomua 原版整合;Arcomua Modpack;ARC
 ;607;;UnityCraft;;UC
 ;608;;灵犀;;
@@ -606,7 +605,7 @@ create-beyond-earth;612;;Create: Beyond Earth;;
 ;614;;Additive;;
 ;615;;无人荒漠-新世界;;
 new-game-modpack-release;616;;New Game - An Improved Vanilla Experience;;
-prodigium-reforged;617;;Prodigium Reforged;;
+prodigium-reforged;617;;Prodigium Reforged (Terraria Pack);;
 ;618;;FTB Presents Integration by Parts DX;;
 striving-standoff;619;;抗争之际;Striving Standoff;SS
 gun-fire-survival;620;;枪火生存;Gun fire survival;
@@ -628,10 +627,10 @@ cobblemon-forge;635;;Cobblemon Official Modpack;;
 sbeevs-industrial-revolution;636;;Sbeev's Industrial Revolution;;
 ;637;;Gensokyo Reimagined QOL;;
 statech-industry;638;;StaTech Industry;;
-vault-hunters-1-18-2;639;;Vault Hunters 3rd Edition;;
+vault-hunters-1-18-2;639;;宝藏猎人3;Vault Hunters 3rd Edition;
 survival-hard-rock;640;;生存硬摇滚;Survival Hard Rock;
 aged;641;;Aged;;
-;642;;The Lost Era;;
+the-lost-era-modpack;642;;The Lost Era;;
 vault-hunters-official-modpack;643;;Vault Hunters 2nd Edition;;
 ;644;;Sodium Plus;;
 ;645;;霜叶表达法;Wither Expression;WE
@@ -640,7 +639,7 @@ create-live_4;646;;Create Live 4;;
 valhelsia-5;648;;Valhelsia 5;;
 caves-cliffs-plus;649;;洞穴与山崖：增强版;Caves & Cliffs: Plus;CC+
 enigmatica9expert;650;;Enigmatica 9: Expert;;E9E
-;651;;虚无之主;The Lord of Ascension;TLoA
+the-lord-of-ascension;651;;虚无之主;The Lord of Ascension;TLoA
 ;652;;寄生科技;;PTY
 rise-of-tech-2;653;;科技飞升2;Rise of Tech 2;RoT2
 ;654;;虚空居者;Void Dweller;
@@ -653,7 +652,7 @@ valhelsia-6;660;;Valhelsia 6;;
 all-the-mods-volcanoblock;661;;All the Mods: Volcano Block;;ATMVB
 gregtronix-revoluton;662;;Gregtronix Revolution;;GR
 ;663;;空岛物语;Empty Island RPG;EIRPG
-prominence-fabric;664;;Prominence I [FABRIC];;
+prominence-fabric;664;;卓越1 [FABRIC];Prominence I;
 multiskyblock-2;665;;模块化空岛2;MultiSkyBlock 2;MSB2
 ;666;;The Minehattan Project;;
 ;667;;万象天工;Millions of Heavens industries;MOHI
@@ -677,7 +676,7 @@ musketeer;683;;Musketeer - One for All;;
 ;685;;我的骑士：怪物大乱斗;;
 ;686;;塔可努的原生优化整合包;TechNoob's Vanilla Boost Pack;TNVBP
 ;687;;灵茗屿空岛;LMY SKY;
-;688;;绿色版红石生电优化;;
+;688;;红石生电优化;Redstone Survival Optimization;RSO
 ;689;;恐惧深渊;Abyss of Fear;AoF
 ;690;;德雷戈拉旅人日记;Diary of Dregora's Traveller;DoDT
 nwtcraft;691;;近西之旅;NwtCraft;Nwtc
@@ -685,26 +684,26 @@ nwtcraft;691;;近西之旅;NwtCraft;Nwtc
 aeropolis;693;;Aeropolis;;
 project-sacrifice;694;;Project Sacrifice;;
 chosens-modded-adventure;695;;Chosen's Modded Adventure;;
-ciscos-fantasy-medieval-adventure-rpg;696;;Cisco's Fantasy Medieval Adventure RPG;;
+ciscos-fantasy-medieval-adventure-rpg;696;;Cisco's Fantasy Medieval RPG [Lite];;
 ;697;;命运之轮;Wheel of Fate;
 all-the-mods-gravitas2;698;;All The Mods - Gravitas²;;ATMG2
 enigmatica9;699;;Enigmatica 9;;E9
 ;700;;死亡突围;Deadout;DT
 create-arcane-engineering;701;;机械动力：奥术工程;Create: Arcane Engineering;CAE
 chroma-endless-2;702;;Chroma Endless 2;;
-techrevolution;703;;TechRevolution;;TECHR
+techrevolution;703;;TechRevolution;;
 cabin;704;;CABIN: Create Above & Beyond In Newer;;CABIN
-aoc;705;;All of Create;;Aofc
+aoc;705;;All of Create;;
 ;706;;交错维度3;Among Dimensions 3;AD
 gregfactory-sky;707;;GregFactory Sky;;GFS
 ;708;;飞翔之路4;Flying Road 4;
 ;709;;星月传说;Celestial Legend;CL
 ctc-create-the-creation;710;;Create：the Creation;;CTC
 create-perfect-world;711;;Create: Perfect World;;
-new-simple-mods;712;;New Simple Mods;;
-;713;;灾变录;Apocalypse of Catastrophe;ACC
+new-simple-mods;712;;New Simple Mods - Easy to Understand;;
+;713;;灾变录;Catastrophe Record;CR
 sky-greg;714;;Sky Greg;;
-deceasedcraft;715;;DeceasedCraft;;
+deceasedcraft;715;;亡者世界;Deceased Craft;
 ;716;;生欲:求生;Vivere The Zombie Apocalypse;VZA
 create-planetary;717;;Create Planetary;;
 master-mabaoguo;718;;Master mabaoguo;;
@@ -717,41 +716,322 @@ the-backrooms-survival;724;;The Backrooms Survival;;
 ;725;;13年前的梦;Dreams 13 years ago;
 cookiecrafter;726;;CookieCrafter;;
 ;727;;理想国：科克肖特;Utopia:Cockshott;UCST
-bigchadguys-plus;728;;BigChadGuys Plus;;BCG+
+bcg;728;;BigChadGuys Plus;;BCG+
 ;729;;异世界探险;ISEKAIBOUKEN;YSB
 create-explore-c-e;730;;Create & Explore;;C&E
 twistercraft;731;;TwisterCraft;;
 all-the-horror;732;;恐怖生存;All The Horror;
 the-backrooms-liminal-spaces;733;;The Backrooms;;
 ;734;;伊甸空天;Eden Aerospace;EAS
-;735;;亚特兰深渊;AtlanAbyss;
+atlanabyss;735;;亚特兰深渊;AtlanAbyss;
 ;736;;龙境II;Dragon Odyssey;DO
 ;737;;龙之冒险：新征程;;
 all-the-mods-9-no-frills;738;;All the Mods 9 - No Frills;;ATM9NF
 toms-cobblemon;739;;Tom's Cobblemon;;
 life-in-the-village-3;740;;Life in the village 3;;LitV3
-;741;;联缘;NEXUS;
+;741;;联缘：NEXUS;;
 ;742;;Create: Cinematic;;
 ;743;;神秘纪元;Thaumic Epoch;ThE
 ;745;;FTB Genesis;;
 cook-in-skyblock;746;;天空厨房;Cook in skyland;CiS
-;747;;被支配的恐惧;Dominated by fear;DF
-;748;;新的原版！;New Vanilla;NVA
+;747;;被恐惧支配 1;Dominated by Fear 1;DoF
+new-vanilla-modpack;748;;新的原版;New Vanilla;NVA
 ;749;;群峦救援非官方版;Terrafirma Rescue Unofficial;TFRU
 stoneopolis;750;;Stoneopolis;;
-;751;;FTB Skies Expert;;
+ftb-skies-expert;751;;FTB Skies Expert;;
 wmshd-pack-what-mojang-should-have-done;752;;What Mojang Should Have Done;;WMSHD
 ;753;;无限:重生;Infinity-Reborn;IF2
 ;754;;随心之旅;spontaneous journey;
 oxmodpack;755;;OxMODPACK 8 +Online;;
 gregtech-community-pack-modern;756;;GregTech Community Pack Modern;;GCPM
-;757;;锻造大师2;Master Blacksmith2;MB2
+;757;;锻造大师3;Master Blacksmith3;MB3
 ;758;;科技用于探索世界;Technology Exploration World;
-;759;;幻梦闲笔;Aetherial Voyage;AV
+;759;;幻梦闲笔;Aetherial Voyage;
 fear-the-mist;760;;雾中的恐惧;Fear The Mist;
 tekkit-resurrection;761;;Tekkit The Resurrection;;
 ;762;;Cup Pineapple UBLU;;CPU
-;763;;FTB Arcanum Institute;;
+ftb-arcanum-institute;763;;FTB Arcanum Institute;;
 create-haven-adventures;764;;Create: Haven Adventures;;
 modecube;765;;ModéCube;;
 electrictechnocraft;766;;ElectricTechnoCraft;;
+create-2-mekanism;767;;Create 2 Mekanism;;C2M
+randblock;768;;随机空岛;RandBlock;RD
+;769;;格雷科技休闲版;GregTech Leisure;GTL
+frozenopolis;770;;Frozenopolis;;
+infernal-rpg;771;;Infernal Origins;;
+;772;;天狼星;Sirius;
+;773;;悠沙海;Ethereal Sand Sea;ESS
+;774;;AIR for JAVA;;AFJ
+;775;;Create Extra;;
+frs-optimisation-for-survival;776;;Fr的生存优化;Fr's Optimisation for Survival;FROS
+;777;;Exile Magic Constructor;;EMC
+;778;;Landscapes Reimagined Genesis;;
+al-nl;779;;冒险生活 - 新生活;Adventure Life - New Life;AL-NL
+harvista;780;;拾穗;Harvista;
+;781;;时间之书 : 星之旅行;BookofTime StarTravel;BKSL
+create-applied-energevation;783;;机械动力：应用能源时代;Create: Applied Energevation;CAEV
+;784;;新星工程：世界;Nova Engineering - World;NEW
+create-chronicles-bosses-and-beyond;785;;Create Chronicles: Bosses and Beyond;;
+;786;;Adrenaline;;
+forget-me-not;787;;勿忘我;Forget Me Not;FMN
+modpack-essentials;788;;整合优选;Modpack Essentials;ME
+desertopolis;789;;Desertopolis;;
+omniopolis;790;;Omniopolis;;
+;791;;战斗的法则;The Law of Battle;
+factory-of-singularity-ii-colorfulness;792;;奇点工厂II：绚彩;Factory of Singularity II: Colorfulness;FoS2
+prey-beta;793;;Prey;;
+;794;;魔法之旅;Magic journey;MJ
+;795;;轻松冒险;Easy adventure;EAT
+;796;;魔幻大陆2;Enchanted Lands 2;
+;797;;艾利克斯的世界;Alexcraft;AC
+terrafirmacraft-wiph-walden-lagu;798;;瓦尔登湖畔;Wiph Walden Lagu;WWL
+aocfabric;799;;All of Create Fabric;;
+craftingcraft;800;;合成工艺;CraftingCraft;
+;801;;感染者手册;Handbook for Infected People;HIP
+;802;;居无定所—中世旷野;;
+;803;;宾果难题;Bingo Madness;
+chemillas-reborn;804;;化学：重生;Chemilla's Reborn;CR
+;805;;群峦传说·异世界行纪;Terra Firma Craft:Travel in Another World;TFC:TAW
+milkyway;806;;Create: Milkyway;;
+farming-crossing-4;807;;Farming Crossing 4;;
+hardrock-terrafirmacraft-4-realistic-extreme;808;;HardRock TerraFirmaCraft;;TFCH/HTFC
+terrafirma-rebirth;809;;群峦：重生;TerraFirma: Rebirth;TFCR
+create-live-5-skyblock;810;;Create Live 5;;
+;811;;万象征程;Cosmos of Endless Allegory;CEA
+;812;;远古之遗;;
+;813;;奈の奇妙冒险;Kotona's Mystery Adventure;KSMA
+;814;;战争魔匠;war craftman;WC
+;815;;命定IV;unique destiny IV;
+;816;;Wither Storm Enhanced;;
+;817;;朝花夕拾;Dawn Blossoms Plucked at Dusk;
+la;818;;胶兽大冒险;Latex Advanture;LA
+mystics-monstrosity;819;;Mystic's Monstrosity;;
+;820;;更完美的MC;More Perfect Minecraft;MPMC
+;821;;动画世界：烂柯人;AnimateCraft: Lankeren;
+;822;;New Create;;NC
+land-of-memories;823;;回忆之地;;LOM
+;824;;异世界冒险2;;
+ragnamod-vii;825;;Ragnamod VII;;
+path-of-truth;826;;真理之路;Path of Truth;PoT
+;827;;TFC生活质量更新;;
+all-the-mods-9-to-the-sky;828;;All The Mod 9 - To The Sky;;ATM9S
+;829;;魔金：探秘;ManaMetalMod Exploration;M3E
+fallenpetals;830;;落英;FallenPetals;FP
+dungeon-heroes;831;;Dungeon Heroes (RPG Series);;
+play-as-dragon-gothic-edition;832;;Play as Dragon: Gothic Edition;;
+skyblock-burgeria;833;;空岛汉堡店;;
+crafting-craft-2;834;;合成工艺2;Crafting Craft 2;
+;835;;僵尸入侵100天;Zombie Invade 100 Days;ZI100D
+compact-world-expert;836;;Compact World Expert;;CWE
+a-fragment-of-peace;837;;宁然一隅;A Fragment of Peace;AFoP
+easy-create-modpack;838;;Easy Create;;
+;839;;流线鱼概念;Fish Spi Rally;FSRMP
+meatballcraft;840;;肉丸工艺，次元提升;MeatballCraft, Dimensional Ascension;
+seaopolis-submerged;841;;海之城: 潜没水中;Seaopolis: Submerged;
+;842;;空中厕所;PoopSky;
+compact-sky;843;;收缩空岛;Compact Sky;
+back-to-back;844;;背靠背;Back to Back;BTB
+adventure-exploration-part2;845;;冒险与探索;Adventure & Exploration;AnE
+;846;;复兴;Renaissance;
+live-like-a-castaway;847;;木筏求生2;Raftcraft2;RC2
+mermaid-legend;848;;人鱼传说;Mermaid legend;
+;849;;文明时代;;Aoc
+create-lost-and-renaissance;850;;机械动力：失落与复兴;Create Lost and Renaissance;CLR
+all-the-mods-10;851;;All the Mods 10;;ATM10
+;852;;格雷伊甸：建造;GregEden:Building;GEB
+;853;;迷失时代;LOST ERA;LE
+create-alchemy-plan;854;;机械动力：炼金计划;Create：Alchemy Plan;CAP
+deus-ex-machina;855;;Deus Ex Machina;;
+create-prepare-to-dye;856;;Create Prepare to Dye;;
+;857;;All The Fabric 5;;
+create-leisurely-delight;858;;机械动力：悠然乐事;Create Delight;CD
+;859;;蔚蓝悠悠;Azure Leisurely;AL
+infinityevolved-reloaded;860;;Infinity Evolved: Reloaded;;
+;861;;空中厕所：生产线;Poopsky：Assembly Line;PAL
+;862;;佛罗伦萨迷思;Fantasy in Florence;FIF
+craftoria;863;;Craftoria;;
+mechanic-craft;864;;MechanicCraft;;
+;865;;无用之人-群星;Good For Nothing:Stellaris;GFN
+;866;;打金无限;;
+ciscos-adventure-rpg-ultimate;867;;Cisco's Fantasy Medieval RPG [Ultimate];;
+jour-avancee-daylight;868;;Jour avancée/DayLight;;DL
+;869;;勇者之章 Ⅱ;Chapter of Yuusha II;CY2
+;870;;Beta 1.7.4;;B1.7.4
+;871;;神不在的星期天;God Without Create;GWC
+createa-colony;872;;Create'a Colony;;
+;873;;黑暗深处;Deep Dark;
+;874;;自在极境;Free Extreme Realm;
+all-of-fabric-7;875;;All of Fabric 7;;AOF7
+ftb-neotech;876;;FTB NeoTech;;
+;877;;Minecraft+;Minecraft plus;MCP
+;878;;龙珠Super;Dragon Ball Super;
+create-vanilla-exploration;879;;Vanilla Create Exploration;;
+progress;880;;Progress: Create;;
+aeon-automata;881;;Aeon Automata;;AA
+;882;;被恐惧支配2：收容失效;Dominated by Fear 2 Containment Breach;DoF2
+;883;;剑拔弩张之时;;TC
+project-architect-2;884;;Project Architect 2;;
+;885;;路网通途 / 更好的我的世界铁路;Railway Network Access;RNA
+create-mekanized;886;;Create: Mekanized;;
+create-perfect-world-2;887;;Create: Perfect World 2;;
+create-stellar;888;;Create Stellar;;
+monifactory;889;;Monifactory;;
+create-factory-builder;890;;Create: Factory Builder;;
+;891;;群峦传说：宝宝快乐版;TerraFirma: Baby Happy Edition;TFBH
+;892;;阶段: 残骸;Phase: the Debris;
+;893;;AE管道;AE Pipes;APE
+skyt-2;894;;SkyT 2;;
+stagecraft;895;;StageCraft;;
+;896;;我的世界从来不简单;Minecraft Is Never Easy;MINE
+ctnh;897;;机械动力：新视野;Create: New Horizon;CTNH
+agora-interregnum;898;;Agora Interregnum;;
+evolving-technology;899;;Evolving Technology;;
+enlightened-6-expert;900;;Enlightened 6 Expert;;En6E
+;901;;历久尤新;Old But New;OBN
+;902;;继承;Inherit;IN
+lucky-world-invasion;903;;幸运世界入侵;Lucky World Invasion;LWI
+ftb-interactions-remastered;904;;FTB Interactions Remastered;;FTBIR
+;905;;崩坏-新生;Broken-New Life;BNL
+;906;;持之永恒重生;Stay With Eternity Rebirth;SWER
+shadow-awakening;907;;暗影觉醒;Shadow Awakening;SAG
+;908;;理想箱庭物语;Second Eden;SE
+finality-genesis-1-20-1;909;;Finality Genesis;;
+;910;;死亡突围 · 重临死境;DeadoutRe;DTR
+soa3;911;;Slow Start AoA3;;SoA3
+new-vanilla-2;912;;新的原版 2;New Vanilla 2;NVA2
+prominence-2-rpg;913;;卓越 II RPG;Prominence II RPG;
+;914;;伟大冒险者：世界之眼;Great Adventurer:the Eye of the World;GAEW
+;915;;破碎;Fractures Rainimator;Rain
+;916;;更好的原版;Better Vanilla;BV
+strictly-medieval-3-forge;917;;Strictly Medival 3;;
+;918;;潘神的迷宫;Pan's Labyrinth;PL
+;919;;持之永恒-天空挑战者;Stay With Eternity Sky Challenger;SWESC
+easy-to-ascension;920;;易如飞升;Easy to Ascension;
+;921;;幽匿末日;The Last Day of Sculk;TLDS
+;922;;交错空岛;Crossisland;CrI
+;923;;机械动力：魔法乐事;Create Magic's Delight;CRMD
+minetech-evolution;924;;科技进化;Minetech Evolution;MTE
+gregified-sky-edition;925;;Gregified: Sky Edition;;
+;926;;原版扩展;Additonal Vanilla;AV
+create-on-a-potato;927;;Create on a Potato PC: Ultimate;;CPU
+;928;;现实主义;realism;RLM
+;929;;晋升之路;path of advance;POA
+;930;;永无止境：超越常新;Above and Beyond : Refresh;CABR
+cosmic-frontiers;931;;Cosmic Frontiers;;
+integrated-minecraft;932;;Integrated MC;;
+;933;;Rising Legends;;
+;934;;城乡之旅;Travel Township;TT
+;935;;龙鸣牢大;FarmerKobeBryant;FKB
+setgamedifficulty-reika;936;;SetGameDifficulty Reika;;
+epic-journey-gtceu;937;;Epic Journey GTCEu;;
+;938;;飞渡群峦;TerraFirmaCraft:Leap The Top;TFC:LTT
+gregtech-skybound;939;;Gregtech: Skybound;;
+simple-tfc;940;;简单群峦;SimpleTFC;
+ftb-presents-direwolf20-s14;941;;FTB Presents Direwolf20 1.21;;
+final-judgment-save-the-world;942;;Final Judgment:Save the world;;
+;943;;极端世界：重置;Extreme World Reset;EWR
+explore-everything;944;;空岛：探索;Explore Everything;SEE
+epic-journey-gtceu-conquerors-edition;945;;Epic Journey GTCEu - Conqueror's Edition;;
+the-undead-blooms;946;;亡灵绽放 | 真菌孢子启示录 |;The Undead Blooms | Fungal Spore Apocalypse |;
+;947;;星地征程;Starland Journey;SJ
+;948;;希望与绝望-惊变100天;Hope and Despair;had
+;949;;梦篡光阴;Dreams Distort Overture;DDO
+;950;;最后的光芒;The Last Light;TLL
+endil-expert-edition;951;;Endil's Expert Edition;;EEE
+peace-of-mind;952;;Peace of Mind;;
+distantly-optimized;953;;Distantly Optimized;;DO
+farming-experience;954;;Farming Experience;;
+hungry-for-tech-2;955;;Hungry For Tech 2;;
+remain;957;;Remain;;
+;958;;末日狂徒;;
+gregtania6-skyblock;959;;Gregtania6 Skyblock;;
+harmonious-engineering;960;;Harmonious Engineering;;
+valley-of-farming-and-ranching;961;;农牧物语;Valley of Farming and Ranching;
+;962;;机械动力：火车;Create Train;
+;963;;理想国冒险之旅;;AOIC
+;964;;生欲:求生2;Vivere The Zombie Apocalypse-II;VZA2
+;965;;起源-世界;OriginCraft Pulses;
+;966;;Legacies;;
+the-legend-of-2900;967;;海上机械师;The Legend Of 2900;TLOU
+mirasites-100-days;968;;畸变：蛊之奇境;Mirasites-BrokenMemories;MBM
+;969;;末日余晖：独自一人;;MRYH
+;970;;幸存者与僵尸;Survivors And Zombies;SAZ
+;971;;海岛寿司店;Sushi Island;
+infinite-alchemy;972;;Infinite Alchemy;;IA
+;973;;探索的时光;Adventuring Time;AT
+;974;;饕餮飨食;;
+;975;;丰富的MC;RichMC;RM
+;976;;刀剑异闻录;Sword Strange Tales;SST
+etbw;977;;探索光明的世界;Explore the Bright World;EtBW
+hardship-era;978;;苦难年代;Hardship Era;HE
+rlcraft-dregora;979;;RLCraft Dregora;;
+;980;;Farm The Ingots;;FTI
+venoms-craft;981;;Venom's Craft;;
+;982;;慢生活冒险;;
+;983;;多元工艺：绘镇曲;Painted Town Melody;PTM
+;984;;遗忘之海;Leisurely Life;
+;985;;幻想国度;F_Land;
+;986;;群峦传说：重制;TerraFirmaCraft Remake;TFCRe
+;987;;未来;;
+;988;;起源生物—崛起;;
+;989;;工匠：技艺革新;Construct：Technological Innovation;CTI
+erstwhile-journey;990;;往昔之旅;Erstwhile Journey;EJ
+;991;;Exploria;;
+ftb-evolution;992;;FTB Evolution;;
+;994;;云程发轫;cloud journey begins;CJB
+forever-factory;995;;永恒工厂;Forever Factory;
+;996;;FTB University 1.19;;
+symbolica;997;;Symbolica;;
+aelstar;998;;Aelstar;;
+srp-qz;999;;SRP：隔离区;SRP: Quarantine Zone;
+industrial-machines;1000;;Industrial Machines;;
+auto-terrafirmacraft-tfc-create;1001;;Auto-TerraFirmaCraft (TFC + Create);;ATFC
+;1002;;时间之书：星的日记;The Book of Time: A Star's Journal;TASL
+;1003;;特摄世界;Tokusatsu World;TW
+journey-of-reincarnation;1004;;转世之旅;Journey of Reincarnation;
+;1005;;冒险与休闲;Adventure and Leisure;AL
+enigmatica10;1006;;Enigmatica 10;;E10
+mc-chocolate-edition;1007;;The Chocolate Edition;;
+civilization-l;1008;;Civilization-L;;
+;1009;;群峦：降临;TerraFirma：Advent;TFA
+valhelsia-7;1010;;Valhelsia 7;;
+mechanical-mastery-plus;1011;;Mechanical Mastery Plus;;
+ashes-to-ashes;1012;;尘归尘;Ashes To Ashes;ATA
+;1013;;格雷乐事;GT So Easy;GTse
+create-silence-and-prosperity;1014;;机械动力：寂静与繁荣;Create Silence and Prosperity;CSP
+mif;1015;;MI:Foundation;;MIF
+c2mse2;1016;;Create 2 Mekanism: Sky Edition 2;;C2MSE2
+;1017;;Tsuri No Gatsu 5 - FDCraft Version;;TSNG5-FDC
+;1018;;无限战争4;Infinity War4;INF4
+;1019;;群峦传说：工业长路;;
+;1020;;自然冒险 初生;Nature Adventure Newborn;NAB
+;1021;;羽舲的基础优化;Hanekmio's Basis Optimization;
+create-star-valley;1022;;Create: Gears of History;;
+;1023;;阿尔法计划;AlphaPlan;AP
+spell-dimension;1024;;咒次元;Spell Dimension;SD
+skyfactory-5;1025;;天空工厂 5;SkyFactory 5;SF5
+;1026;;破劫之刃;Break Disaster;
+reminiscent-create;1027;;Reminiscent Create;;
+techsert;1028;;Techsert;;TH
+prehistoric-world-dinosaurs-adventure;1029;;Prehistoric World - Dinosaurs & Adventure;;
+terminal;1030;;终末;Terminal;
+;1031;;异次元水晶 3;Isolated Crystal 3;
+;1032;;机械动力：无限总是小于零;Create:Infinity Always Smaller Than Zero;CIASZ
+;1033;;踪灭I-开端;;
+;1034;;踪灭II;;
+rabbits-dawn-craft;1035;;某兔子的破晓之界;A Certain Rabbit's DawnCraft - Dawn of the Deep Soul;RDC
+;1036;;铁砧天空;;ASKY
+grand-architect-journey;1037;;伟大工程巡礼;Grand Architecture Journey;GAJ
+the-adventure-of-valkyriens;1038;;瓦尔基里大冒险;The Adventure of Valkyriens;TAOV
+;1039;;方块宝可梦:奥瑞星光;Cobblemon Ori Starlight;COS
+;1040;;群峦传说：天才版;;
+compression;1041;;Compression;;
+compact-sky-easy;1042;;Compact Sky: Easy;;CSE
+;1043;;丰收与探索;;
+;1044;;脆骨症：黯光;No Flesh Within Chest-DIM;NFWC-DIM
+;1045;;小雷的优化冒险;;
+cobblemon-eternal-edition;1046;;Cobblemon Eternal;;
+;1047;;Tinkerer's Quilt;;
+gregtech-expert;1048;;GregTech Expert;;
+;1049;;Beta Horizons;;
+minecraft-legendary-edition;1050;;Legendary Edition;;

--- a/FCL/src/main/java/com/tungsten/fcl/ui/manage/ModpackFileSelectionPage.java
+++ b/FCL/src/main/java/com/tungsten/fcl/ui/manage/ModpackFileSelectionPage.java
@@ -294,7 +294,8 @@ public class ModpackFileSelectionPage extends FCLTempPage implements View.OnClic
                                 /* overrideJavaArgs */ true,
                                 /* overrideConsole */ true,
                                 /* overrideCommands */ true,
-                                /* overrideWindow */ true
+                                /* overrideWindow */ true,
+                                /* iconKey */ null // TODO
                         ), modpackFile);
             }
 

--- a/FCLCore/src/main/java/com/tungsten/fclcore/download/LibraryAnalyzer.java
+++ b/FCLCore/src/main/java/com/tungsten/fclcore/download/LibraryAnalyzer.java
@@ -171,6 +171,7 @@ public final class LibraryAnalyzer implements Iterable<LibraryAnalyzer.LibraryMa
         Version resolvedVersion = version.resolve(provider);
         String mainClass = resolvedVersion.getMainClass();
         return mainClass != null && (LAUNCH_WRAPPER_MAIN.equals(mainClass)
+                || mainClass.startsWith("net.minecraftforge")
                 || mainClass.startsWith("net.fabricmc")
                 || mainClass.startsWith("org.quiltmc")
                 || mainClass.startsWith("cpw.mods"));

--- a/FCLCore/src/main/java/com/tungsten/fclcore/download/game/GameLibrariesTask.java
+++ b/FCLCore/src/main/java/com/tungsten/fclcore/download/game/GameLibrariesTask.java
@@ -132,7 +132,7 @@ public final class GameLibrariesTask extends Task<Void> {
                     }
                 }
             }
-            if (shouldDownloadLibrary(gameRepository, version, library, integrityCheck) && library.hasDownloadURL()) {
+            if (shouldDownloadLibrary(gameRepository, version, library, integrityCheck) && (library.hasDownloadURL() || !"optifine".equals(library.getGroupId()))) {
                 dependencies.add(new LibraryDownloadTask(dependencyManager, file, library));
             } else {
                 dependencyManager.getCacheRepository().tryCacheLibrary(library, file.toPath());

--- a/FCLCore/src/main/java/com/tungsten/fclcore/mod/multimc/MultiMCInstanceConfiguration.java
+++ b/FCLCore/src/main/java/com/tungsten/fclcore/mod/multimc/MultiMCInstanceConfiguration.java
@@ -54,6 +54,7 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
     private final boolean overrideConsole; // OverrideConsole
     private final boolean overrideCommands; // OverrideCommands
     private final boolean overrideWindow; // OverrideWindow
+    private final String iconKey;
 
     private final MultiMCManifest mmcPack;
 
@@ -90,6 +91,7 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
         wrapperCommand = readValue(p, "WrapperCommand");
         name = defaultName;
         notes = Optional.ofNullable(readValue(p, "notes")).orElse("");
+        iconKey = readValue(p, "iconKey");
     }
 
     /**
@@ -107,7 +109,7 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
         return value;
     }
 
-    public MultiMCInstanceConfiguration(String instanceType, String name, String gameVersion, Integer permGen, String wrapperCommand, String preLaunchCommand, String postExitCommand, String notes, String javaPath, String jvmArgs, boolean fullscreen, Integer width, Integer height, Integer maxMemory, Integer minMemory, boolean showConsole, boolean showConsoleOnError, boolean autoCloseConsole, boolean overrideMemory, boolean overrideJavaLocation, boolean overrideJavaArgs, boolean overrideConsole, boolean overrideCommands, boolean overrideWindow) {
+    public MultiMCInstanceConfiguration(String instanceType, String name, String gameVersion, Integer permGen, String wrapperCommand, String preLaunchCommand, String postExitCommand, String notes, String javaPath, String jvmArgs, boolean fullscreen, Integer width, Integer height, Integer maxMemory, Integer minMemory, boolean showConsole, boolean showConsoleOnError, boolean autoCloseConsole, boolean overrideMemory, boolean overrideJavaLocation, boolean overrideJavaArgs, boolean overrideConsole, boolean overrideCommands, boolean overrideWindow, String iconKey) {
         this.instanceType = instanceType;
         this.name = name;
         this.gameVersion = gameVersion;
@@ -133,6 +135,7 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
         this.overrideCommands = overrideCommands;
         this.overrideWindow = overrideWindow;
         this.mmcPack = null;
+        this.iconKey = iconKey;
     }
 
     public String getInstanceType() {
@@ -305,6 +308,10 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
         return overrideWindow;
     }
 
+    public String getIconKey() {
+        return iconKey;
+    }
+
     public Properties toProperties() {
         Properties p = new Properties();
         if (instanceType != null) p.setProperty("InstanceType", instanceType);
@@ -331,6 +338,7 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
         if (wrapperCommand != null) p.setProperty("WrapperCommand", wrapperCommand);
         if (name != null) p.setProperty("name", name);
         if (notes != null) p.setProperty("notes", notes);
+        if (iconKey != null) p.setProperty("iconKey", iconKey);
         return p;
     }
 

--- a/FCLCore/src/main/java/com/tungsten/fclcore/mod/multimc/MultiMCInstanceConfiguration.java
+++ b/FCLCore/src/main/java/com/tungsten/fclcore/mod/multimc/MultiMCInstanceConfiguration.java
@@ -58,36 +58,53 @@ public final class MultiMCInstanceConfiguration implements ModpackManifest {
     private final MultiMCManifest mmcPack;
 
     MultiMCInstanceConfiguration(String defaultName, InputStream contentStream, MultiMCManifest mmcPack) throws IOException {
+        // instance.cfg is in .ini format. As it's like the .properties format, we use Properties to parse thie file.
+        // Maybe this will provide some problems (and it does, such as https://github.com/HMCL-dev/HMCL/issues/2991), but this workaround works, doesn't it?
         Properties p = new Properties();
         p.load(new InputStreamReader(contentStream, StandardCharsets.UTF_8));
 
         this.mmcPack = mmcPack;
 
-        instanceType = p.getProperty("InstanceType");
-        autoCloseConsole = Boolean.parseBoolean(p.getProperty("AutoCloseConsole"));
+        instanceType = readValue(p, "InstanceType");
+        autoCloseConsole = Boolean.parseBoolean(readValue(p, "AutoCloseConsole"));
         gameVersion = mmcPack != null ? mmcPack.getComponents().stream().filter(e -> "net.minecraft".equals(e.getUid())).findAny()
-                .orElseThrow(() -> new IOException("Malformed mmc-pack.json")).getVersion() : p.getProperty("IntendedVersion");
-        javaPath = p.getProperty("JavaPath");
-        jvmArgs = p.getProperty("JvmArgs");
-        fullscreen = Boolean.parseBoolean(p.getProperty("LaunchMaximized"));
-        maxMemory = Lang.toIntOrNull(p.getProperty("MaxMemAlloc"));
-        minMemory = Lang.toIntOrNull(p.getProperty("MinMemAlloc"));
-        height = Lang.toIntOrNull(p.getProperty("MinecraftWinHeight"));
-        width = Lang.toIntOrNull(p.getProperty("MinecraftWinWidth"));
-        overrideCommands = Boolean.parseBoolean(p.getProperty("OverrideCommands"));
-        overrideConsole = Boolean.parseBoolean(p.getProperty("OverrideConsole"));
-        overrideJavaArgs = Boolean.parseBoolean(p.getProperty("OverrideJavaArgs"));
-        overrideJavaLocation = Boolean.parseBoolean(p.getProperty("OverrideJavaLocation"));
-        overrideMemory = Boolean.parseBoolean(p.getProperty("OverrideMemory"));
-        overrideWindow = Boolean.parseBoolean(p.getProperty("OverrideWindow"));
-        permGen = Lang.toIntOrNull(p.getProperty("PermGen"));
-        postExitCommand = p.getProperty("PostExitCommand");
-        preLaunchCommand = p.getProperty("PreLaunchCommand");
-        showConsole = Boolean.parseBoolean(p.getProperty("ShowConsole"));
-        showConsoleOnError = Boolean.parseBoolean(p.getProperty("ShowConsoleOnError"));
-        wrapperCommand = p.getProperty("WrapperCommand");
+                .orElseThrow(() -> new IOException("Malformed mmc-pack.json")).getVersion() : readValue(p, "IntendedVersion");
+        javaPath = readValue(p, "JavaPath");
+        jvmArgs = readValue(p, "JvmArgs");
+        fullscreen = Boolean.parseBoolean(readValue(p, "LaunchMaximized"));
+        maxMemory = Lang.toIntOrNull(readValue(p, "MaxMemAlloc"));
+        minMemory = Lang.toIntOrNull(readValue(p, "MinMemAlloc"));
+        height = Lang.toIntOrNull(readValue(p, "MinecraftWinHeight"));
+        width = Lang.toIntOrNull(readValue(p, "MinecraftWinWidth"));
+        overrideCommands = Boolean.parseBoolean(readValue(p, "OverrideCommands"));
+        overrideConsole = Boolean.parseBoolean(readValue(p, "OverrideConsole"));
+        overrideJavaArgs = Boolean.parseBoolean(readValue(p, "OverrideJavaArgs"));
+        overrideJavaLocation = Boolean.parseBoolean(readValue(p, "OverrideJavaLocation"));
+        overrideMemory = Boolean.parseBoolean(readValue(p, "OverrideMemory"));
+        overrideWindow = Boolean.parseBoolean(readValue(p, "OverrideWindow"));
+        permGen = Lang.toIntOrNull(readValue(p, "PermGen"));
+        postExitCommand = readValue(p, "PostExitCommand");
+        preLaunchCommand = readValue(p, "PreLaunchCommand");
+        showConsole = Boolean.parseBoolean(readValue(p, "ShowConsole"));
+        showConsoleOnError = Boolean.parseBoolean(readValue(p, "ShowConsoleOnError"));
+        wrapperCommand = readValue(p, "WrapperCommand");
         name = defaultName;
-        notes = Optional.ofNullable(p.getProperty("notes")).orElse("");
+        notes = Optional.ofNullable(readValue(p, "notes")).orElse("");
+    }
+
+    /**
+     * A workaround for <a href="https://github.com/HMCL-dev/HMCL/issues/2991">...</a>
+     */
+    private String readValue(Properties p, String key) {
+        String value = p.getProperty(key);
+        if (value == null) {
+            return null;
+        }
+        int l = value.length();
+        if (l >= 2 && value.charAt(0) == '"' && value.charAt(l - 1) == ':') {
+            return value.substring(0, l - 1);
+        }
+        return value;
     }
 
     public MultiMCInstanceConfiguration(String instanceType, String name, String gameVersion, Integer permGen, String wrapperCommand, String preLaunchCommand, String postExitCommand, String notes, String javaPath, String jvmArgs, boolean fullscreen, Integer width, Integer height, Integer maxMemory, Integer minMemory, boolean showConsole, boolean showConsoleOnError, boolean autoCloseConsole, boolean overrideMemory, boolean overrideJavaLocation, boolean overrideJavaArgs, boolean overrideConsole, boolean overrideCommands, boolean overrideWindow) {

--- a/FCLCore/src/main/java/com/tungsten/fclcore/mod/multimc/MultiMCModpackInstallTask.java
+++ b/FCLCore/src/main/java/com/tungsten/fclcore/mod/multimc/MultiMCModpackInstallTask.java
@@ -197,6 +197,14 @@ public final class MultiMCModpackInstallTask extends Task<Void> {
             Path jarmods = root.resolve("jarmods");
             if (Files.exists(jarmods))
                 FileUtils.copyDirectory(jarmods, repository.getVersionRoot(name).toPath().resolve("jarmods"));
+
+            String iconKey = this.manifest.getIconKey();
+            if (iconKey != null) {
+                Path iconFile = root.resolve(iconKey + ".png");
+                if (Files.exists(iconFile)) {
+                    FileUtils.copyFile(iconFile, repository.getVersionRoot(name).toPath().resolve("icon.png"));
+                }
+            }
         }
 
         dependencies.add(repository.saveAsync(version));


### PR DESCRIPTION
https://github.com/HMCL-dev/HMCL/pull/3030

https://github.com/HMCL-dev/HMCL/pull/3541

https://github.com/HMCL-dev/HMCL/pull/3113

https://github.com/HMCL-dev/HMCL/pull/3601

https://github.com/HMCL-dev/HMCL/pull/3439
