### PR TITLE
chore: bump ci version to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload apk
         if: startsWith(github.ref, 'refs/heads/')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: app-${{matrix.arch}}
           path: FCL/build/outputs/apk/release/*
@@ -97,7 +97,7 @@ jobs:
           ./gradlew assemblefordebug -Darch=${{ matrix.arch }} --no-daemon
 
       - name: Upload apk
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: app-${{matrix.arch}}
           path: FCL/build/outputs/apk/fordebug/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload apk
         if: startsWith(github.ref, 'refs/heads/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-${{matrix.arch}}
           path: FCL/build/outputs/apk/release/*
@@ -69,13 +69,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -85,7 +85,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -97,7 +97,7 @@ jobs:
           ./gradlew assemblefordebug -Darch=${{ matrix.arch }} --no-daemon
 
       - name: Upload apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-${{matrix.arch}}
           path: FCL/build/outputs/apk/fordebug/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
@@ -47,7 +47,7 @@ jobs:
           ./gradlew assemblerelease -Darch=${{ matrix.arch }} --no-daemon
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.TOKEN }}
           files: |


### PR DESCRIPTION
### Reason:
When ci runs, the older version cause **deprecated Node.js warning**. So I fixed it by bump to latest version.
### What's changed:
Actions bellow is bumped:
- `actions/checkout` 4 -> 7
- `actions/setup-java` 4 -> 5
- `actions/cache` 4 -> 6
- `softprops/gh-action-release` 1 -> 3

For more detail, view changed files.
> [!NOTE]
> All bumped versions are stable and tested in many repos
> Warning won't be fixed 100% due some action is no longer update

