### PR TITLE
fix: 将 Spinner 布局中的 auto_text_tint 属性更名为 use_theme_color

### DIFF
--- a/FCL/src/main/res/layout/item_spinner_auto_tint.xml
+++ b/FCL/src/main/res/layout/item_spinner_auto_tint.xml
@@ -11,5 +11,5 @@
     android:singleLine="true"
     android:textAlignment="inherit"
     android:background="@android:color/transparent"
-    app:auto_text_tint="true"
+    app:use_theme_color="true"
     android:textSize="14sp"/>


### PR DESCRIPTION
简而言之，修复了上传布局语言选择后不显示的问题（