### PR TITLE
自动更新走Github直链时，能够使用最合适的ABI下载

### DIFF
--- a/FCL/src/main/java/com/tungsten/fcl/upgrade/UpdateDialog.java
+++ b/FCL/src/main/java/com/tungsten/fcl/upgrade/UpdateDialog.java
@@ -178,7 +178,11 @@ public class UpdateDialog extends FCLDialog implements View.OnClickListener {
                 arch = "x86_64";
                 break;
         }
-        url = url.replace("-all", "-" + arch);
+        if (url.endsWith("-all.apk")) {
+            url = url.replace("-all.apk", "-" + arch + ".apk");
+        } else {
+            url = url.replace("-all", "-" + arch);
+        }
         return url;
     }
 }


### PR DESCRIPTION
修改代码，通过 getDeviceArchitecture() 方法获取当前设备支持的最高架构，从而只下载对应架构的安装包，以达到节省存储空间的目的。
已测试于arm64-v8a设备上