### PR TITLE
Quality: Unpack command failures are silently ignored because process exit codes are never checked

### DIFF
--- a/FCLCore/src/main/java/com/tungsten/fclcore/util/Pack200Utils.java
+++ b/FCLCore/src/main/java/com/tungsten/fclcore/util/Pack200Utils.java
@@ -24,9 +24,15 @@ public class Pack200Utils {
         for(File jarFile : files) {
             try {
                 Process process = processBuilder.command("./libunpack200.so", "-r", jarFile.getAbsolutePath(), jarFile.getAbsolutePath().replace(".pack", "")).start();
-                process.waitFor();
-            } catch (InterruptedException | IOException e) {
-                Logging.LOG.log(Level.WARNING, "Failed to unpack files in " + dir, e);
+                int exitCode = process.waitFor();
+                if (exitCode != 0) {
+                    throw new IOException("unpack200 failed with exit code " + exitCode);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Logging.LOG.log(Level.WARNING, "Failed to unpack file: " + jarFile.getAbsolutePath(), e);
+            } catch (IOException e) {
+                Logging.LOG.log(Level.WARNING, "Failed to unpack file: " + jarFile.getAbsolutePath(), e);
             }
         }
     }
@@ -41,8 +47,14 @@ public class Pack200Utils {
             File workdir = new File(nativeLibraryDir);
             ProcessBuilder processBuilder = new ProcessBuilder().directory(workdir);
             Process process = processBuilder.command("./libunpack200.so", "-r", in, out).start();
-            process.waitFor();
-        } catch (InterruptedException | IOException e) {
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new IOException("unpack200 failed with exit code " + exitCode);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Logging.LOG.log(Level.WARNING, "Failed to unpack file: " + in, e);
+        } catch (IOException e) {
             Logging.LOG.log(Level.WARNING, "Failed to unpack file: " + in, e);
         }
     }


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `FCLCore/src/main/java/com/tungsten/fclcore/util/Pack200Utils.java`.

**Context:**
Both `unpack(...)` methods call `process.waitFor()` but never inspect the returned exit code. If `libunpack200.so` exits non-zero (bad input, missing permissions, incompatible binary), the code treats it as success. This can leave `.pack` files unconverted and cause downstream runtime failures with no immediate signal.


**Proposed fix:**
Capture and validate the exit code, and propagate failure. Example: `int exit = process.waitFor();` `if (exit != 0) { throw new IOException("unpack200 failed for " + in + " with exit code " + exit); }` In the directory loop, log per-file failure and collect/throw at end (or return a boolean) so callers can react.


**Files touched:**
- `FCLCore/src/main/java/com/tungsten/fclcore/util/Pack200Utils.java` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
