### PR TITLE
fix(gl_bridge): restore old Zink vsync behavior for Kopper path

### DIFF
--- a/FCLauncher/src/main/jni/ctxbridges/gl_bridge.c
+++ b/FCLauncher/src/main/jni/ctxbridges/gl_bridge.c
@@ -210,6 +210,11 @@ void gl_setup_window() {
 void gl_swap_interval(int swapInterval) {
     if(pojav_environ->force_vsync) swapInterval = 1;
 
+    const char *renderer = getenv("POJAV_RENDERER");
+    if (renderer && !strcmp(renderer, "opengles3_desktopgl_zink_kopper") && !getenv("POJAV_VSYNC_IN_ZINK")) {
+        return;
+    }
+
     eglSwapInterval_p(g_EglDisplay, swapInterval);
 }
 


### PR DESCRIPTION
Commit 18f18fe7 changed the Zink renderer from OSMesa bridge to GL bridge
for Kopper support. The OSMesa bridge ignored swap intervals unless
POJAV_VSYNC_IN_ZINK was set, while the GL bridge calls eglSwapInterval
unconditionally. This causes FPS to be locked to the display refresh rate
for Zink/MobileGlues users when the game requests v