### PR TITLE
fix(miuix): 下载分页栏/语言切换/菜单守卫/键码弹窗 四处 UI 修复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,11 @@ FCL/src/main/java/com/tungsten/fcl/ui/download/compose
 
 已迁移页面和弹窗通过 `USE_COMPOSE_*` 开关选择 Compose 或旧 View/XML 路径，默认通常为 `true`。旧实现暂时不能随意删除，涉及 UI 的改动应验证两条路径。联机菜单、游戏内菜单、控制器以及部分复杂页面仍保留原生 View 实现。游戏启动链路、JNI/NDK、`FCLCore`、文件系统路径、权限体系和游戏内控制 UI 属于高风险边界，迁移 UI 时不要改变其行为或生命周期假设。
 
+Compose 弹窗自适应的两个实测坑（2026-08 键码弹窗修复记录）：
+
+- `wrapContentWidth` 卡片内任何 `fillMaxWidth` 子组件（如 `FCLDialogButtonsRow`）会把卡片撑到最大约束宽度，内容不足时右侧留白；按钮行应 wrap 宽度 + `align(Alignment.End)`。
+- 不要把"等比缩放原生 View"当自适应首选：`graphicsLayer` 作用在 `AndroidView` 上 `transformOrigin` 不可靠；`FCLLinearLayout` 等主题 View 在 UNSPECIFIED 测量下固有尺寸会失真，运行时测量再缩放风险高。优先对齐旧版 wrap_content 语义（弹窗迁就内容自然尺寸），竖向溢出交给布局内 ScrollView。
+
 ## 构建命令
 
 优先使用项目自带 Gradle Wrapper。Windows 使用 `gradlew.bat`，Linux/macOS 或 Git Bash 使用 `./gradlew`。

--- a/FCL/src/main/java/com/tungsten/fcl/activity/MainActivity.kt
+++ b/FCL/src/main/java/com/tungsten/fcl/activity/MainActivity.kt
@@ -394,6 +394,24 @@ class MainActivity : FCLActivity(), OnSelectListener, View.OnClickListener {
     }
 
     override fun onSelect(view: FCLMenuView) {
+        // 幂等守卫：目标 UI 已是当前页时直接返回，不重播按钮动画、不重复 switchUI。
+        // 正常路径下 FCLMenuView 选中态已拦截重复点击，但选中态可能被 NavigationBus
+        // 重放/refreshMenuView(null) 重置，导致 onSelect 再次触发（真机表现为
+        // "页面已打开，按钮还能反复点击重播动画"）。
+        val targetUI = binding.let {
+            when (view) {
+                it.home -> uiManager.mainUI
+                it.manage ->
+                    if (Profiles.getSelectedProfile().selectedVersion == null) uiManager.versionUI
+                    else uiManager.manageUI
+                it.download -> uiManager.downloadUI
+                it.controller -> uiManager.controllerUI
+                it.multiplayer -> uiManager.multiplayerUI
+                it.setting -> uiManager.settingUI
+                else -> null
+            }
+        }
+        if (targetUI != null && uiManager.currentUI === targetUI) return
         refreshMenuView(view)
         val speed = ThemeEngine.getInstance().getTheme().animationSpeed
         AnimUtil.playRotation(view, speed * 100L, 0f, 360f)

--- a/FCL/src/main/java/com/tungsten/fcl/ui/compose/FCLControls.kt
+++ b/FCL/src/main/java/com/tungsten/fcl/ui/compose/FCLControls.kt
@@ -379,6 +379,9 @@ fun fclButtonColors(): ButtonColors = ButtonDefaults.buttonColorsPrimary()
  * [minWidth] 直通 Miuix [Button] 的 minWidth：默认保持 Miuix 现状；
  * 旧 XML 按行宽比例定宽的窄按钮（如主题色三行 0.13/0.25/0.11）传 0.dp，
  * 否则默认 minWidth 会把按比例计算的宽度撑回去、挤掉后续按钮文字。
+ * [insideMargin] 直通 Miuix [Button] 的 insideMargin（默认 16×13dp）；
+ * 旧 XML 用 auto_padding=false + padding=10dp 的紧凑按钮（如下载页分页按钮）
+ * 传 PaddingValues(10.dp)，否则默认内边距会把按钮撑大、窄屏溢出。
  * 其余参数直通 Miuix [Button]，业务行为零改动。
  */
 @Composable
@@ -387,6 +390,7 @@ fun FCLButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     minWidth: Dp = ButtonDefaults.MinWidth,
+    insideMargin: PaddingValues = ButtonDefaults.InsideMargin,
     colors: ButtonColors = fclButtonColors(),
     content: @Composable RowScope.() -> Unit,
 ) {
@@ -396,6 +400,7 @@ fun FCLButton(
         enabled = enabled,
         cornerRadius = FCLCornerRadius.Card,
         minWidth = minWidth,
+        insideMargin = insideMargin,
         colors = colors,
         content = content,
     )

--- a/FCL/src/main/java/com/tungsten/fcl/ui/compose/dialog/MiuixSelectKeycodeDialog.kt
+++ b/FCL/src/main/java/com/tungsten/fcl/ui/compose/dialog/MiuixSelectKeycodeDialog.kt
@@ -4,14 +4,15 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
@@ -20,11 +21,11 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.tungsten.fcl.R
 import com.tungsten.fcl.control.view.KeycodeView
 import com.tungsten.fcl.ui.compose.FCLComposeDialog
-import com.tungsten.fcl.ui.compose.FCLDialogButton
-import com.tungsten.fcl.ui.compose.FCLDialogButtonsRow
+import com.tungsten.fcl.ui.compose.fclDialogTextButtonColors
 import kotlinx.coroutines.flow.MutableStateFlow
 import com.tungsten.fcl.ui.compose.FCLCard
 import com.tungsten.fcl.ui.compose.FCLCornerRadius
+import top.yukonga.miuix.kmp.basic.TextButton
 
 /**
  * Miuix 版键码选择弹窗（4.1，对应 control/SelectKeycodeDialog + dialog_select_keycode，
@@ -45,8 +46,9 @@ import com.tungsten.fcl.ui.compose.FCLCornerRadius
  *
  * 卡片宽度说明：view_keyboard 固定 600dp，超出 FCLDialogCard 的 560dp 上限，
  * 故此处自建 Card（wrapContentWidth），不用 FCLDialogCard。
- * 宽度上限取屏宽 - 48dp（两侧各 24dp 卡片外边距），避免窄屏右侧溢出；
- * 键盘区在卡片宽不足以容纳 600dp 时以 horizontalScroll 横向滚动兜底（宽屏视觉不变）。
+ * 宽度对齐原版语义（FCLDialog 默认 wrap_content 窗口）：弹窗迁就键盘自然宽度
+ * （620dp），不做缩放；上限屏宽 - 48dp（两侧各 24dp 卡片外边距）防窄屏右溢；
+ * 高度超限时由布局内 ScrollView（height=0dp+weight=1）自行滚动。
  *
  * 运行于游戏内（GameMenu/EditViewDialog → ControllerActivity），
  * AppCompatDialog + ComposeView 可用（同批 2/批 4 各 Miuix 游戏内弹窗）。
@@ -91,12 +93,12 @@ class MiuixSelectKeycodeDialog(
                 insideMargin = PaddingValues(horizontal = 20.dp, vertical = 16.dp),
             ) {
                 Column {
-                    // 键盘区限高随屏幕收缩：游戏内横屏（屏高常仅 360~410dp）下固定 400dp
-                    // 会把确定按钮挤出屏幕；预留 ~150dp 给卡片边距与按钮区
+                    // 对齐原版 SelectKeycodeDialog（FCLDialog wrap_content 窗口）：
+                    // 弹窗宽度迁就键盘自然宽度（620dp），不缩放不横滚；
+                    // 高度超限由布局内 ScrollView 自己滚动（height=0dp+weight=1）
                     AndroidView(
                         modifier = Modifier
-                            // 卡片宽不足以容纳 600dp 键盘时横向滚动兜底（宽屏视觉不变）
-                            .horizontalScroll(rememberScrollState())
+                            .wrapContentSize()
                             .heightIn(
                                 max = minOf(
                                     400.dp,
@@ -120,17 +122,23 @@ class MiuixSelectKeycodeDialog(
                                 }
                         },
                     )
-                    FCLDialogButtonsRow(
-                        listOf(
-                            FCLDialogButton(
-                                text = stringResource(com.tungsten.fcllibrary.R.string.dialog_positive),
-                                onClick = {
-                                    onConfirm(this@MiuixSelectKeycodeDialog)
-                                    dismiss()
-                                },
-                            ),
-                        ),
-                    )
+                    // 确认按钮右对齐但自身 wrap 宽度：不能用 FCLDialogButtonsRow
+                    // （其 fillMaxWidth 会把 wrapContentWidth 卡片撑到最大约束，右侧留白）
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .padding(top = 12.dp)
+                            .wrapContentWidth(),
+                    ) {
+                        TextButton(
+                            text = stringResource(com.tungsten.fcllibrary.R.string.dialog_positive),
+                            onClick = {
+                                onConfirm(this@MiuixSelectKeycodeDialog)
+                                dismiss()
+                            },
+                            colors = fclDialogTextButtonColors(),
+                        )
+                    }
                 }
             }
         }

--- a/FCL/src/main/java/com/tungsten/fcl/ui/download/compose/RemoteModSearchScreen.kt
+++ b/FCL/src/main/java/com/tungsten/fcl/ui/download/compose/RemoteModSearchScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -661,10 +662,14 @@ private fun PageButton(
     onClick: () -> Unit,
 ) {
     // 对齐 page_download.xml 分页 FCLButton（主色实心 = primary，文字 autoTint = onPrimary，
-    // marginStart=10dp）
+    // marginStart=10dp、padding=10dp、auto_padding=false、wrap_content）：
+    // minWidth=0 + 紧凑 insideMargin 还原旧版"按文字宽度自适应"，避免 Miuix 默认
+    // 58dp minWidth + 16×13dp 内边距把按钮撑大导致窄窗格溢出（自适应差）。
     FCLButton(
         onClick = onClick,
         enabled = enabled,
+        minWidth = 0.dp,
+        insideMargin = PaddingValues(horizontal = 10.dp, vertical = 10.dp),
         modifier = Modifier.padding(start = 10.dp),
         colors = ButtonDefaults.buttonColorsPrimary(),
     ) {

--- a/FCL/src/main/java/com/tungsten/fcl/ui/setting/compose/LauncherSettingHost.kt
+++ b/FCL/src/main/java/com/tungsten/fcl/ui/setting/compose/LauncherSettingHost.kt
@@ -23,6 +23,7 @@ import com.tungsten.fcllibrary.component.theme.ThemeEngine
 import com.tungsten.fcllibrary.util.LocaleUtils
 import java.io.File
 import java.io.IOException
+import java.util.function.Consumer
 
 /**
  * 启动器设置页宿主事件处理器（小步骤 3.1）：承接 [LauncherSettingEvent] 中需要
@@ -53,11 +54,14 @@ object LauncherSettingHost {
             is LauncherSettingEvent.ShowAlert ->
                 showAlert(context, event.message, event.isError)
 
-            // 对齐 LauncherSettingPage.java:524-537：先用页面 Activity 上下文 setLanguage
-            // （当前 Activity 资源配置即时切到新语言），再以新语言弹"重启生效"提示。
+            // 先以当前语言弹"重启生效"提示，用户点确认后再 setLanguage 应用新资源配置：
+            // 应用配置引发的闪黑因此发生在提示之后（修复"先变黑再提示"的顺序问题）。
+            // 弹窗文案随之保持当前语言，用户能读懂提示内容（遗留 :524-537 是先切语言再弹，
+            // 文案变新语言但顺序相反）。
             LauncherSettingEvent.ShowRestartHint -> {
-                LocaleUtils.setLanguage(context)
-                showAlert(context, context.getString(R.string.message_warn_restart_after_change))
+                showAlert(context, context.getString(R.string.message_warn_restart_after_change)) {
+                    LocaleUtils.setLanguage(context)
+                }
             }
         }
     }
@@ -200,10 +204,22 @@ object LauncherSettingHost {
     /**
      * 通用提示弹窗：优先 LegacyBridge.requestAlertDialog（Miuix WindowDialog），
      * 槽位占用时回退遗留 FCLAlertDialog（对齐各调用点的单按钮形态）。
+     * [onConfirm] 仅在点击确认按钮后回调（两条通道语义一致）。
      */
-    private fun showAlert(context: Context, message: String, isError: Boolean = false) {
+    private fun showAlert(
+        context: Context,
+        message: String,
+        isError: Boolean = false,
+        onConfirm: (() -> Unit)? = null,
+    ) {
         val positive = context.getString(com.tungsten.fcllibrary.R.string.dialog_positive)
-        val accepted = LegacyBridge.requestAlertDialog(null, message, positive, null, null)
+        val accepted = LegacyBridge.requestAlertDialog(
+            null,
+            message,
+            positive,
+            null,
+            onConfirm?.let { cb -> Consumer<Boolean> { if (it) cb() } },
+        )
         if (!accepted) {
             val builder = FCLAlertDialog.Builder(context)
             builder.setCancelable(false)
@@ -211,7 +227,7 @@ object LauncherSettingHost {
                 if (isError) FCLAlertDialog.AlertLevel.ALERT else FCLAlertDialog.AlertLevel.INFO,
             )
             builder.setMessage(message)
-            builder.setNegativeButton(positive, null)
+            builder.setNegativeButton(positive) { onConfirm?.invoke() }
             builder.create().show()
         }
     }


### PR DESCRIPTION
基于 refactor/miuix 的 4 个 Compose 迁移 UI 修复，均已在 Redmi K40 真机（fordebug R8 包）验证：

- **fix(download)**：复原分页栏按钮旧版尺寸（minWidth=0 + 紧凑 10dp 内边距），修复 Miuix 默认 58dp 最小宽度导致窄窗格溢出
- **fix(setting)**：语言切换改为先弹提示、确认后再应用新语言配置，修复"先黑屏再弹窗"的顺序问题
- **fix(main)**：左侧菜单 onSelect 增加幂等守卫，目标 UI 已是当前页时不再重播按钮动画/重复 switchUI
- **fix(dialog)**：键码选择弹窗对齐遗留 SelectKeycodeDialog 的 wrap_content 语义——键盘按自然 620dp 完整铺开、弹窗迁就内容；修复 FCLDialogButtonsRow 的 fillMaxWidth 把卡片撑到最大约束导致右侧留白的问题

另在 AGENTS.md 补充两条 Compose 弹窗自适应实测经验（fillMaxWidth 撑卡片、原生 View 缩放方案不可靠）。